### PR TITLE
enable error messages

### DIFF
--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -7,7 +7,7 @@
 // according to those terms.
 
 use super::CommandTemplate;
-use internal::print_error_and_exit;
+use internal::print_error;
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
@@ -25,15 +25,14 @@ pub fn job(
         // Create a lock on the shared receiver for this thread.
         let lock = rx.lock().unwrap();
 
-        // Obtain the next path from the receiver, else if the channel
+        // Obtain the next result from the receiver, else if the channel
         // has closed, exit from the loop
         let value: PathBuf = match lock.recv() {
-            Ok(value) => match value {
-                WorkerResult::Entry(val) => val,
-                WorkerResult::Error(err) => {
-                    print_error_and_exit(&format!("{}", err));
-                }
-            },
+            Ok(WorkerResult::Entry(val)) => val,
+            Ok(WorkerResult::Error(err)) => {
+                print_error(&format!("{}", err));
+                continue;
+            }
             Err(_) => break,
         };
 

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -7,7 +7,7 @@
 // according to those terms.
 
 use super::CommandTemplate;
-use internal::error;
+use internal::print_error_and_exit;
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
@@ -31,7 +31,7 @@ pub fn job(
             Ok(value) => match value {
                 WorkerResult::Entry(val) => val,
                 WorkerResult::Error(err) => {
-                    error(&format!("{}", err));
+                    print_error_and_exit(&format!("{}", err));
                 }
             },
             Err(_) => break,

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -9,13 +9,14 @@
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
-
+use::walk::WorkerResult;
+use::internal::error;
 use super::CommandTemplate;
 
 /// An event loop that listens for inputs from the `rx` receiver. Each received input will
 /// generate a command with the supplied command template. The generated command will then
 /// be executed, and this process will continue until the receiver's sender has closed.
-pub fn job(rx: Arc<Mutex<Receiver<PathBuf>>>, cmd: Arc<CommandTemplate>, out_perm: Arc<Mutex<()>>) {
+pub fn job(rx: Arc<Mutex<Receiver<WorkerResult>>>, cmd: Arc<CommandTemplate>, out_perm: Arc<Mutex<()>>) {
     loop {
         // Create a lock on the shared receiver for this thread.
         let lock = rx.lock().unwrap();
@@ -23,7 +24,14 @@ pub fn job(rx: Arc<Mutex<Receiver<PathBuf>>>, cmd: Arc<CommandTemplate>, out_per
         // Obtain the next path from the receiver, else if the channel
         // has closed, exit from the loop
         let value: PathBuf = match lock.recv() {
-            Ok(value) => value,
+            Ok(value) => {
+                match value {
+                    WorkerResult::Entry(val) => val,
+                    WorkerResult::Error(err) => {
+                        error(&format!("{}", err));
+                    }
+                }
+            },
             Err(_) => break,
         };
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -7,7 +7,6 @@
 // according to those terms.
 
 use std::ffi::OsString;
-use std::io::Write;
 use std::path::PathBuf;
 use std::process;
 use std::time;
@@ -174,9 +173,14 @@ pub struct FdOptions {
     pub size_constraints: Vec<SizeFilter>,
 }
 
+/// Print error message to stderr.
+pub fn print_error(message: &str) {
+    eprintln!("{}", message);
+}
+
 /// Print error message to stderr and exit with status `1`.
-pub fn error(message: &str) -> ! {
-    writeln!(&mut ::std::io::stderr(), "{}", message).expect("Failed writing to stderr");
+pub fn print_error_and_exit(message: &str) -> ! {
+    print_error(message);
     process::exit(1);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,8 @@ use regex::{RegexBuilder, RegexSetBuilder};
 
 use exec::CommandTemplate;
 use internal::{
-    error, pattern_has_uppercase_char, transform_args_with_exec, FdOptions, FileTypes, SizeFilter,
+    pattern_has_uppercase_char, print_error_and_exit, transform_args_with_exec, FdOptions,
+    FileTypes, SizeFilter,
 };
 use lscolors::LsColors;
 
@@ -52,7 +53,7 @@ fn main() {
     // Get the current working directory
     let current_dir = Path::new(".");
     if !fshelper::is_dir(current_dir) {
-        error("Error: could not get current directory.");
+        print_error_and_exit("Error: could not get current directory.");
     }
 
     // Get one or more root directories to search.
@@ -61,7 +62,7 @@ fn main() {
             .map(|path| {
                 let path_buffer = PathBuf::from(path);
                 if !fshelper::is_dir(&path_buffer) {
-                    error(&format!(
+                    print_error_and_exit(&format!(
                         "Error: '{}' is not a directory.",
                         path_buffer.to_string_lossy()
                     ));
@@ -89,7 +90,7 @@ fn main() {
         && pattern.contains(std::path::MAIN_SEPARATOR)
         && fshelper::is_dir(Path::new(pattern))
     {
-        error(&format!(
+        print_error_and_exit(&format!(
             "Error: The search pattern '{pattern}' contains a path-separation character ('{sep}') \
              and will not lead to any search results.\n\n\
              If you want to search for all files inside the '{pattern}' directory, use a match-all pattern:\n\n  \
@@ -142,7 +143,7 @@ fn main() {
                 if let Some(f) = SizeFilter::from_string(sf) {
                     return f;
                 }
-                error(&format!("Error: {} is not a valid size constraint.", sf));
+                print_error_and_exit(&format!("Error: {} is not a valid size constraint.", sf));
             })
             .collect()
         })
@@ -211,7 +212,7 @@ fn main() {
                 .build()
             {
                 Ok(re) => re,
-                Err(err) => error(err.description()),
+                Err(err) => print_error_and_exit(err.description()),
             }
         }),
         command,
@@ -232,7 +233,7 @@ fn main() {
         .build()
     {
         Ok(re) => walk::scan(&dir_vec, Arc::new(re), Arc::new(config)),
-        Err(err) => error(
+        Err(err) => print_error_and_exit(
             format!(
                 "{}\nHint: You can use the '--fixed-strings' option to search for a \
                  literal string instead of a regular expression",

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -39,7 +39,7 @@ enum ReceiverMode {
 /// The Worker threads can result in a valid entry having PathBuf or an error.
 pub enum WorkerResult {
     Entry(PathBuf),
-    Error(ignore::Error)
+    Error(ignore::Error),
 }
 
 /// Recursively scan the given search path for files / pathnames matching the pattern.
@@ -300,7 +300,9 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) {
             if let Some(search_str) = search_str_o {
                 if pattern.is_match(&*search_str) {
                     // TODO: take care of the unwrap call
-                    tx_thread.send(WorkerResult::Entry(entry_path.to_owned())).unwrap()
+                    tx_thread
+                        .send(WorkerResult::Entry(entry_path.to_owned()))
+                        .unwrap()
                 }
             }
 


### PR DESCRIPTION
Fixes #311.
This PR enables the display of error messages such as permission denied. It adds the `WorkerResult` enum representing the results of the worker threads which are passed through the `mpsc::channel` to the main thread.