### PR TITLE
Allow overriding of OUT_DIR in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use clap::Shell;
 include!("src/app.rs");
 
 fn main() {
-    let var = std::env::var_os("OVRD_OUT_DIR").or_else(|| std::env::var_os("OUT_DIR"));
+    let var = std::env::var_os("SHELL_COMPLETIONS_DIR").or(std::env::var_os("OUT_DIR"));
     let outdir = match var {
         None => return,
         Some(outdir) => outdir,

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,8 @@ use clap::Shell;
 include!("src/app.rs");
 
 fn main() {
-    let outdir = match std::env::var_os("OUT_DIR") {
+    let var = std::env::var_os("OVRD_OUT_DIR").or_else(|| std::env::var_os("OUT_DIR"));
+    let outdir = match var {
         None => return,
         Some(outdir) => outdir,
     };


### PR DESCRIPTION
Fixes #121.
* Uses SHELL_COMPLETIONS_DIR to change the output directory of the completions.
