### PR TITLE
Move exit code consts into enum

### DIFF
--- a/src/exit_codes.rs
+++ b/src/exit_codes.rs
@@ -1,13 +1,13 @@
 pub enum ExitCode {
-    Error,
-    Sigint,
+    GeneralError,
+    KilledBySigint,
 }
 
 impl Into<i32> for ExitCode {
     fn into(self) -> i32 {
         match self {
-            ExitCode::Error => 1,
-            ExitCode::Sigint => 130,
+            ExitCode::GeneralError => 1,
+            ExitCode::KilledBySigint => 130,
         }
     }
 }

--- a/src/exit_codes.rs
+++ b/src/exit_codes.rs
@@ -1,4 +1,13 @@
-/// exit code 1 represents a general error
-pub const ERROR: i32 = 1;
-/// exit code 130 represents a process killed by signal SIGINT
-pub const SIGINT: i32 = 130;
+pub enum ExitCode {
+    Error,
+    Sigint,
+}
+
+impl Into<i32> for ExitCode {
+    fn into(self) -> i32 {
+        match self {
+            ExitCode::Error => 1,
+            ExitCode::Sigint => 130,
+        }
+    }
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -214,12 +214,6 @@ fn hir_has_uppercase_char(hir: &Hir) -> bool {
 /// Maximum size of the output buffer before flushing results to the console
 pub const MAX_BUFFER_LENGTH: usize = 1000;
 
-/// Exit code representing a general error
-pub const EXITCODE_ERROR: i32 = 1;
-
-/// Exit code representing that the process was killed by SIGINT
-pub const EXITCODE_SIGINT: i32 = 130;
-
 /// Traverse args_os, looking for -exec and replacing it with --exec.
 ///
 /// # Returns

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ extern crate regex_syntax;
 
 mod app;
 mod exec;
+mod exit_codes;
 pub mod fshelper;
 mod internal;
 pub mod lscolors;

--- a/src/output.rs
+++ b/src/output.rs
@@ -45,7 +45,7 @@ pub fn print_entry(entry: &PathBuf, config: &FdOptions, wants_to_quit: &Arc<Atom
 
     if r.is_err() {
         // Probably a broken pipe. Exit gracefully.
-        process::exit(ExitCode::Error.into());
+        process::exit(ExitCode::GeneralError.into());
     }
 }
 
@@ -87,7 +87,7 @@ fn print_entry_colorized(
 
         if wants_to_quit.load(Ordering::Relaxed) {
             write!(handle, "\n")?;
-            process::exit(ExitCode::Sigint.into());
+            process::exit(ExitCode::KilledBySigint.into());
         }
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -6,8 +6,9 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use exit_codes::ExitCode;
 use fshelper::is_executable;
-use internal::{FdOptions, EXITCODE_ERROR, EXITCODE_SIGINT};
+use internal::FdOptions;
 use lscolors::LsColors;
 
 use std::io::{self, Write};
@@ -44,7 +45,7 @@ pub fn print_entry(entry: &PathBuf, config: &FdOptions, wants_to_quit: &Arc<Atom
 
     if r.is_err() {
         // Probably a broken pipe. Exit gracefully.
-        process::exit(EXITCODE_ERROR);
+        process::exit(ExitCode::Error.into());
     }
 }
 
@@ -86,7 +87,7 @@ fn print_entry_colorized(
 
         if wants_to_quit.load(Ordering::Relaxed) {
             write!(handle, "\n")?;
-            process::exit(EXITCODE_SIGINT);
+            process::exit(ExitCode::Sigint.into());
         }
     }
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -319,6 +319,6 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) {
     receiver_thread.join().unwrap();
 
     if wants_to_quit.load(Ordering::Relaxed) {
-        process::exit(ExitCode::Sigint.into());
+        process::exit(ExitCode::KilledBySigint.into());
     }
 }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -9,8 +9,9 @@
 extern crate ctrlc;
 
 use exec;
+use exit_codes::ExitCode;
 use fshelper;
-use internal::{print_error, print_error_and_exit, FdOptions, EXITCODE_SIGINT, MAX_BUFFER_LENGTH};
+use internal::{print_error, print_error_and_exit, FdOptions, MAX_BUFFER_LENGTH};
 use output;
 
 use std::error::Error;
@@ -318,6 +319,6 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) {
     receiver_thread.join().unwrap();
 
     if wants_to_quit.load(Ordering::Relaxed) {
-        process::exit(EXITCODE_SIGINT);
+        process::exit(ExitCode::Sigint.into());
     }
 }


### PR DESCRIPTION
Previously, the constants defined in `src/exit_codes` weren't being used, and the constants for exit codes were being redefined in the `internals` module.

This PR removes the exit code consts and instead uses an enum defined in `src/exit_codes`. This centralizes the definitions of exit codes making them easier to modify and keep track of.