### PR TITLE
Preserve non utf8 names

### DIFF
--- a/src/exec/input.rs
+++ b/src/exec/input.rs
@@ -71,90 +71,46 @@ pub fn dirname(path: &str) -> &str {
 }
 
 #[cfg(test)]
-mod tests {
+mod path_tests {
     use super::{basename, dirname, remove_extension, MAIN_SEPARATOR};
 
     fn correct(input: &str) -> String {
         input.replace('/', &MAIN_SEPARATOR.to_string())
     }
 
-    #[test]
-    fn path_remove_ext_simple() {
-        assert_eq!(remove_extension("foo.txt"), "foo");
+    macro_rules! func_tests {
+        ($($name:ident: $func:ident for $input:expr => $output:expr)+) => {
+            $(
+                #[test]
+                fn $name() {
+                    assert_eq!($func(&correct($input)), correct($output));
+                }
+            )+
+        }
+    }
+
+    func_tests! {
+        remove_ext_simple:  remove_extension  for  "foo.txt"      =>  "foo"
+        remove_ext_dir:     remove_extension  for  "dir/foo.txt"  =>  "dir/foo"
+        hidden:             remove_extension  for  ".foo"         =>  ".foo"
+        remove_ext_utf8:    remove_extension  for  "💖.txt"       =>  "💖"
+        remove_ext_empty:   remove_extension  for  ""             =>  ""
+
+        basename_simple:  basename  for  "foo.txt"      =>  "foo.txt"
+        basename_dir:     basename  for  "dir/foo.txt"  =>  "foo.txt"
+        basename_empty:   basename  for  ""             =>  ""
+        basename_utf8_0:  basename  for  "💖/foo.txt"   =>  "foo.txt"
+        basename_utf8_1:  basename  for  "dir/💖.txt"   =>  "💖.txt"
+
+        dirname_simple:  dirname  for  "foo.txt"      =>  "."
+        dirname_dir:     dirname  for  "dir/foo.txt"  =>  "dir"
+        dirname_utf8_0:  dirname  for  "💖/foo.txt"   =>  "💖"
+        dirname_utf8_1:  dirname  for  "dir/💖.txt"   =>  "dir"
+        dirname_empty:   dirname  for  ""             =>  "."
     }
 
     #[test]
-    fn path_remove_ext_dir() {
-        assert_eq!(
-            remove_extension(&correct("dir/foo.txt")),
-            correct("dir/foo")
-        );
-    }
-
-    #[test]
-    fn path_hidden() {
-        assert_eq!(remove_extension(".foo"), ".foo")
-    }
-
-    #[test]
-    fn path_remove_ext_utf8() {
-        assert_eq!(remove_extension("💖.txt"), "💖");
-    }
-
-    #[test]
-    fn path_remove_ext_empty() {
-        assert_eq!(remove_extension(""), "");
-    }
-
-    #[test]
-    fn path_basename_simple() {
-        assert_eq!(basename("foo.txt"), "foo.txt");
-    }
-
-    #[test]
-    fn path_basename_no_ext() {
-        assert_eq!(remove_extension(basename("foo.txt")), "foo");
-    }
-
-    #[test]
-    fn path_basename_dir() {
-        assert_eq!(basename(&correct("dir/foo.txt")), "foo.txt");
-    }
-
-    #[test]
-    fn path_basename_empty() {
-        assert_eq!(basename(""), "");
-    }
-
-    #[test]
-    fn path_basename_utf8() {
-        assert_eq!(basename(&correct("💖/foo.txt")), "foo.txt");
-        assert_eq!(basename(&correct("dir/💖.txt")), "💖.txt");
-    }
-
-    #[test]
-    fn path_dirname_simple() {
-        assert_eq!(dirname("foo.txt"), ".");
-    }
-
-    #[test]
-    fn path_dirname_dir() {
-        assert_eq!(dirname(&correct("dir/foo.txt")), "dir");
-    }
-
-    #[test]
-    fn path_dirname_utf8() {
-        assert_eq!(dirname(&correct("💖/foo.txt")), "💖");
-        assert_eq!(dirname(&correct("dir/💖.txt")), "dir");
-    }
-
-    #[test]
-    fn path_dirname_empty() {
-        assert_eq!(dirname(""), ".");
-    }
-
-    #[test]
-    fn path_dirname_root() {
+    fn dirname_root() {
         #[cfg(windows)]
         assert_eq!(dirname("C:\\"), "C:");
         #[cfg(windows)]

--- a/src/exec/input.rs
+++ b/src/exec/input.rs
@@ -6,6 +6,11 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+#![cfg(not(unix))]
+///! The operations in this module are not strictly speaking 100% correct,
+///! as not all platforms use always-valid UTF-8 paths.
+///! This is just a temporary solution until they can be implemented correctly
+///! for every platform
 use std::path::MAIN_SEPARATOR;
 
 /// Removes the parent component of the path

--- a/src/exec/input_unix.rs
+++ b/src/exec/input_unix.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2018 fd developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0>
+// or the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+#![cfg(unix)]
+///! This division is a temporary solution, until we can perform these operations on
+///! `Path`s directly on all platforms, without going thru `str`
+use std::ffi::OsStr;
+use std::path::Path;
+
+use std::os::unix::ffi::OsStrExt;
+
+/// Removes the parent component of the path
+pub fn basename(path: &Path) -> &Path {
+    use std::path::Component;
+    match path.components().last() {
+        Some(Component::Normal(s)) => s.as_ref(),
+        _ => "".as_ref(),
+    }
+}
+
+/// Removes the extension (if any) from the path
+pub fn remove_extension(path: &Path) -> &Path {
+    if let Some(ext) = path.extension() {
+        let ext_bytes = ext.as_bytes().len();
+        let stem = strip_suffix_bytes(path, ext_bytes + 1 /* for the dot character */);
+        OsStr::from_bytes(stem).as_ref()
+    } else {
+        path
+    }
+}
+
+/// Removes the basename from the path.
+pub fn dirname(path: &Path) -> &OsStr {
+    let base = basename(path);
+    let base_bytes = base.as_os_str().as_bytes().len();
+
+    let stripped = strip_suffix_bytes(path, base_bytes);
+    if stripped.is_empty() {
+        ".".as_ref()
+    } else if let Some((&b'/', noslash)) = stripped.split_last() {
+        OsStr::from_bytes(noslash)
+    } else {
+        OsStr::from_bytes(stripped)
+    }
+}
+
+/// This is only meaningful on unix, where a `Path` is a sequence of non-zero bytes
+/// This function slices the given `path` and returns the same data,
+/// minus exactly `count` bytes at the end.
+fn strip_suffix_bytes(path: &Path, count: usize) -> &[u8] {
+    let all_bytes = path.as_os_str().as_bytes().len();
+    let remaining = all_bytes.saturating_sub(count);
+
+    &path.as_os_str().as_bytes()[..remaining]
+}
+
+#[cfg(test)]
+mod path_tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    fn pathinate(s: &str) -> PathBuf {
+        OsString::from(s).into()
+    }
+
+    /// IMPORTANTi: comparisons are performed here as `OsString`, NEVER as `Path`s.
+    /// This is because path comparison disregards a final separator,
+    /// and we were fortunate enough to have this caught by integration tests
+    macro_rules! func_tests {
+        ($($name:ident: $func:ident for $input:expr => $output:expr)+) => {
+            $(
+                #[test]
+                fn $name() {
+                    assert_eq!(OsString::from($func(&pathinate($input))), OsString::from($output));
+                }
+            )+
+        }
+    }
+
+    func_tests! {
+        remove_ext_simple:  remove_extension  for  "foo.txt"      =>  "foo"
+        remove_ext_dir:     remove_extension  for  "dir/foo.txt"  =>  "dir/foo"
+        hidden:             remove_extension  for  ".foo"         =>  ".foo"
+        remove_ext_utf8:    remove_extension  for  "💖.txt"       =>  "💖"
+        remove_ext_empty:   remove_extension  for  ""             =>  ""
+
+        basename_simple:  basename  for  "foo.txt"      =>  "foo.txt"
+        basename_dir:     basename  for  "dir/foo.txt"  =>  "foo.txt"
+        basename_empty:   basename  for  ""             =>  ""
+        basename_utf8_0:  basename  for  "💖/foo.txt"   =>  "foo.txt"
+        basename_utf8_1:  basename  for  "dir/💖.txt"   =>  "💖.txt"
+
+        dirname_simple:  dirname  for  "foo.txt"      =>  "."
+        dirname_dir:     dirname  for  "dir/foo.txt"  =>  "dir"
+        dirname_utf8_0:  dirname  for  "💖/foo.txt"   =>  "💖"
+        dirname_utf8_1:  dirname  for  "dir/💖.txt"   =>  "dir"
+        dirname_empty:   dirname  for  ""             =>  "."
+    }
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -97,11 +97,24 @@ fn print_entry_colorized(
     }
 }
 
+#[cfg(not(target_os = "linux"))]
 fn print_entry_uncolorized(path: &Path, config: &FdOptions) -> io::Result<()> {
     let separator = if config.null_separator { "\0" } else { "\n" };
 
     let path_str = path.to_string_lossy();
     write!(&mut io::stdout(), "{}{}", path_str, separator)
+}
+
+#[cfg(target_os = "linux")]
+fn print_entry_uncolorized(path: &Path, config: &FdOptions) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let separator = if config.null_separator { "\0" } else { "\n" };
+
+    let mut out = io::stdout();
+    out.write(path.as_os_str().as_bytes())?;
+    out.write(separator.as_bytes())?;
+    Ok(())
 }
 
 fn get_path_style<'a>(path: &Path, ls_colors: &'a LsColors) -> Option<&'a ansi_term::Style> {

--- a/src/output.rs
+++ b/src/output.rs
@@ -112,8 +112,8 @@ fn print_entry_uncolorized(path: &Path, config: &FdOptions) -> io::Result<()> {
     let separator = if config.null_separator { "\0" } else { "\n" };
 
     let mut out = io::stdout();
-    out.write(path.as_os_str().as_bytes())?;
-    out.write(separator.as_bytes())?;
+    out.write_all(path.as_os_str().as_bytes())?;
+    out.write_all(separator.as_bytes())?;
     Ok(())
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -977,6 +977,23 @@ fn test_exec_invalid_utf8() {
         &["", "test1/", "--exec", "echo", "{}"],
         b"test1/test_\xFEinvalid.txt\n",
     );
+
+    te.assert_output_raw(
+        &["", "test1/", "--exec", "echo", "{/}"],
+        b"test_\xFEinvalid.txt\n",
+    );
+
+    te.assert_output_raw(&["", "test1/", "--exec", "echo", "{//}"], b"test1\n");
+
+    te.assert_output_raw(
+        &["", "test1/", "--exec", "echo", "{.}"],
+        b"test1/test_\xFEinvalid\n",
+    );
+
+    te.assert_output_raw(
+        &["", "test1/", "--exec", "echo", "{/.}"],
+        b"test_\xFEinvalid\n",
+    );
 }
 
 /// Literal search (--fixed-strings)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -958,7 +958,13 @@ fn assert_exec_output(exec_style: &str) {
 }
 
 /// Filenames with non-utf8 paths are passed to the exec'ed program unchanged
-#[cfg(target_os = "linux")]
+///
+/// This is unix-only, due to the ability to use OsStr as [u8] on unix.
+/// TODO: extend test to other platforms, with their specific non-utf they support
+///
+/// Note: the test is disabled on Darwin/OSX, since it coerces file names to UTF-8,
+///       even when the requesed file name is not valid UTF-8.
+#[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn test_exec_invalid_utf8() {
     use std::ffi::OsStr;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1003,9 +1003,9 @@ fn test_invalid_utf8() {
             .join(OsStr::from_bytes(b"test1/test_\xFEinvalid.txt")),
     ).unwrap();
 
-    te.assert_output(&["", "test1/"], "test1/test_�invalid.txt");
+    te.assert_output_raw(&["", "test1/"], b"test1/test_\xFEinvalid.txt\n");
 
-    te.assert_output(&["invalid", "test1/"], "test1/test_�invalid.txt");
+    te.assert_output_raw(&["invalid", "test1/"], b"test1/test_\xFEinvalid.txt\n");
 
     // Should not be found under a different extension
     te.assert_output(&["-e", "zip", "", "test1/"], "");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -957,6 +957,28 @@ fn assert_exec_output(exec_style: &str) {
     }
 }
 
+/// Filenames with non-utf8 paths are passed to the exec'ed program unchanged
+#[cfg(target_os = "linux")]
+#[test]
+fn test_exec_invalid_utf8() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let dirs = &["test1"];
+    let files = &[];
+    let te = TestEnv::new(dirs, files);
+
+    fs::File::create(
+        te.test_root()
+            .join(OsStr::from_bytes(b"test1/test_\xFEinvalid.txt")),
+    ).unwrap();
+
+    te.assert_output_raw(
+        &["", "test1/", "--exec", "echo", "{}"],
+        b"test1/test_\xFEinvalid.txt\n",
+    );
+}
+
 /// Literal search (--fixed-strings)
 #[test]
 fn test_fixed_strings() {


### PR DESCRIPTION
Hopefully this fixes #295 .
Right now it's linux-only, since i don't have access to other unices.
The test harness changes are also a little fragile, and it will work reliably only for single-line output.
Let me know if anything needs adjusting, or if there's anything better to be done about `TestEnv`.