### PR TITLE
Switch symlink arg from 's' to 'l'

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ FLAGS:
 
 OPTIONS:
     -d, --max-depth <depth>    Set maximum search depth (default: none)
-    -t, --type <filetype>      Filter by type: f(ile), d(irectory), s(ymlink)
+    -t, --type <filetype>      Filter by type: f(ile), d(irectory), (sym)l(ink)
     -e, --extension <ext>      Filter by file extension
     -c, --color <when>         When to use color in the output:
                                never, auto, always (default: auto)

--- a/src/app.rs
+++ b/src/app.rs
@@ -46,7 +46,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .short("t")
                 .takes_value(true)
                 .value_name("filetype")
-                .possible_values(&["f", "file", "d", "directory", "s", "symlink"])
+                .possible_values(&["f", "file", "d", "directory", "l", "symlink"])
                 .hide_possible_values(true),
         )
         .arg(

--- a/src/app.rs
+++ b/src/app.rs
@@ -117,11 +117,11 @@ fn usage() -> HashMap<&'static str, Help> {
         , "Limit the directory traversal to a given depth. By default, there is no limit \
            on the search depth.");
     doc!(h, "file-type"
-        , "Filter by type: f(ile), d(irectory), s(ymlink)"
+        , "Filter by type: f(ile), d(irectory), (sym)l(ink)"
         , "Filter the search by type:\n  \
              'f' or 'file':         regular files\n  \
              'd' or 'directory':    directories\n  \
-             's' or 'symlink':      symbolic links");
+             'l' or 'symlink':      symbolic links");
     doc!(h, "extension"
         , "Filter by file extension"
         , "(Additionally) filter search results by their file extension.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,7 +432,7 @@ fn main() {
         file_type:         match matches.value_of("file-type") {
                                Some("f") | Some("file") => FileType::RegularFile,
                                Some("d") | Some("directory") => FileType::Directory,
-                               Some("s") | Some("symlink") => FileType::SymLink,
+                               Some("l") | Some("symlink") => FileType::SymLink,
                                _  => FileType::Any,
                            },
         extension:         matches.value_of("extension")

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -295,7 +295,7 @@ fn test_type() {
         one/two/three/directory_foo");
 
     te.assert_output(
-        &["--type", "s"],
+        &["--type", "l"],
         "symlink");
 }
 


### PR DESCRIPTION
Switch the symlink argument for `--type` from `s` to `l`. Fixing #80.