### PR TITLE
The -i flag allows a package to be installed without updating.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,14 +80,14 @@ matrix:
       # skip the global install step
       install:
         - which cargo-install-update || cargo install cargo-update
-        - cargo install-update rustfmt
+        - cargo install-update -i rustfmt
       script: cargo fmt -- --write-mode=diff
     - os: linux
       rust: nightly
       # skip the global install step
       install:
         - which cargo-install-update || cargo install cargo-update
-        - cargo install-update rustfmt-nightly
+        - cargo install-update -i rustfmt-nightly
       script: cargo fmt -- --write-mode=diff
 
 addons:


### PR DESCRIPTION
The -i flag allows installation of the package when it's not installed. Otherwise cargo-update will just not update the package since it has to be installed to update it.

From the help page for cargo-update:
`    -i, --allow-no-update    Allow for fresh-installing packages `