### PR TITLE
Typo fix: Change 'descent' to 'descend'

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -138,7 +138,7 @@ fn usage() -> HashMap<&'static str, Help> {
         , "Shows the full path starting from the root as opposed to relative paths.");
     doc!(h, "follow"
         , "Follow symbolic links"
-        , "By default, fd does not descent into symlinked directories. Using this flag, symbolic \
+        , "By default, fd does not descend into symlinked directories. Using this flag, symbolic \
            links are also traversed.");
     doc!(h, "full-path"
         , "Search full path (default: file-/dirname only)"


### PR DESCRIPTION
The correct word is 'descend'

Change-Id: I6833bd28e84841799f3f060239a36876949d890e