### PR TITLE
Added support for filtering by multiple filetypes and extensions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -175,13 +175,14 @@ fn usage() -> HashMap<&'static str, Help> {
            on the search depth.");
     doc!(h, "file-type"
         , "Filter by type: f(ile), d(irectory), (sym)l(ink)"
-        , "Filter the search by type:\n  \
+        , "Filter the search by type (multiple allowable filetypes can be specified):\n  \
              'f' or 'file':         regular files\n  \
              'd' or 'directory':    directories\n  \
              'l' or 'symlink':      symbolic links");
     doc!(h, "extension"
         , "Filter by file extension"
-        , "(Additionally) filter search results by their file extension.");
+        , "(Additionally) filter search results by their file extension. Multiple allowable file \
+           extensions can be specified.");
     doc!(h, "exec"
         , "Execute a command for each search result"
         , "Execute a command for each search result.\n\

--- a/src/app.rs
+++ b/src/app.rs
@@ -71,6 +71,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("type")
                 .short("t")
                 .multiple(true)
+                .number_of_values(1)
                 .takes_value(true)
                 .value_name("filetype")
                 .possible_values(&["f", "file", "d", "directory", "l", "symlink"])
@@ -81,6 +82,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("extension")
                 .short("e")
                 .multiple(true)
+                .number_of_values(1)
                 .takes_value(true)
                 .value_name("ext"),
         )

--- a/src/app.rs
+++ b/src/app.rs
@@ -70,6 +70,7 @@ pub fn build_app() -> App<'static, 'static> {
             arg("file-type")
                 .long("type")
                 .short("t")
+                .multiple(true)
                 .takes_value(true)
                 .value_name("filetype")
                 .possible_values(&["f", "file", "d", "directory", "l", "symlink"])
@@ -79,6 +80,7 @@ pub fn build_app() -> App<'static, 'static> {
             arg("extension")
                 .long("extension")
                 .short("e")
+                .multiple(true)
                 .takes_value(true)
                 .value_name("ext"),
         )

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -6,6 +6,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use std::collections::HashSet;
 use std::process;
 use std::time;
 use std::io::Write;
@@ -58,12 +59,12 @@ pub struct FdOptions {
     pub ls_colors: Option<LsColors>,
 
     /// The type of file to search for. All files other than the specified type will be ignored.
-    pub file_type: FileType,
+    pub file_types: HashSet<FileType>,
 
     /// The extension to search for. Only entries matching the extension will be included.
     ///
     /// The value (if present) will be a lowercase string without leading dots.
-    pub extension: Option<String>,
+    pub extensions: Option<HashSet<String>>,
 
     /// If a value is supplied, each item found will be used to generate and execute commands.
     pub command: Option<CommandTemplate>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,15 +136,20 @@ fn main() {
             .and_then(|n| u64::from_str_radix(n, 10).ok())
             .map(time::Duration::from_millis),
         ls_colors,
-        file_type: match matches.value_of("file-type") {
-            Some("f") | Some("file") => FileType::RegularFile,
-            Some("d") |
-            Some("directory") => FileType::Directory,
-            Some("l") | Some("symlink") => FileType::SymLink,
-            _ => FileType::Any,
+        file_types: match matches.values_of("file-type") {
+            None => vec![FileType::RegularFile,
+                         FileType::Directory,
+                         FileType::SymLink]
+                    .into_iter().collect(),
+            Some(values) => values.map(|value| match value {
+                "f" | "file" => FileType::RegularFile,
+                "d" | "directory" => FileType::Directory,
+                "l" | "symlink" => FileType::SymLink,
+                _ => FileType::RegularFile,
+            }).collect()
         },
-        extension: matches.value_of("extension").map(|e| {
-            e.trim_left_matches('.').to_lowercase()
+        extensions: matches.values_of("extension").map(|exts| {
+            exts.map(|e| e.trim_left_matches('.').to_lowercase()).collect()
         }),
         command,
         exclude_patterns: matches

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -471,11 +471,25 @@ fn test_type() {
     );
 
     te.assert_output(
+        &["--type", "f", "e1"],
+        "e1 e2",
+    );
+
+    te.assert_output(
         &["--type", "d"],
         "one
         one/two
         one/two/three
         one/two/three/directory_foo",
+    );
+
+    te.assert_output(
+        &["--type", "d", "--type", "l"],
+        "one
+        one/two
+        one/two/three
+        one/two/three/directory_foo
+        symlink",
     );
 
     te.assert_output(&["--type", "l"], "symlink");
@@ -500,6 +514,20 @@ fn test_extension() {
         one/b.foo
         one/two/c.foo
         one/two/three/d.foo",
+    );
+
+    te.assert_output(
+        &["--extension", ".foo", "--extension", "foo2"],
+        "a.foo
+        one/b.foo
+        one/two/c.foo
+        one/two/three/d.foo
+        one/two/C.Foo2",
+    );
+
+    te.assert_output(
+        &["--extension", ".foo", "a"],
+        "a.foo",
     );
 
     te.assert_output(&["--extension", "foo2"], "one/two/C.Foo2");


### PR DESCRIPTION
#177 #199

### Changes 
You can now specify multiple extension and file type filters by simply adding more `-e` or `-t` options, respectively, as was suggested in the above issues. 

So, to find all files and symlinks with the extension `.c` or `.h`, you could run

```
fd -ec -eh -tf -tl
```
