### PR TITLE
Allow -exec to work as --exec 

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -90,7 +90,6 @@ pub fn build_app() -> App<'static, 'static> {
             arg("exec")
                 .long("exec")
                 .short("x")
-                .multiple(true)
                 .min_values(1)
                 .allow_hyphen_values(true)
                 .value_terminator(";")

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,19 +195,19 @@ where
             }
             args.push(curr);
             return args;
-        } else {
-            if curr == target || curr == long_start || curr == short_start {
-                args.push(if curr == target {
-                    OsString::from("--exec")
-                } else {
-                    curr
-                });
-                in_exec_opt = true;
-            } else {
-                args.push(curr);
-            }
-            args
         }
+
+        if curr == target || curr == long_start || curr == short_start {
+            args.push(if curr == target {
+                OsString::from("--exec")
+            } else {
+                curr
+            });
+            in_exec_opt = true;
+        } else {
+            args.push(curr);
+        }
+        args
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ use lscolors::LsColors;
 use walk::FileType;
 
 fn main() {
-    let checked_args = transform_args_with_exec(env::args_os().collect());
+    let checked_args = transform_args_with_exec(env::args_os());
     let matches = app::build_app().get_matches_from(checked_args);
 
     // Get the search pattern
@@ -178,7 +178,10 @@ fn main() {
 /// # Returns
 ///
 /// * The args, with substitution if required
-fn transform_args_with_exec(original: Vec<OsString>) -> Vec<OsString> {
+fn transform_args_with_exec<I>(original: I) -> Vec<OsString>
+where
+    I: Iterator<Item = OsString>,
+{
     let target = OsString::from("-exec");
     original
         .into_iter()
@@ -203,7 +206,7 @@ fn normal_exec_substitution() {
     let original = vec![oss("fd"), oss("foo"), oss("-exec"), oss("cmd")];
     let expected = vec![oss("fd"), oss("foo"), oss("--exec"), oss("cmd")];
 
-    let actual = transform_args_with_exec(original);
+    let actual = transform_args_with_exec(original.into_iter());
     assert_eq!(expected, actual);
 }
 
@@ -213,7 +216,7 @@ fn passthru_of_original_exec() {
     let original = vec![oss("fd"), oss("foo"), oss("--exec"), oss("cmd")];
     let expected = vec![oss("fd"), oss("foo"), oss("--exec"), oss("cmd")];
 
-    let actual = transform_args_with_exec(original);
+    let actual = transform_args_with_exec(original.into_iter());
     assert_eq!(expected, actual);
 }
 
@@ -238,6 +241,6 @@ fn nexted_exec_gets_transformed() {
         oss("--exec"),
     ];
 
-    let actual = transform_args_with_exec(original);
+    let actual = transform_args_with_exec(original.into_iter());
     assert_eq!(expected, actual);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,27 +288,3 @@ fn temp_check_that_exec_context_observed() {
     let actual = transform_args_with_exec(original.into_iter());
     assert_eq!(expected, actual);
 }
-// Show that -exec passed as param to previous --exec will get changed
-// #[test]
-// fn nexted_exec_gets_transformed() {
-//     // N.B: This is not desirable, but it is here to show that it will
-//     // happen. However, the likelihood is relatively low that a
-//     // secondary command will have -exec as an option.
-//     let original = vec![
-//         oss("fd"),
-//         oss("foo"),
-//         oss("-exec"),
-//         oss("find"),
-//         oss("-exec"),
-//     ];
-//     let expected = vec![
-//         oss("fd"),
-//         oss("foo"),
-//         oss("--exec"),
-//         oss("find"),
-//         oss("--exec"),
-//     ];
-
-//     let actual = transform_args_with_exec(original.into_iter());
-//     assert_eq!(expected, actual);
-// }


### PR DESCRIPTION
This will check for the presence of -exec and change it to --exec prior to passing the args to clap to support the request of #221 

There may be some merit to updating the help docs for -e option to ensure it is known that an .xec file extension will require the --extension option instead. But that may not really be needed as .xec files don't really seem to be a common type.