### PR TITLE
Install `rustfmt-nightly` in debug mode in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
       rust: nightly
       # skip the global install step
       install:
-        - cargo install --force rustfmt-nightly
+        - cargo install --debug --force rustfmt-nightly
       script: cargo fmt -- --write-mode=diff
 
 addons:


### PR DESCRIPTION
This should quicken the build time of the `rustfmt-nightly` binary by a factor of two without impacting the actual runtime, hence reducing the total CI job time by about 3 minutes.