### PR TITLE
Fixed #234: Suggest --fixed-strings on invalid regexps

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,12 @@ fn main() {
         .build()
     {
         Ok(re) => walk::scan(&dir_vec, Arc::new(re), Arc::new(config)),
-        Err(err) => error(err.description()),
+        Err(err) => error(
+            format!(
+                "{}\nHint: You can use the '--fixed-strings' option to search for a \
+                            literal string instead of a regular expression",
+                err.description()
+            ).as_str(),
+        ),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ fn main() {
         Err(err) => error(
             format!(
                 "{}\nHint: You can use the '--fixed-strings' option to search for a \
-                            literal string instead of a regular expression",
+                 literal string instead of a regular expression",
                 err.description()
             ).as_str(),
         ),


### PR DESCRIPTION
Fixed #234 
Giving suggestion to use `--fixed-strings` in case user passes invalid metacharacters as a regex.

@sharkdp it may be a very dumb solution, I have started giving suggestion to use `--fixed-string` for any value of `ErrorKind` of `regex` library. Please let me know if I need to exclude any specific set of `ErrorKind`. All test cases are passing over this changeset.

Let me know if any test case needs to be added for this.

Plus I have added intellij-idea based editor config directory in .gitignore, so it doesn't annoy other devs in git's unstaging area.

Thanks