### PR TITLE
Add extension filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,12 @@ FLAGS:
     -V, --version           Prints version information
 
 OPTIONS:
-    -d, --max-depth <depth>    Set maximum search depth (default: none)
-    -j, --threads <threads>    The number of threads used for searching
-    -t, --type <file-type>     The type of file to search for [values: f, file,
-                               d, directory, s, symlink]
+    -d, --max-depth <depth>        Set maximum search depth (default: none)
+    -j, --threads <threads>        The number of threads used for searching
+    -t, --type <file-type>
+            The type of file to search for [values: f, file,
+            d, directory, s, symlink]
+    -e, --extension <extension>    The file extension to search for
 
 ARGS:
     <pattern>    the search pattern, a regular expression (optional)

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,7 +309,7 @@ fn scan(root: &Path, pattern: Arc<Regex>, base: &Path, config: Arc<FdOptions>) {
             // Filter out unwanted extensions.
             if let Some(ref filter_ext) = config.extension {
                 let entry_ext = entry.path().extension().map(|e| e.to_string_lossy().to_lowercase());
-                if entry_ext.map_or(false, |ext| ext != *filter_ext) {
+                if entry_ext.map_or(true, |ext| ext != *filter_ext) {
                     return ignore::WalkState::Continue;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,14 +307,11 @@ fn scan(root: &Path, pattern: Arc<Regex>, base: &Path, config: Arc<FdOptions>) {
             }
 
             // Filter out unwanted extensions.
-            match (&config.extension, entry.path().extension()) {
-                (&None, _) => (),
-                (&Some(_), None) => return ignore::WalkState::Continue,
-                (&Some(ref e1), Some(e2)) => {
-                    if e1 != &e2.to_string_lossy().to_lowercase() {
-                        return ignore::WalkState::Continue;
-                    }
-                },
+            if let Some(ref filter_ext) = config.extension {
+                let entry_ext = entry.path().extension().map(|e| e.to_string_lossy().to_lowercase());
+                if entry_ext.map_or(false, |ext| ext != *filter_ext) {
+                    return ignore::WalkState::Continue;
+                }
             }
 
             let path_rel_buf = match fshelper::path_relative_from(entry.path(), &*base) {

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -238,5 +238,17 @@ one/two/three
 one/two/three/directory_foo" --type d
 expect "symlink" --type s
 
+
+suite "File extension (--ext)"
+expect "a.foo
+one/b.foo
+one/two/c.foo
+one/two/three/d.foo" --extension foo
+expect "a.foo
+one/b.foo
+one/two/c.foo
+one/two/three/d.foo" --extension .foo
+expect "one/two/C.Foo2" --extension foo2
+
 # All done
 echo

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -239,7 +239,7 @@ one/two/three/directory_foo" --type d
 expect "symlink" --type s
 
 
-suite "File extension (--ext)"
+suite "File extension (--extension)"
 expect "a.foo
 one/b.foo
 one/two/c.foo


### PR DESCRIPTION
Add extension filtering as suggested in #56.

I went for the following behavior:
* File extension comparison is always case insensitive.
* Leading dots from the argument are ignored. So both `-e rs` and `-e .rs` have the same effect.

Let me know what you think!