### PR TITLE
Initial impl of size constraints.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -264,16 +264,20 @@ fn usage() -> HashMap<&'static str, Help> {
         , "Alias for no-ignore ('u') and no-ignore and hidden ('uu')");
     doc!(h, "size"
         , "Limit results based on the size of files."
-        , "Limit results based on the size of files using the format <+-><NUM><UN>.\n   \
-            '+': file size must be greater than this\n   \
-            '-': file size must be less than this\n   \
-            'NUM':      The numeric size (e.g. 500)\n   \
-            'UN':       The units for NUM.\n\
+        , "Limit results based on the size of files using the format <+-><NUM><UNIT>.\n   \
+            '+': file size must be greater than or equal to this\n   \
+            '-': file size must be less than or equal to this\n   \
+            'NUM':  The numeric size (e.g. 500)\n   \
+            'UNIT': The units for NUM. They are not case-sensitive.\n\
             Allowed unit values:\n   \
-                'b' or 'B': bytes\n   \
-                'k' or 'K': kilobytes\n   \
-                'm' or 'M': megabytes\n   \
-                'g' or 'G': gigabytes\n   \
-                't' or 'T': terabytes");
+                'b':  bytes\n   \
+                'k':  kilobytes\n   \
+                'm':  megabytes\n   \
+                'g':  gigabytes\n   \
+                't':  terabytes\n   \
+                'ki': kibibytes\n   \
+                'mi': mebibytes\n   \
+                'gi': gibibytes\n   \
+                'ti': tebibytes");
     h
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,6 @@
 // at your option. All files in the project carrying such
 // notice may not be copied, modified, or distributed except
 // according to those terms.
-
 use std::collections::HashMap;
 
 use clap::{App, AppSettings, Arg};
@@ -16,10 +15,10 @@ struct Help {
 }
 
 macro_rules! doc {
-    ($map:expr, $name:expr, $short:expr) => {
+    ($map: expr, $name: expr, $short: expr) => {
         doc!($map, $name, $short, $short)
     };
-    ($map:expr, $name:expr, $short:expr, $long:expr) => {
+    ($map: expr, $name: expr, $short: expr, $long: expr) => {
         $map.insert(
             $name,
             Help {
@@ -147,6 +146,15 @@ pub fn build_app() -> App<'static, 'static> {
                 .value_name("num"),
         )
         .arg(
+            arg("size")
+                .long("size")
+                .short("S")
+                .takes_value(true)
+                .number_of_values(1)
+                .allow_hyphen_values(true)
+                .multiple(true),
+        )
+        .arg(
             arg("max-buffer-time")
                 .long("max-buffer-time")
                 .takes_value(true)
@@ -254,6 +262,18 @@ fn usage() -> HashMap<&'static str, Help> {
     doc!(h, "rg-alias-hidden-ignore"
         , "Alias for no-ignore and/or hidden"
         , "Alias for no-ignore ('u') and no-ignore and hidden ('uu')");
-
+    doc!(h, "size"
+        , "Limit results based on the size of files."
+        , "Limit results based on the size of files using the format <+-><NUM><UN>.\n   \
+            '+': file size must be greater than this\n   \
+            '-': file size must be less than this\n   \
+            'NUM':      The numeric size (e.g. 500)\n   \
+            'UN':       The units for NUM.\n\
+            Allowed unit values:\n   \
+                'b' or 'B': bytes\n   \
+                'k' or 'K': kilobytes\n   \
+                'm' or 'M': megabytes\n   \
+                'g' or 'G': gigabytes\n   \
+                't' or 'T': terabytes");
     h
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -70,16 +70,22 @@ impl SizeFilter {
             return None;
         }
 
-        let captures = SIZE_CAPTURES.captures(s)?;
+        let captures = match SIZE_CAPTURES.captures(s) {
+            Some(cap) => cap,
+            None => return None,
+        };
 
         let limit = match captures.get(1).map_or("+", |m| m.as_str()) {
             "+" => SizeLimitType::Min,
             _ => SizeLimitType::Max,
         };
 
-        let quantity = match captures.get(2)?.as_str().parse::<u64>() {
-            Ok(val) => val,
-            _ => return None,
+        let quantity = match captures.get(2) {
+            None => return None,
+            Some(v) => match v.as_str().parse::<u64>() {
+                Ok(val) => val,
+                _ => return None,
+            },
         };
 
         let multiplier = match &captures.get(3).map_or("k", |m| m.as_str()).to_lowercase()[..] {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,11 +34,16 @@ use std::sync::Arc;
 use std::time;
 
 use atty::Stream;
-use regex::{RegexBuilder, RegexSetBuilder};
+use regex::{RegexBuilder, RegexSetBuilder, Regex};
 
 use exec::CommandTemplate;
-use internal::{error, pattern_has_uppercase_char, transform_args_with_exec, FdOptions, FileTypes};
+use internal::{error, pattern_has_uppercase_char, transform_args_with_exec, FdOptions, FileTypes,
+               SizeFilter};
 use lscolors::LsColors;
+
+lazy_static! {
+    static ref VALIDATE_SIZE: Regex = { Regex::new(r"^[\+-]{1}\d+[bBkKmMgGTt]{1,2}$").unwrap() };
+}
 
 fn main() {
     let checked_args = transform_args_with_exec(env::args_os());
@@ -132,6 +137,16 @@ fn main() {
 
     let command = matches.values_of("exec").map(CommandTemplate::new);
 
+    let size_limits: Vec<SizeFilter> = matches
+        .values_of("size")
+        .map(|v| v.map(|sf| {
+            if !VALIDATE_SIZE.is_match(sf) {
+                error(&format!("Error: {} is not a valid size constraint.", sf));
+            }
+            sf.into()
+        }).collect())
+        .unwrap_or_else(|| vec![]);
+
     let config = FdOptions {
         case_sensitive,
         search_full_path: matches.is_present("full-path"),
@@ -195,6 +210,7 @@ fn main() {
             .values_of("ignore-file")
             .map(|vs| vs.map(PathBuf::from).collect())
             .unwrap_or_else(|| vec![]),
+        size_constraints: size_limits,
     };
 
     match RegexBuilder::new(&pattern_regex)

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -248,6 +248,16 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) {
                 }
             }
 
+            // Filter out unwanted sizes if it is a file and we have been given size constraints.
+            if entry_path.is_file() && config.size_constraints.len() > 0 {
+                if let Ok(metadata) = entry_path.metadata() {
+                    let file_size = metadata.len();
+                    if config.size_constraints.iter().any(|sc| !sc.is_within(file_size)) {
+                        return ignore::WalkState::Continue;
+                    }
+                }
+            }
+
             let search_str_o = if config.search_full_path {
                 match fshelper::path_absolute_form(entry_path) {
                     Ok(path_abs_buf) => Some(path_abs_buf.to_string_lossy().into_owned().into()),

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -249,10 +249,14 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) {
             }
 
             // Filter out unwanted sizes if it is a file and we have been given size constraints.
-            if entry_path.is_file() && config.size_constraints.len() > 0 {
+            if config.size_constraints.len() > 0 && entry_path.is_file() {
                 if let Ok(metadata) = entry_path.metadata() {
                     let file_size = metadata.len();
-                    if config.size_constraints.iter().any(|sc| !sc.is_within(file_size)) {
+                    if config
+                        .size_constraints
+                        .iter()
+                        .any(|sc| !sc.is_within(file_size))
+                    {
                         return ignore::WalkState::Continue;
                     }
                 }


### PR DESCRIPTION
This adds find-style size constraints in relation to #276.

Sizes are indicated using the same notation for find:
`+`: Greater than or equal to this value
`-`: Less than or equal to this value

Thus, greater than 10KB is `+10K` and less than 1MB is `-1M`.  Values can have trailing B if desired and are not case-sensitive.

As a side note, on current master `test_fixed_strings` fails for some reason on Linux (Fedora 27, up-to-date),