### PR TITLE
Improve smart case to only consider literal uppercase chars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "ignore 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ansi_term = "0.9"
 clap = "2.26.0"
 atty = "0.2"
 regex = "0.2"
+regex-syntax = "0.4"
 ignore = "0.2"
 num_cpus = "1.6.2"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate clap;
 extern crate ansi_term;
 extern crate atty;
 extern crate regex;
+extern crate regex_syntax;
 extern crate ignore;
 extern crate num_cpus;
 
@@ -22,7 +23,7 @@ use std::time;
 use atty::Stream;
 use regex::RegexBuilder;
 
-use internal::{error, FdOptions, PathDisplay, ROOT_DIR};
+use internal::{error, pattern_has_uppercase_char, FdOptions, PathDisplay, ROOT_DIR};
 use lscolors::LsColors;
 use walk::FileType;
 
@@ -65,11 +66,8 @@ fn main() {
 
     // The search will be case-sensitive if the command line flag is set or
     // if the pattern has an uppercase character (smart case).
-    let case_sensitive = if !matches.is_present("ignore-case") {
-        matches.is_present("case-sensitive") || pattern.chars().any(char::is_uppercase)
-    } else {
-        false
-    };
+    let case_sensitive = !matches.is_present("ignore-case") &&
+        (matches.is_present("case-sensitive") || pattern_has_uppercase_char(pattern));
 
     let colored_output = match matches.value_of("color") {
         Some("always") => true,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -115,6 +115,14 @@ fn test_smart_case() {
     te.assert_output(&["C.Foo"], "one/two/C.Foo2");
 
     te.assert_output(&["Foo"], "one/two/C.Foo2");
+
+    // Only literal uppercase chars should trigger case sensitivity.
+    te.assert_output(
+        &["\\Ac"],
+        "one/two/c.foo
+        one/two/C.Foo2",
+    );
+    te.assert_output(&["\\AC"], "one/two/C.Foo2");
 }
 
 /// Case sensitivity (--case-sensitive)


### PR DESCRIPTION
Fixes #103.

Uses a slightly simplified version of what ripgrep does.