### PR TITLE
Add `--maxdepth` as hidden alias for `--max-depth`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -204,9 +204,8 @@ fn usage() -> HashMap<&'static str, Help> {
         , "Limit the directory traversal to a given depth. By default, there is no limit \
            on the search depth.");
     doc!(h, "rg-depth"
-        , "Set maximum search depth (default: none)"
-        , "Limit the directory traversal to a given depth. By default, there is no limit \
-           on the search depth.");
+        , "See --max-depth"
+        , "See --max-depth");
     doc!(h, "file-type"
         , "Filter by type: file (f), directory (d), symlink (l),\nexecutable (x), empty (e)"
         , "Filter the search by type (multiple allowable filetypes can be specified):\n  \

--- a/src/app.rs
+++ b/src/app.rs
@@ -70,7 +70,13 @@ pub fn build_app() -> App<'static, 'static> {
         .arg(arg("full-path").long("full-path").short("p"))
         .arg(arg("null_separator").long("print0").short("0"))
         .arg(arg("depth").long("max-depth").short("d").takes_value(true))
+        // support --maxdepth as well, for compatibility with rg
         .arg(
+            arg("rg-depth")
+                .long("maxdepth")
+                .hidden(true)
+                .takes_value(true),
+        ).arg(
             arg("file-type")
                 .long("type")
                 .short("t")
@@ -194,6 +200,10 @@ fn usage() -> HashMap<&'static str, Help> {
         , "Separate search results by the null character (instead of newlines). Useful for \
            piping results to 'xargs'.");
     doc!(h, "depth"
+        , "Set maximum search depth (default: none)"
+        , "Limit the directory traversal to a given depth. By default, there is no limit \
+           on the search depth.");
+    doc!(h, "rg-depth"
         , "Set maximum search depth (default: none)"
         , "Limit the directory traversal to a given depth. By default, there is no limit \
            on the search depth.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,7 @@ fn main() {
         null_separator: matches.is_present("null_separator"),
         max_depth: matches
             .value_of("depth")
+            .or_else(|| matches.value_of("rg-depth"))
             .and_then(|n| usize::from_str_radix(n, 10).ok()),
         threads: std::cmp::max(
             matches


### PR DESCRIPTION
For muscle memory compatibility with `rg`. This variant will not show in
the help or in the program options, and is only checked if `--maxdepth`
is not specified.