### PR TITLE
Add exec tests and cfg(test) compiler guards

### DIFF
--- a/src/exec/input.rs
+++ b/src/exec/input.rs
@@ -72,7 +72,7 @@ pub fn dirname(path: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{basename, dirname, remove_extension, MAIN_SEPARATOR};
+    use super::*;
 
     fn correct(input: &str) -> String {
         input.replace('/', &MAIN_SEPARATOR.to_string())

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -150,26 +150,69 @@ impl ArgumentTemplate {
 
 #[cfg(test)]
 mod tests {
-    use super::{ArgumentTemplate, CommandTemplate, Token};
+    use super::*;
 
     #[test]
-    fn tokens() {
-        let expected = CommandTemplate {
-            args: vec![
-                ArgumentTemplate::Text("echo".into()),
-                ArgumentTemplate::Text("${SHELL}:".into()),
-                ArgumentTemplate::Tokens(vec![Token::Placeholder]),
-            ],
-        };
+    fn tokens_with_placeholder() {
+        assert_eq!(
+            CommandTemplate::new(&[&"echo", &"${SHELL}:"]),
+            CommandTemplate {
+                args: vec![
+                    ArgumentTemplate::Text("echo".into()),
+                    ArgumentTemplate::Text("${SHELL}:".into()),
+                    ArgumentTemplate::Tokens(vec![Token::Placeholder]),
+                ],
+            }
+        );
+    }
 
-        assert_eq!(CommandTemplate::new(&[&"echo", &"${SHELL}:"]), expected);
-
+    #[test]
+    fn tokens_with_no_extension() {
         assert_eq!(
             CommandTemplate::new(&["echo", "{.}"]),
             CommandTemplate {
                 args: vec![
                     ArgumentTemplate::Text("echo".into()),
                     ArgumentTemplate::Tokens(vec![Token::NoExt]),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn tokens_with_basename() {
+        assert_eq!(
+            CommandTemplate::new(&["echo", "{/}"]),
+            CommandTemplate {
+                args: vec![
+                    ArgumentTemplate::Text("echo".into()),
+                    ArgumentTemplate::Tokens(vec![Token::Basename]),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn tokens_with_parent() {
+        assert_eq!(
+            CommandTemplate::new(&["echo", "{//}"]),
+            CommandTemplate {
+                args: vec![
+                    ArgumentTemplate::Text("echo".into()),
+                    ArgumentTemplate::Tokens(vec![Token::Parent]),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn tokens_with_basename_no_extension() {
+        assert_eq!(
+            CommandTemplate::new(&["echo", "{/.}"]),
+            CommandTemplate {
+                args: vec![
+                    ArgumentTemplate::Text("echo".into()),
+                    ArgumentTemplate::Tokens(vec![Token::BasenameNoExt]),
                 ],
             }
         );

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -259,89 +259,91 @@ where
 }
 
 #[cfg(test)]
-fn oss(v: &str) -> OsString {
-    OsString::from(v)
-}
-
-/// Ensure that -exec gets transformed into --exec
-#[test]
-fn normal_exec_substitution() {
-    let original = vec![oss("fd"), oss("foo"), oss("-exec"), oss("cmd")];
-    let expected = vec![oss("fd"), oss("foo"), oss("--exec"), oss("cmd")];
-
-    let actual = transform_args_with_exec(original.into_iter());
-    assert_eq!(expected, actual);
-}
-
-/// Ensure that --exec is not touched
-#[test]
-fn passthru_of_original_exec() {
-    let original = vec![oss("fd"), oss("foo"), oss("--exec"), oss("cmd")];
-    let expected = vec![oss("fd"), oss("foo"), oss("--exec"), oss("cmd")];
-
-    let actual = transform_args_with_exec(original.into_iter());
-    assert_eq!(expected, actual);
-}
-
-#[test]
-fn temp_check_that_exec_context_observed() {
-    let original = vec![
-        oss("fd"),
-        oss("foo"),
-        oss("-exec"),
-        oss("cmd"),
-        oss("-exec"),
-        oss("ls"),
-        oss(";"),
-        oss("-exec"),
-        oss("rm"),
-        oss(";"),
-        oss("--exec"),
-        oss("find"),
-        oss("-exec"),
-        oss("rm"),
-        oss(";"),
-        oss("-x"),
-        oss("foo"),
-        oss("-exec"),
-        oss("something"),
-        oss(";"),
-        oss("-exec"),
-    ];
-    let expected = vec![
-        oss("fd"),
-        oss("foo"),
-        oss("--exec"),
-        oss("cmd"),
-        oss("-exec"),
-        oss("ls"),
-        oss(";"),
-        oss("--exec"),
-        oss("rm"),
-        oss(";"),
-        oss("--exec"),
-        oss("find"),
-        oss("-exec"),
-        oss("rm"),
-        oss(";"),
-        oss("-x"),
-        oss("foo"),
-        oss("-exec"),
-        oss("something"),
-        oss(";"),
-        oss("--exec"),
-    ];
-
-    let actual = transform_args_with_exec(original.into_iter());
-    assert_eq!(expected, actual);
-}
-
-/// Parsing and size conversion tests
-#[cfg(test)]
-mod size_parsing {
+mod tests {
     use super::*;
 
-    macro_rules! gen_size_filter_parse_test {
+    fn oss(v: &str) -> OsString {
+        OsString::from(v)
+    }
+
+    /// Ensure that -exec gets transformed into --exec
+    #[test]
+    fn normal_exec_substitution() {
+        let original = vec![oss("fd"), oss("foo"), oss("-exec"), oss("cmd")];
+        let expected = vec![oss("fd"), oss("foo"), oss("--exec"), oss("cmd")];
+
+        let actual = transform_args_with_exec(original.into_iter());
+        assert_eq!(expected, actual);
+    }
+
+    /// Ensure that --exec is not touched
+    #[test]
+    fn passthru_of_original_exec() {
+        let original = vec![oss("fd"), oss("foo"), oss("--exec"), oss("cmd")];
+        let expected = vec![oss("fd"), oss("foo"), oss("--exec"), oss("cmd")];
+
+        let actual = transform_args_with_exec(original.into_iter());
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn temp_check_that_exec_context_observed() {
+        let original = vec![
+            oss("fd"),
+            oss("foo"),
+            oss("-exec"),
+            oss("cmd"),
+            oss("-exec"),
+            oss("ls"),
+            oss(";"),
+            oss("-exec"),
+            oss("rm"),
+            oss(";"),
+            oss("--exec"),
+            oss("find"),
+            oss("-exec"),
+            oss("rm"),
+            oss(";"),
+            oss("-x"),
+            oss("foo"),
+            oss("-exec"),
+            oss("something"),
+            oss(";"),
+            oss("-exec"),
+        ];
+        let expected = vec![
+            oss("fd"),
+            oss("foo"),
+            oss("--exec"),
+            oss("cmd"),
+            oss("-exec"),
+            oss("ls"),
+            oss(";"),
+            oss("--exec"),
+            oss("rm"),
+            oss(";"),
+            oss("--exec"),
+            oss("find"),
+            oss("-exec"),
+            oss("rm"),
+            oss(";"),
+            oss("-x"),
+            oss("foo"),
+            oss("-exec"),
+            oss("something"),
+            oss(";"),
+            oss("--exec"),
+        ];
+
+        let actual = transform_args_with_exec(original.into_iter());
+        assert_eq!(expected, actual);
+    }
+
+    /// Parsing and size conversion tests
+    mod size_parsing {
+        use super::*;
+
+        macro_rules! gen_size_filter_parse_test {
         ($($name: ident: $val: expr,)*) => {
             $(
                 #[test]
@@ -354,85 +356,84 @@ mod size_parsing {
         };
     }
 
-    /// Parsing and size conversion tests data. Ensure that each type gets properly interpreted.
-    /// Call with higher base values to ensure expected multiplication (only need a couple)
-    gen_size_filter_parse_test! {
-        byte_plus:                ("+1b",     SizeFilter::Min(1)),
-        byte_plus_multiplier:     ("+10b",    SizeFilter::Min(10)),
-        byte_minus:               ("-1b",     SizeFilter::Max(1)),
-        kilo_plus:                ("+1k",     SizeFilter::Min(1000)),
-        kilo_plus_suffix:         ("+1kb",    SizeFilter::Min(1000)),
-        kilo_minus:               ("-1k",     SizeFilter::Max(1000)),
-        kilo_minus_multiplier:    ("-100k",   SizeFilter::Max(100000)),
-        kilo_minus_suffix:        ("-1kb",    SizeFilter::Max(1000)),
-        kilo_plus_upper:          ("+1K",     SizeFilter::Min(1000)),
-        kilo_plus_suffix_upper:   ("+1KB",    SizeFilter::Min(1000)),
-        kilo_minus_upper:         ("-1K",     SizeFilter::Max(1000)),
-        kilo_minus_suffix_upper:  ("-1Kb",    SizeFilter::Max(1000)),
-        kibi_plus:                ("+1ki",    SizeFilter::Min(1024)),
-        kibi_plus_multiplier:     ("+10ki",   SizeFilter::Min(10240)),
-        kibi_plus_suffix:         ("+1kib",   SizeFilter::Min(1024)),
-        kibi_minus:               ("-1ki",    SizeFilter::Max(1024)),
-        kibi_minus_multiplier:    ("-100ki",  SizeFilter::Max(102400)),
-        kibi_minus_suffix:        ("-1kib",   SizeFilter::Max(1024)),
-        kibi_plus_upper:          ("+1KI",    SizeFilter::Min(1024)),
-        kibi_plus_suffix_upper:   ("+1KiB",   SizeFilter::Min(1024)),
-        kibi_minus_upper:         ("-1Ki",    SizeFilter::Max(1024)),
-        kibi_minus_suffix_upper:  ("-1KIB",   SizeFilter::Max(1024)),
-        mega_plus:                ("+1m",     SizeFilter::Min(1000000)),
-        mega_plus_suffix:         ("+1mb",    SizeFilter::Min(1000000)),
-        mega_minus:               ("-1m",     SizeFilter::Max(1000000)),
-        mega_minus_suffix:        ("-1mb",    SizeFilter::Max(1000000)),
-        mega_plus_upper:          ("+1M",     SizeFilter::Min(1000000)),
-        mega_plus_suffix_upper:   ("+1MB",    SizeFilter::Min(1000000)),
-        mega_minus_upper:         ("-1M",     SizeFilter::Max(1000000)),
-        mega_minus_suffix_upper:  ("-1Mb",    SizeFilter::Max(1000000)),
-        mebi_plus:                ("+1mi",    SizeFilter::Min(1048576)),
-        mebi_plus_suffix:         ("+1mib",   SizeFilter::Min(1048576)),
-        mebi_minus:               ("-1mi",    SizeFilter::Max(1048576)),
-        mebi_minus_suffix:        ("-1mib",   SizeFilter::Max(1048576)),
-        mebi_plus_upper:          ("+1MI",    SizeFilter::Min(1048576)),
-        mebi_plus_suffix_upper:   ("+1MiB",   SizeFilter::Min(1048576)),
-        mebi_minus_upper:         ("-1Mi",    SizeFilter::Max(1048576)),
-        mebi_minus_suffix_upper:  ("-1MIB",   SizeFilter::Max(1048576)),
-        giga_plus:                ("+1g",     SizeFilter::Min(1000000000)),
-        giga_plus_suffix:         ("+1gb",    SizeFilter::Min(1000000000)),
-        giga_minus:               ("-1g",     SizeFilter::Max(1000000000)),
-        giga_minus_suffix:        ("-1gb",    SizeFilter::Max(1000000000)),
-        giga_plus_upper:          ("+1G",     SizeFilter::Min(1000000000)),
-        giga_plus_suffix_upper:   ("+1GB",    SizeFilter::Min(1000000000)),
-        giga_minus_upper:         ("-1G",     SizeFilter::Max(1000000000)),
-        giga_minus_suffix_upper:  ("-1Gb",    SizeFilter::Max(1000000000)),
-        gibi_plus:                ("+1gi",    SizeFilter::Min(1073741824)),
-        gibi_plus_suffix:         ("+1gib",   SizeFilter::Min(1073741824)),
-        gibi_minus:               ("-1gi",    SizeFilter::Max(1073741824)),
-        gibi_minus_suffix:        ("-1gib",   SizeFilter::Max(1073741824)),
-        gibi_plus_upper:          ("+1GI",    SizeFilter::Min(1073741824)),
-        gibi_plus_suffix_upper:   ("+1GiB",   SizeFilter::Min(1073741824)),
-        gibi_minus_upper:         ("-1Gi",    SizeFilter::Max(1073741824)),
-        gibi_minus_suffix_upper:  ("-1GIB",   SizeFilter::Max(1073741824)),
-        tera_plus:                ("+1t",     SizeFilter::Min(1000000000000)),
-        tera_plus_suffix:         ("+1tb",    SizeFilter::Min(1000000000000)),
-        tera_minus:               ("-1t",     SizeFilter::Max(1000000000000)),
-        tera_minus_suffix:        ("-1tb",    SizeFilter::Max(1000000000000)),
-        tera_plus_upper:          ("+1T",     SizeFilter::Min(1000000000000)),
-        tera_plus_suffix_upper:   ("+1TB",    SizeFilter::Min(1000000000000)),
-        tera_minus_upper:         ("-1T",     SizeFilter::Max(1000000000000)),
-        tera_minus_suffix_upper:  ("-1Tb",    SizeFilter::Max(1000000000000)),
-        tebi_plus:                ("+1ti",    SizeFilter::Min(1099511627776)),
-        tebi_plus_suffix:         ("+1tib",   SizeFilter::Min(1099511627776)),
-        tebi_minus:               ("-1ti",    SizeFilter::Max(1099511627776)),
-        tebi_minus_suffix:        ("-1tib",   SizeFilter::Max(1099511627776)),
-        tebi_plus_upper:          ("+1TI",    SizeFilter::Min(1099511627776)),
-        tebi_plus_suffix_upper:   ("+1TiB",   SizeFilter::Min(1099511627776)),
-        tebi_minus_upper:         ("-1Ti",    SizeFilter::Max(1099511627776)),
-        tebi_minus_suffix_upper:  ("-1TIB",   SizeFilter::Max(1099511627776)),
+        /// Parsing and size conversion tests data. Ensure that each type gets properly interpreted.
+        /// Call with higher base values to ensure expected multiplication (only need a couple)
+        gen_size_filter_parse_test! {
+            byte_plus:                ("+1b",     SizeFilter::Min(1)),
+            byte_plus_multiplier:     ("+10b",    SizeFilter::Min(10)),
+            byte_minus:               ("-1b",     SizeFilter::Max(1)),
+            kilo_plus:                ("+1k",     SizeFilter::Min(1000)),
+            kilo_plus_suffix:         ("+1kb",    SizeFilter::Min(1000)),
+            kilo_minus:               ("-1k",     SizeFilter::Max(1000)),
+            kilo_minus_multiplier:    ("-100k",   SizeFilter::Max(100000)),
+            kilo_minus_suffix:        ("-1kb",    SizeFilter::Max(1000)),
+            kilo_plus_upper:          ("+1K",     SizeFilter::Min(1000)),
+            kilo_plus_suffix_upper:   ("+1KB",    SizeFilter::Min(1000)),
+            kilo_minus_upper:         ("-1K",     SizeFilter::Max(1000)),
+            kilo_minus_suffix_upper:  ("-1Kb",    SizeFilter::Max(1000)),
+            kibi_plus:                ("+1ki",    SizeFilter::Min(1024)),
+            kibi_plus_multiplier:     ("+10ki",   SizeFilter::Min(10240)),
+            kibi_plus_suffix:         ("+1kib",   SizeFilter::Min(1024)),
+            kibi_minus:               ("-1ki",    SizeFilter::Max(1024)),
+            kibi_minus_multiplier:    ("-100ki",  SizeFilter::Max(102400)),
+            kibi_minus_suffix:        ("-1kib",   SizeFilter::Max(1024)),
+            kibi_plus_upper:          ("+1KI",    SizeFilter::Min(1024)),
+            kibi_plus_suffix_upper:   ("+1KiB",   SizeFilter::Min(1024)),
+            kibi_minus_upper:         ("-1Ki",    SizeFilter::Max(1024)),
+            kibi_minus_suffix_upper:  ("-1KIB",   SizeFilter::Max(1024)),
+            mega_plus:                ("+1m",     SizeFilter::Min(1000000)),
+            mega_plus_suffix:         ("+1mb",    SizeFilter::Min(1000000)),
+            mega_minus:               ("-1m",     SizeFilter::Max(1000000)),
+            mega_minus_suffix:        ("-1mb",    SizeFilter::Max(1000000)),
+            mega_plus_upper:          ("+1M",     SizeFilter::Min(1000000)),
+            mega_plus_suffix_upper:   ("+1MB",    SizeFilter::Min(1000000)),
+            mega_minus_upper:         ("-1M",     SizeFilter::Max(1000000)),
+            mega_minus_suffix_upper:  ("-1Mb",    SizeFilter::Max(1000000)),
+            mebi_plus:                ("+1mi",    SizeFilter::Min(1048576)),
+            mebi_plus_suffix:         ("+1mib",   SizeFilter::Min(1048576)),
+            mebi_minus:               ("-1mi",    SizeFilter::Max(1048576)),
+            mebi_minus_suffix:        ("-1mib",   SizeFilter::Max(1048576)),
+            mebi_plus_upper:          ("+1MI",    SizeFilter::Min(1048576)),
+            mebi_plus_suffix_upper:   ("+1MiB",   SizeFilter::Min(1048576)),
+            mebi_minus_upper:         ("-1Mi",    SizeFilter::Max(1048576)),
+            mebi_minus_suffix_upper:  ("-1MIB",   SizeFilter::Max(1048576)),
+            giga_plus:                ("+1g",     SizeFilter::Min(1000000000)),
+            giga_plus_suffix:         ("+1gb",    SizeFilter::Min(1000000000)),
+            giga_minus:               ("-1g",     SizeFilter::Max(1000000000)),
+            giga_minus_suffix:        ("-1gb",    SizeFilter::Max(1000000000)),
+            giga_plus_upper:          ("+1G",     SizeFilter::Min(1000000000)),
+            giga_plus_suffix_upper:   ("+1GB",    SizeFilter::Min(1000000000)),
+            giga_minus_upper:         ("-1G",     SizeFilter::Max(1000000000)),
+            giga_minus_suffix_upper:  ("-1Gb",    SizeFilter::Max(1000000000)),
+            gibi_plus:                ("+1gi",    SizeFilter::Min(1073741824)),
+            gibi_plus_suffix:         ("+1gib",   SizeFilter::Min(1073741824)),
+            gibi_minus:               ("-1gi",    SizeFilter::Max(1073741824)),
+            gibi_minus_suffix:        ("-1gib",   SizeFilter::Max(1073741824)),
+            gibi_plus_upper:          ("+1GI",    SizeFilter::Min(1073741824)),
+            gibi_plus_suffix_upper:   ("+1GiB",   SizeFilter::Min(1073741824)),
+            gibi_minus_upper:         ("-1Gi",    SizeFilter::Max(1073741824)),
+            gibi_minus_suffix_upper:  ("-1GIB",   SizeFilter::Max(1073741824)),
+            tera_plus:                ("+1t",     SizeFilter::Min(1000000000000)),
+            tera_plus_suffix:         ("+1tb",    SizeFilter::Min(1000000000000)),
+            tera_minus:               ("-1t",     SizeFilter::Max(1000000000000)),
+            tera_minus_suffix:        ("-1tb",    SizeFilter::Max(1000000000000)),
+            tera_plus_upper:          ("+1T",     SizeFilter::Min(1000000000000)),
+            tera_plus_suffix_upper:   ("+1TB",    SizeFilter::Min(1000000000000)),
+            tera_minus_upper:         ("-1T",     SizeFilter::Max(1000000000000)),
+            tera_minus_suffix_upper:  ("-1Tb",    SizeFilter::Max(1000000000000)),
+            tebi_plus:                ("+1ti",    SizeFilter::Min(1099511627776)),
+            tebi_plus_suffix:         ("+1tib",   SizeFilter::Min(1099511627776)),
+            tebi_minus:               ("-1ti",    SizeFilter::Max(1099511627776)),
+            tebi_minus_suffix:        ("-1tib",   SizeFilter::Max(1099511627776)),
+            tebi_plus_upper:          ("+1TI",    SizeFilter::Min(1099511627776)),
+            tebi_plus_suffix_upper:   ("+1TiB",   SizeFilter::Min(1099511627776)),
+            tebi_minus_upper:         ("-1Ti",    SizeFilter::Max(1099511627776)),
+            tebi_minus_suffix_upper:  ("-1TIB",   SizeFilter::Max(1099511627776)),
+        }
     }
-}
 
-/// Invalid parse testing
-#[cfg(test)]
-macro_rules! gen_size_filter_failure {
+    /// Invalid parse testing
+    macro_rules! gen_size_filter_failure {
     ($($name:ident: $value:expr,)*) => {
         $(
             #[test]
@@ -444,42 +445,42 @@ macro_rules! gen_size_filter_failure {
     };
 }
 
-/// Invalid parse data
-#[cfg(test)]
-gen_size_filter_failure! {
-    ensure_missing_symbol_returns_none: "10M",
-    ensure_missing_number_returns_none: "+g",
-    ensure_missing_unit_returns_none: "+18",
-    ensure_bad_format_returns_none_1: "$10M",
-    ensure_bad_format_returns_none_2: "badval",
-    ensure_bad_format_returns_none_3: "9999",
-    ensure_invalid_unit_returns_none_1: "+50a",
-    ensure_invalid_unit_returns_none_2: "-10v",
-    ensure_invalid_unit_returns_none_3: "+1Mv",
-    ensure_bib_format_returns_none: "+1bib",
-    ensure_bb_format_returns_none: "+1bb",
-}
+    /// Invalid parse data
+    gen_size_filter_failure! {
+        ensure_missing_symbol_returns_none: "10M",
+        ensure_missing_number_returns_none: "+g",
+        ensure_missing_unit_returns_none: "+18",
+        ensure_bad_format_returns_none_1: "$10M",
+        ensure_bad_format_returns_none_2: "badval",
+        ensure_bad_format_returns_none_3: "9999",
+        ensure_invalid_unit_returns_none_1: "+50a",
+        ensure_invalid_unit_returns_none_2: "-10v",
+        ensure_invalid_unit_returns_none_3: "+1Mv",
+        ensure_bib_format_returns_none: "+1bib",
+        ensure_bb_format_returns_none: "+1bb",
+    }
 
-#[test]
-fn is_within_less_than() {
-    let f = SizeFilter::from_string("-1k").unwrap();
-    assert!(f.is_within(999));
-}
+    #[test]
+    fn is_within_less_than() {
+        let f = SizeFilter::from_string("-1k").unwrap();
+        assert!(f.is_within(999));
+    }
 
-#[test]
-fn is_within_less_than_equal() {
-    let f = SizeFilter::from_string("-1k").unwrap();
-    assert!(f.is_within(1000));
-}
+    #[test]
+    fn is_within_less_than_equal() {
+        let f = SizeFilter::from_string("-1k").unwrap();
+        assert!(f.is_within(1000));
+    }
 
-#[test]
-fn is_within_greater_than() {
-    let f = SizeFilter::from_string("+1k").unwrap();
-    assert!(f.is_within(1001));
-}
+    #[test]
+    fn is_within_greater_than() {
+        let f = SizeFilter::from_string("+1k").unwrap();
+        assert!(f.is_within(1001));
+    }
 
-#[test]
-fn is_within_greater_than_equal() {
-    let f = SizeFilter::from_string("+1K").unwrap();
-    assert!(f.is_within(1000));
+    #[test]
+    fn is_within_greater_than_equal() {
+        let f = SizeFilter::from_string("+1K").unwrap();
+        assert!(f.is_within(1000));
+    }
 }

--- a/src/lscolors/mod.rs
+++ b/src/lscolors/mod.rs
@@ -167,65 +167,70 @@ impl LsColors {
     }
 }
 
-#[test]
-fn test_parse_simple() {
-    assert_eq!(Some(Colour::Red.normal()), LsColors::parse_style("31"));
-}
+#[cfg(test)]
+mod test {
+    use super::*;
 
-#[test]
-fn test_parse_decoration() {
-    assert_eq!(Some(Colour::Red.normal()), LsColors::parse_style("00;31"));
+    #[test]
+    fn test_parse_simple() {
+        assert_eq!(Some(Colour::Red.normal()), LsColors::parse_style("31"));
+    }
 
-    assert_eq!(Some(Colour::Blue.italic()), LsColors::parse_style("03;34"));
+    #[test]
+    fn test_parse_decoration() {
+        assert_eq!(Some(Colour::Red.normal()), LsColors::parse_style("00;31"));
 
-    assert_eq!(Some(Colour::Cyan.bold()), LsColors::parse_style("01;36"));
-}
+        assert_eq!(Some(Colour::Blue.italic()), LsColors::parse_style("03;34"));
 
-#[test]
-fn test_parse_decoration_backwards() {
-    assert_eq!(Some(Colour::Blue.italic()), LsColors::parse_style("34;03"));
+        assert_eq!(Some(Colour::Cyan.bold()), LsColors::parse_style("01;36"));
+    }
 
-    assert_eq!(Some(Colour::Cyan.bold()), LsColors::parse_style("36;01"));
+    #[test]
+    fn test_parse_decoration_backwards() {
+        assert_eq!(Some(Colour::Blue.italic()), LsColors::parse_style("34;03"));
 
-    assert_eq!(Some(Colour::Red.normal()), LsColors::parse_style("31;00"));
-}
+        assert_eq!(Some(Colour::Cyan.bold()), LsColors::parse_style("36;01"));
 
-#[test]
-fn test_parse_256() {
-    assert_eq!(
-        Some(Colour::Fixed(115).normal()),
-        LsColors::parse_style("38;5;115")
-    );
+        assert_eq!(Some(Colour::Red.normal()), LsColors::parse_style("31;00"));
+    }
 
-    assert_eq!(
-        Some(Colour::Fixed(115).normal()),
-        LsColors::parse_style("00;38;5;115")
-    );
+    #[test]
+    fn test_parse_256() {
+        assert_eq!(
+            Some(Colour::Fixed(115).normal()),
+            LsColors::parse_style("38;5;115")
+        );
 
-    assert_eq!(
-        Some(Colour::Fixed(119).bold()),
-        LsColors::parse_style("01;38;5;119")
-    );
+        assert_eq!(
+            Some(Colour::Fixed(115).normal()),
+            LsColors::parse_style("00;38;5;115")
+        );
 
-    assert_eq!(
-        Some(Colour::Fixed(119).bold()),
-        LsColors::parse_style("38;5;119;01")
-    );
-}
+        assert_eq!(
+            Some(Colour::Fixed(119).bold()),
+            LsColors::parse_style("01;38;5;119")
+        );
 
-#[test]
-fn test_from_string() {
-    assert_eq!(LsColors::default(), LsColors::from_string(&String::new()));
+        assert_eq!(
+            Some(Colour::Fixed(119).bold()),
+            LsColors::parse_style("38;5;119;01")
+        );
+    }
 
-    let result = LsColors::from_string(&String::from(
-        "rs=0:di=03;34:ln=01;36:*.foo=01;35:*README=33",
-    ));
+    #[test]
+    fn test_from_string() {
+        assert_eq!(LsColors::default(), LsColors::from_string(&String::new()));
 
-    assert_eq!(Colour::Blue.italic(), result.directory);
-    assert_eq!(Colour::Cyan.bold(), result.symlink);
-    assert_eq!(Some(&Colour::Purple.bold()), result.extensions.get("foo"));
-    assert_eq!(
-        Some(&Colour::Yellow.normal()),
-        result.filenames.get("README")
-    );
+        let result = LsColors::from_string(&String::from(
+            "rs=0:di=03;34:ln=01;36:*.foo=01;35:*README=33",
+        ));
+
+        assert_eq!(Colour::Blue.italic(), result.directory);
+        assert_eq!(Colour::Cyan.bold(), result.symlink);
+        assert_eq!(Some(&Colour::Purple.bold()), result.extensions.get("foo"));
+        assert_eq!(
+            Some(&Colour::Yellow.normal()),
+            result.filenames.get("README")
+        );
+    }
 }


### PR DESCRIPTION
Some tests throughout the codebase were just functions marked with the `#[test]` macro. It is convention to have these test functions in a `test` module with a compiler guard `cfg(test)`. This PR updates the tests that aren't already setup like this to be in the `test` module.

Additionally, this PR also adds tests to the `exec` module to check the remaining `Token` enum variations.