### PR TITLE
Use absolute path to perform search, fixes #81

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -68,6 +68,16 @@ fn test_explicit_root_path() {
         three/d.foo
         three/directory_foo",
     );
+
+    te.assert_output_subdirectory(
+        "one/two/three",
+        &["", ".."],
+        ".
+        ../c.foo
+        ../C.Foo2
+        d.foo
+        directory_foo",
+    );
 }
 
 /// Regex searches
@@ -150,8 +160,6 @@ fn test_full_path() {
         "one/two/three/d.foo
         one/two/three/directory_foo",
     );
-
-    te.assert_output(&["--full-path", "^a\\.foo"], "a.foo");
 }
 
 /// Hidden files (--hidden)
@@ -307,6 +315,23 @@ fn test_absolute_path() {
 
     #[cfg(windows)]
     let abs_path = abs_path.trim_left_matches(r"\\?\");
+
+    te.assert_output(
+        &["--absolute-path"],
+        &format!(
+            "{abs_path}/a.foo
+            {abs_path}/one
+            {abs_path}/one/b.foo
+            {abs_path}/one/two
+            {abs_path}/one/two/c.foo
+            {abs_path}/one/two/C.Foo2
+            {abs_path}/one/two/three
+            {abs_path}/one/two/three/d.foo
+            {abs_path}/one/two/three/directory_foo
+            {abs_path}/symlink",
+            abs_path = abs_path
+        ),
+    );
 
     te.assert_output(
         &["--absolute-path", "foo"],


### PR DESCRIPTION
Previously, we were using the relative path to extract the search
string. For the current directory, the returned relative path was equal
to `""`. This is why the current directory did not show in the search
results (see #81).

This commit also changes the way that `--full-path` works, which was
previously working on relative paths. It seems more useful to search the
absolute path, though. Otherwise, search results could change just by
calling fd (with a given search path) from a different directory.