### PR TITLE
Add support for exclude-patterns

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -82,6 +82,22 @@ pub fn build_app() -> App<'static, 'static> {
                 .value_name("ext"),
         )
         .arg(
+            arg("exec")
+                .long("exec")
+                .short("x")
+                .takes_value(true)
+                .value_name("cmd"),
+        )
+        .arg(
+            arg("exclude")
+                .long("exclude")
+                .short("E")
+                .takes_value(true)
+                .value_name("pattern")
+                .number_of_values(1)
+                .multiple(true),
+        )
+        .arg(
             arg("color")
                 .long("color")
                 .short("c")
@@ -102,13 +118,6 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("max-buffer-time")
                 .takes_value(true)
                 .hidden(true),
-        )
-        .arg(
-            arg("exec")
-                .long("exec")
-                .short("x")
-                .takes_value(true)
-                .value_name("cmd"),
         )
         .arg(arg("pattern"))
         .arg(arg("path"))
@@ -158,6 +167,9 @@ fn usage() -> HashMap<&'static str, Help> {
              'f' or 'file':         regular files\n  \
              'd' or 'directory':    directories\n  \
              'l' or 'symlink':      symbolic links");
+    doc!(h, "extension"
+        , "Filter by file extension"
+        , "(Additionally) filter search results by their file extension.");
     doc!(h, "exec"
         , "Execute the given command for each search result"
         , "Execute the given command for each search result.\n\
@@ -167,10 +179,11 @@ fn usage() -> HashMap<&'static str, Help> {
              '{.}':  removes the extension from the input\n \
              '{/}':  places the basename of the input\n \
              '{//}': places the parent of the input\n \
-             '{/.}': places the basename of the input, without the extension\n");
-    doc!(h, "extension"
-        , "Filter by file extension"
-        , "(Additionally) filter search results by their file extension.");
+             '{/.}': places the basename of the input, without the extension");
+    doc!(h, "exclude"
+        , "Exclude entries that match the given glob pattern."
+        , "Exclude files/directories that match the given glob pattern. This overrides any \
+           other ignore logic. Multiple exclude patterns can be specified.");
     doc!(h, "color"
         , "When to use colors: never, *auto*, always"
         , "Declare when to use color for the pattern match output:\n  \

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -77,6 +77,9 @@ pub struct FdOptions {
 
     /// If a value is supplied, each item found will be used to generate and execute commands.
     pub command: Option<TokenizedCommand>,
+
+    /// A list of glob patterns that should be excluded from the search.
+    pub exclude_patterns: Vec<String>,
 }
 
 /// Print error message to stderr and exit with status `1`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,10 @@ fn main() {
             e.trim_left_matches('.').to_lowercase()
         }),
         command,
+        exclude_patterns: matches
+            .values_of("exclude")
+            .map(|v| v.map(|p| String::from("!") + p).collect())
+            .unwrap_or(vec![]),
     };
 
     match RegexBuilder::new(pattern)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -538,3 +538,50 @@ fn test_symlink() {
         ),
     );
 }
+
+/// Exclude patterns (--exclude)
+#[test]
+fn test_excludes() {
+    let te = TestEnv::new();
+
+    te.assert_output(
+        &["--exclude", "*.foo"],
+        "one
+        one/two
+        one/two/C.Foo2
+        one/two/three
+        one/two/three/directory_foo
+        symlink",
+    );
+
+    te.assert_output(
+        &["--exclude", "*.foo", "--exclude", "*.Foo2"],
+        "one
+        one/two
+        one/two/three
+        one/two/three/directory_foo
+        symlink",
+    );
+
+    te.assert_output(
+        &["--exclude", "*.foo", "--exclude", "*.Foo2", "foo"],
+        "one/two/three/directory_foo",
+    );
+
+    te.assert_output(
+        &["--exclude", "one/two", "foo"],
+        "a.foo
+        one/b.foo",
+    );
+
+    te.assert_output(
+        &["--exclude", "one/**/*.foo"],
+        "a.foo
+        one
+        one/two
+        one/two/C.Foo2
+        one/two/three
+        one/two/three/directory_foo
+        symlink",
+    );
+}


### PR DESCRIPTION
* Adds the `--exclude`/`-E` option.
* Support for multiple exclude patterns

Example:
``` bash
> fd --exclude 'tests/**/*.rs' mod
src/exec/mod.rs
src/fshelper/mod.rs
src/lscolors/mod.rs
```

I finally decided to call this `--exclude` because it is not exactly the same as ripgrep's `--glob` and I think the name is pretty clear.

Closes #89

/CC @tmccombs @Detegr