### PR TITLE
Using wants_to_quit to exit the sender as well as the reciever.

### DIFF
--- a/src/exit_codes.rs
+++ b/src/exit_codes.rs
@@ -1,0 +1,3 @@
+
+pub const ERROR: i32 = 1;
+pub const SIGINT: i32 = 130;

--- a/src/exit_codes.rs
+++ b/src/exit_codes.rs
@@ -1,3 +1,4 @@
-
+/// exit code 1 represents a general error
 pub const ERROR: i32 = 1;
+/// exit code 130 represents a process killed by signal SIGINT
 pub const SIGINT: i32 = 130;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ extern crate num_cpus;
 extern crate regex;
 extern crate regex_syntax;
 
+mod exit_codes;
 pub mod fshelper;
 pub mod lscolors;
 mod app;

--- a/src/output.rs
+++ b/src/output.rs
@@ -6,6 +6,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use exit_codes;
 use internal::FdOptions;
 use lscolors::LsColors;
 
@@ -20,9 +21,6 @@ use std::os::unix::fs::PermissionsExt;
 
 use ansi_term;
 
-const EXIT_CODE_ERROR: i32 = 1;
-const EXIT_CODE_SIGINT: i32 = 130;
-
 pub fn print_entry(entry: &PathBuf, config: &FdOptions, wants_to_quit: &Arc<AtomicBool>) {
     let path = entry.strip_prefix(".").unwrap_or(entry);
 
@@ -34,7 +32,7 @@ pub fn print_entry(entry: &PathBuf, config: &FdOptions, wants_to_quit: &Arc<Atom
 
     if r.is_err() {
         // Probably a broken pipe. Exit gracefully.
-        process::exit(EXIT_CODE_ERROR);
+        process::exit(exit_codes::ERROR);
     }
 }
 
@@ -76,7 +74,7 @@ fn print_entry_colorized(
 
         if wants_to_quit.load(Ordering::Relaxed) {
             write!(handle, "\n")?;
-            process::exit(EXIT_CODE_SIGINT);
+            process::exit(exit_codes::SIGINT);
         }
     }
 


### PR DESCRIPTION
#210 
Adding a conditional for wants_to_quit to the sender thread allows us to exit the sender thread as well as the receiver thread when ctrl-c is received.