### PR TITLE
Cygwin forward slashes

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -15,6 +15,8 @@ use std::ops::Deref;
 use std::path::{self, Path, PathBuf, Component};
 #[cfg(any(unix, target_os = "redox"))]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(windows)]
+use std::env;
 
 use ansi_term;
 
@@ -30,6 +32,20 @@ pub fn print_entry(entry: &PathBuf, config: &FdOptions) {
     if r.is_err() {
         // Probably a broken pipe. Exit gracefully.
         process::exit(0);
+    }
+}
+
+#[cfg(not(windows))]
+fn get_separator() -> String {
+    path::MAIN_SEPARATOR.to_string()
+}
+
+#[cfg(windows)]
+fn get_separator() -> String {
+    if let Some(_) = env::var_os("PATH") {
+        String::from("/")
+    } else {
+        path::MAIN_SEPARATOR.to_string()
     }
 }
 
@@ -61,7 +77,9 @@ fn print_entry_colorized(path: &Path, config: &FdOptions, ls_colors: &LsColors) 
             // RootDir is already a separator.
             Component::RootDir => String::new(),
             // Everything else uses a separator that is painted the same way as the component.
-            _ => style.paint(path::MAIN_SEPARATOR.to_string()).to_string(),
+            _ => {
+                    style.paint(get_separator()).to_string()
+            },
         };
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -43,6 +43,9 @@ fn get_separator() -> String {
 
 #[cfg(windows)]
 fn get_separator() -> String {
+    // The HOME environment variable is not available when using cmd
+    // and allows a way to determine if we're running fd with cmd
+    // or cygwin.
     if let Some(_) = env::var_os("HOME") {
         String::from("/")
     } else {
@@ -78,9 +81,7 @@ fn print_entry_colorized(path: &Path, config: &FdOptions, ls_colors: &LsColors) 
             // RootDir is already a separator.
             Component::RootDir => String::new(),
             // Everything else uses a separator that is painted the same way as the component.
-            _ => {
-                style.paint(get_separator()).to_string()
-            },
+            _ => style.paint(get_separator()).to_string(),
         };
     }
 
@@ -98,6 +99,10 @@ fn write_entry_uncolorized(entry: Cow<str>, separator: &'static str) -> io::Resu
 
 #[cfg(windows)]
 fn write_entry_uncolorized(entry: Cow<str>, separator: &'static str) -> io::Result<()> {
+    // The HOME environment variable is not available when using cmd
+    // and allows a way to determine if we're running fd with cmd
+    // or cygwin.
+    // Replace back slashes with forward slashes when running on cygwin.
     if let Some(_) = env::var_os("HOME") {
 		write!(&mut io::stdout(), "{}{}", entry.replace("\\", "/"), separator)
 	} else {

--- a/src/output.rs
+++ b/src/output.rs
@@ -104,17 +104,22 @@ fn write_entry_uncolorized(entry: Cow<str>, separator: &'static str) -> io::Resu
     // or cygwin.
     // Replace back slashes with forward slashes when running on cygwin.
     if let Some(_) = env::var_os("HOME") {
-		write!(&mut io::stdout(), "{}{}", entry.replace("\\", "/"), separator)
-	} else {
-		write!(&mut io::stdout(), "{}{}", entry, separator)
-	}
+        write!(
+            &mut io::stdout(),
+            "{}{}",
+            entry.replace("\\", "/"),
+            separator
+        )
+    } else {
+        write!(&mut io::stdout(), "{}{}", entry, separator)
+    }
 }
 
 fn print_entry_uncolorized(path: &Path, config: &FdOptions) -> io::Result<()> {
     let separator = if config.null_separator { "\0" } else { "\n" };
 
     let path_str = path.to_string_lossy();
-	write_entry_uncolorized(path_str, separator)
+    write_entry_uncolorized(path_str, separator)
 }
 
 fn get_path_style<'a>(path: &Path, ls_colors: &'a LsColors) -> Option<&'a ansi_term::Style> {

--- a/src/output.rs
+++ b/src/output.rs
@@ -15,6 +15,7 @@ use std::ops::Deref;
 use std::path::{self, Path, PathBuf, Component};
 #[cfg(any(unix, target_os = "redox"))]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(windows)]
 use std::env;
 use std::borrow::Cow;
 
@@ -91,7 +92,7 @@ fn print_entry_colorized(path: &Path, config: &FdOptions, ls_colors: &LsColors) 
 }
 
 #[cfg(not(windows))]
-fn write_entry_uncolorized(entry: Cow<str>, separator: str) -> io::Result<()> {
+fn write_entry_uncolorized(entry: Cow<str>, separator: &'static str) -> io::Result<()> {
     write!(&mut io::stdout(), "{}{}", entry, separator)
 }
 


### PR DESCRIPTION
#153 
@sharkdp, I was messing around with this and figured I'd go ahead and open a PR, hope you don't mind. This change adds a check for if the HOME environment variable is present at run time on windows builds. The HOME environment variable is not available in cmd so it servers as a way to differentiate between the two environments and print the appropriate slashes accordingly.