### PR TITLE
Dot "." also matches newline by default (closes #111)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,7 @@ fn main() {
 
     match RegexBuilder::new(pattern)
         .case_insensitive(!config.case_sensitive)
+        .dot_matches_new_line(true)
         .build() {
         Ok(re) => walk::scan(root_dir, Arc::new(re), base, Arc::new(config)),
         Err(err) => error(err.description()),


### PR DESCRIPTION
Please ignore another patch in issue 96.