### PR TITLE
windows compatibility

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::error::Error;
 use std::ffi::OsStr;
 use std::fs;
 use std::io::Write;
+#[cfg(target_os = "linux")]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, Component};
 use std::process;
@@ -77,12 +78,16 @@ fn print_entry(base: &Path, entry: &Path, config: &FdOptions) {
         None    => return
     };
 
+    #[cfg(target_os = "linux")]
     let is_executable = |p: &std::path::PathBuf| {
         p.metadata()
          .ok()
          .map(|f| f.permissions().mode() & 0o111 != 0)
          .unwrap_or(false)
     };
+
+    #[cfg(not(target_os = "linux"))]
+    let is_executable =  |p: &std::path::PathBuf| {false};
 
     if let Some(ref ls_colors) = config.ls_colors {
         let mut component_path = base.to_path_buf();

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::error::Error;
 use std::ffi::OsStr;
 use std::fs;
 use std::io::Write;
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, Component};
 use std::process;
@@ -78,7 +78,7 @@ fn print_entry(base: &Path, entry: &Path, config: &FdOptions) {
         None    => return
     };
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_os = "unix")]
     let is_executable = |p: &std::path::PathBuf| {
         p.metadata()
          .ok()
@@ -86,7 +86,7 @@ fn print_entry(base: &Path, entry: &Path, config: &FdOptions) {
          .unwrap_or(false)
     };
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(target_os = "unix"))]
     let is_executable =  |p: &std::path::PathBuf| {false};
 
     if let Some(ref ls_colors) = config.ls_colors {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn print_entry(base: &Path, entry: &Path, config: &FdOptions) {
         None    => return
     };
 
-    #[cfg(target_os = "unix")]
+    #[cfg(target_family = "unix")]
     let is_executable = |p: &std::path::PathBuf| {
         p.metadata()
          .ok()
@@ -86,7 +86,7 @@ fn print_entry(base: &Path, entry: &Path, config: &FdOptions) {
          .unwrap_or(false)
     };
 
-    #[cfg(not(target_os = "unix"))]
+    #[cfg(not(target_family = "unix"))]
     let is_executable =  |p: &std::path::PathBuf| {false};
 
     if let Some(ref ls_colors) = config.ls_colors {


### PR DESCRIPTION
On windows machines, the file mode is less relevant than on unix machines. On top of that the `std::os::unix::fs::PermissionsExt` crate has no windows alternative as of this moment, so the highlighting of executable files is disabled with a conditional compilation directive that verifies the target os.