### PR TITLE
Do not include non-files when using --size

### DIFF
--- a/src/walk.rs
+++ b/src/walk.rs
@@ -249,16 +249,22 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) {
             }
 
             // Filter out unwanted sizes if it is a file and we have been given size constraints.
-            if config.size_constraints.len() > 0 && entry_path.is_file() {
-                if let Ok(metadata) = entry_path.metadata() {
-                    let file_size = metadata.len();
-                    if config
-                        .size_constraints
-                        .iter()
-                        .any(|sc| !sc.is_within(file_size))
-                    {
+            if config.size_constraints.len() > 0 {
+                if entry_path.is_file() {
+                    if let Ok(metadata) = entry_path.metadata() {
+                        let file_size = metadata.len();
+                        if config
+                            .size_constraints
+                            .iter()
+                            .any(|sc| !sc.is_within(file_size))
+                        {
+                            return ignore::WalkState::Continue;
+                        }
+                    } else {
                         return ignore::WalkState::Continue;
                     }
+                } else {
+                    return ignore::WalkState::Continue;
                 }
             }
 


### PR DESCRIPTION
Right now, directories (and other non-files) are included, when using the `--size` option. With this change, we exclude everything except files.

/cc @stevepentland 