### PR TITLE
AppVeyor: fix path of cache direcotry

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,5 +89,5 @@ branches:
     - /^v\d+\.\d+\.\d+.*$/
 
 cache:
-  - target\debug\deps -> Cargo.lock
+  - target -> Cargo.lock
   - C:\Users\appveyor\.cargo\registry


### PR DESCRIPTION
`target/debug/.fingerprint/` and `target/debug/deps` are both important. The file structure may changed in the future, so just cache the whole `target` directory. Only clear cache when Cargo.lock changes, so that it won't exceed the space capacity.