### PR TITLE
Add a comment about the default value of --threads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -419,7 +419,8 @@ fn main() {
                         .long("threads")
                         .short("j")
                         .takes_value(true)
-                        .help("Set number of threads to use for searching"))
+                        .help("Set number of threads to use for searching\n\
+                               (default: number of available CPU cores)"))
             .arg(Arg::with_name("max-buffer-time")
                         .long("max-buffer-time")
                         .takes_value(true)


### PR DESCRIPTION
I was wondering what the default value was and thought it would make sense to add it in the help description.