### PR TITLE
Add ripgrep aliases for no-ignore and hidden

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -34,6 +34,7 @@ pub fn build_app() -> App<'static, 'static> {
         .setting(AppSettings::DeriveDisplayOrder)
         .arg(arg("hidden").long("hidden").short("H"))
         .arg(arg("no-ignore").long("no-ignore").short("I"))
+        .arg(arg("rg-alias-hidden-ignore").short("u").multiple(true).hidden(true))
         .arg(arg("case-sensitive").long("case-sensitive").short("s"))
         .arg(arg("absolute-path").long("absolute-path").short("a"))
         .arg(arg("follow").long("follow").short("L").alias("dereference"))
@@ -144,6 +145,9 @@ fn usage() -> HashMap<&'static str, Help> {
         , "the root directory for the filesystem search (optional)"
         , "The directory where the filesystem search is rooted (optional). \
            If omitted, search the current working directory.");
+    doc!(h, "rg-alias-hidden-ignore"
+        , "Alias for no-ignore and/or hidden"
+        , "Alias for no-ignore ('u') and no-ignore and hidden ('uu')");
 
     h
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn main() {
     let config = FdOptions {
         case_sensitive:    case_sensitive,
         search_full_path:  matches.is_present("full-path"),
-        ignore_hidden:     !(matches.is_present("hidden") || matches.occurrences_of("rg-alias-hidden-ignore") == 2),
+        ignore_hidden:     !(matches.is_present("hidden") || matches.occurrences_of("rg-alias-hidden-ignore") >= 2),
         read_ignore:       !(matches.is_present("no-ignore") || matches.is_present("rg-alias-hidden-ignore")),
         follow_links:      matches.is_present("follow"),
         null_separator:    matches.is_present("null_separator"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,8 +86,8 @@ fn main() {
     let config = FdOptions {
         case_sensitive:    case_sensitive,
         search_full_path:  matches.is_present("full-path"),
-        ignore_hidden:     !matches.is_present("hidden"),
-        read_ignore:       !matches.is_present("no-ignore"),
+        ignore_hidden:     !(matches.is_present("hidden") || matches.occurrences_of("rg-alias-hidden-ignore") == 2),
+        read_ignore:       !(matches.is_present("no-ignore") || matches.is_present("rg-alias-hidden-ignore")),
         follow_links:      matches.is_present("follow"),
         null_separator:    matches.is_present("null_separator"),
         max_depth:         matches.value_of("depth")

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -175,6 +175,33 @@ fn test_no_ignore() {
         one/two/three/directory_foo");
 }
 
+/// Ignored files with ripgrep aliases (-u / -uu)
+#[test]
+fn test_no_ignore_aliases() {
+    let te = TestEnv::new();
+
+    te.assert_output(
+        &["-u", "foo"],
+        "a.foo
+        ignored.foo
+        one/b.foo
+        one/two/c.foo
+        one/two/C.Foo2
+        one/two/three/d.foo
+        one/two/three/directory_foo");
+
+    te.assert_output(
+        &["-uu", "foo"],
+        ".hidden.foo
+        a.foo
+        ignored.foo
+        one/b.foo
+        one/two/c.foo
+        one/two/C.Foo2
+        one/two/three/d.foo
+        one/two/three/directory_foo");
+}
+
 /// Symlinks (--follow)
 #[test]
 fn test_follow() {


### PR DESCRIPTION
Add `-u` and `-uu` aliases for **no-ignore** and **no-ignore+hidden** to match behaviour of ripgrep. This fixes #92.

Note: I have implemented this using a hidden argument. I am new to rust so please let me know if there is a more idiomatic approach.