### PR TITLE
Add chocolatey install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ Alternatively, you can install `fd` via [Scoop](http://scoop.sh):
 scoop install fd
 ```
 
+Or via [Chocolatey](https://chocolatey.org):
+```
+choco install fd
+```
+
 ### On NixOS / via Nix
 
 You can use the [Nix package manager](https://nixos.org/nix/) to install `fd`:


### PR DESCRIPTION
This fixes #262 .

Add installation instructions for chocolatey on Windows.