### PR TITLE
Handle invalid UTF-8, fixes #34

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -198,5 +198,10 @@ $root/one/two/C.Foo
 $root/one/two/three/d.foo
 $root/one/two/three/directory_foo" --absolute-path foo
 
+
+suite "Invalid UTF-8"
+touch "$(printf 'test-invalid-utf8-\xc3.txt')"
+expect "$(printf 'test-invalid-utf8-\ufffd.txt')" test-invalid-utf8
+
 # All done
 echo


### PR DESCRIPTION
Maybe not the prettiest solution, but at least this makes sure that files with invalid UTF-8 in the filename will still be shown.