### PR TITLE
Upgrade minimum reqiured version of Rust to 1.29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,19 +64,19 @@ matrix:
 
     # Minimum Rust supported channel.
     - os: linux
-      rust: 1.20.0
+      rust: 1.29.0
       env: TARGET=x86_64-unknown-linux-gnu
     - os: linux
-      rust: 1.20.0
+      rust: 1.29.0
       env: TARGET=x86_64-unknown-linux-musl
     - os: linux
-      rust: 1.20.0
+      rust: 1.29.0
       env: TARGET=i686-unknown-linux-gnu
     - os: linux
-      rust: 1.20.0
+      rust: 1.29.0
       env: TARGET=i686-unknown-linux-musl
     - os: osx
-      rust: 1.20.0
+      rust: 1.29.0
       env: TARGET=x86_64-apple-darwin
 
     # Code formatting check

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ With Rust's package manager [cargo](https://github.com/rust-lang/cargo), you can
 ```
 cargo install fd-find
 ```
-Note that rust version *1.20.0* or later is required.
+Note that rust version *1.29.0* or later is required.
 
 ### From binaries
 

--- a/build.rs
+++ b/build.rs
@@ -18,12 +18,11 @@ use std::process::exit;
 include!("src/app.rs");
 
 fn main() {
-    match version_check::is_min_version("1.20") {
-        // rustc >= 1.20
+    match version_check::is_min_version("1.29") {
         Some((true, _)) => {}
-        // rustc < 1.20 or can't figure it out
+        // rustc version too small or can't figure it out
         _ => {
-            writeln!(&mut io::stderr(), "This crate requires rustc >= 1.20").unwrap();
+            writeln!(&mut io::stderr(), "'fd' requires rustc >= 1.29").unwrap();
             exit(1);
         }
     }


### PR DESCRIPTION
This upgrades the minimum required version of Rust to 1.29 in order to fix #288.

See also:
- Rust compiler bug ticket: rust-lang/rust#50619
- Rust compiler PR with the fix: rust-lang/rust#50630

closes #288