### PR TITLE
(Proper) Windows support

### DIFF
--- a/src/fshelper/mod.rs
+++ b/src/fshelper/mod.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::io;
 
 /// Get a relative path with respect to a certain base path.
 /// See: https://stackoverflow.com/a/39343127/704831
@@ -40,4 +41,13 @@ pub fn path_relative_from(path: &Path, base: &Path) -> Option<PathBuf> {
         }
         Some(comps.iter().map(|c| c.as_os_str()).collect())
     }
+}
+
+pub fn absolute_path(path: &Path) -> io::Result<PathBuf> {
+    let path_buf = path.canonicalize()?;
+
+    #[cfg(windows)]
+    let path_buf = Path::new(path_buf.as_path().to_string_lossy().trim_left_matches(r"\\?\")).to_path_buf();
+
+    Ok(path_buf)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,13 @@ pub mod lscolors;
 pub mod fshelper;
 mod app;
 
-use std::borrow::Cow;
 use std::env;
 use std::error::Error;
 use std::io::Write;
 use std::ops::Deref;
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
 use std::sync::mpsc::channel;
@@ -113,9 +112,6 @@ enum ReceiverMode {
 /// Root directory
 static ROOT_DIR: &'static str = "/";
 
-/// Parent directory
-static PARENT_DIR: &'static str = "..";
-
 /// Print a search result to the console.
 fn print_entry(base: &Path, entry: &PathBuf, config: &FdOptions) {
     let path_full = base.join(entry);
@@ -145,11 +141,7 @@ fn print_entry(base: &Path, entry: &PathBuf, config: &FdOptions) {
 
         // Traverse the path and colorize each component
         for component in entry.components() {
-            let comp_str = match component {
-                Component::Normal(p) => p.to_string_lossy(),
-                Component::ParentDir => Cow::from(PARENT_DIR),
-                _                    => error("Error: unexpected path component.")
-            };
+            let comp_str = component.as_os_str().to_string_lossy();
 
             component_path.push(Path::new(comp_str.deref()));
 

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -47,6 +47,8 @@ fn create_working_directory() -> Result<TempDir, io::Error> {
         #[cfg(unix)]
         unix::fs::symlink(root.join("one/two"), root.join("symlink"))?;
 
+        // Note: creating symlinks on Windows requires the `SeCreateSymbolicLinkPrivilege` which
+        // is by default only granted for administrators.
         #[cfg(windows)]
         windows::fs::symlink_dir(root.join("one/two"), root.join("symlink"))?;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,5 @@
 //! Integration tests for the CLI interface of fd.
 
-#![allow(dead_code, unused_imports)]
-
 mod testenv;
 
 use testenv::TestEnv;
@@ -245,6 +243,9 @@ fn test_absolute_path() {
         .canonicalize().expect("absolute path")
         .to_str().expect("string")
         .to_string();
+
+    #[cfg(windows)]
+    let abs_path = abs_path.trim_left_matches(r"\\?\");
 
     te.assert_output(
         &["--absolute-path", "foo"],

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -39,8 +39,6 @@ fn test_simple() {
 }
 
 /// Explicit root path
-// TODO: Fails on windows
-#[cfg_attr(windows, ignore)]
 #[test]
 fn test_explicit_root_path() {
     let te = TestEnv::new();
@@ -239,8 +237,6 @@ fn test_max_depth() {
 }
 
 /// Absolute paths (--absolute-path)
-// TODO: fails on windows
-#[cfg_attr(windows, ignore)]
 #[test]
 fn test_absolute_path() {
     let te = TestEnv::new();


### PR DESCRIPTION
This fixes the failing tests on Windows

- For now, this is just a workaround: I'm stripping the prefix (`\\?\`) from the absolute paths on Windows. 

For future reference: Windows paths with the `\\?\` prefix are called UNC paths. More information here: https://github.com/rust-lang/rust/issues/42869