### PR TITLE
Add print_error macros to replace functions

### DIFF
--- a/src/exec/command.rs
+++ b/src/exec/command.rs
@@ -30,10 +30,10 @@ pub fn execute_command(mut cmd: Command, out_perm: Arc<Mutex<()>>) {
             let _ = stderr.lock().write_all(&output.stderr);
         }
         Err(ref why) if why.kind() == io::ErrorKind::NotFound => {
-            eprintln!("fd: execution error: command not found");
+            print_error!("fd: execution error: command not found");
         }
         Err(why) => {
-            eprintln!("fd: execution error: {}", why);
+            print_error!("fd: execution error: {}", why);
         }
     }
 }

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -7,7 +7,6 @@
 // according to those terms.
 
 use super::CommandTemplate;
-use internal::print_error;
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
@@ -30,7 +29,7 @@ pub fn job(
         let value: PathBuf = match lock.recv() {
             Ok(WorkerResult::Entry(val)) => val,
             Ok(WorkerResult::Error(err)) => {
-                print_error(&format!("{}", err));
+                print_error!("{}", err);
                 continue;
             }
             Err(_) => break,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -8,7 +8,6 @@
 
 use std::ffi::OsString;
 use std::path::PathBuf;
-use std::process;
 use std::time::{self, SystemTime};
 
 use exec::CommandTemplate;
@@ -199,15 +198,15 @@ pub struct FdOptions {
     pub time_constraints: Vec<TimeFilter>,
 }
 
-/// Print error message to stderr.
-pub fn print_error(message: &str) {
-    eprintln!("{}", message);
+macro_rules! print_error {
+    ($($arg:tt)*) => (eprintln!($($arg)*))
 }
 
-/// Print error message to stderr and exit with status `1`.
-pub fn print_error_and_exit(message: &str) -> ! {
-    print_error(message);
-    process::exit(1);
+macro_rules! print_error_and_exit {
+    ($($arg:tt)*) => {
+        print_error!($($arg)*);
+        ::std::process::exit(1);
+    };
 }
 
 /// Determine if a regex pattern contains a literal uppercase character.

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -11,7 +11,7 @@ extern crate ctrlc;
 use exec;
 use exit_codes::ExitCode;
 use fshelper;
-use internal::{print_error, print_error_and_exit, FdOptions, MAX_BUFFER_LENGTH};
+use internal::{FdOptions, MAX_BUFFER_LENGTH};
 use output;
 
 use std::error::Error;
@@ -61,11 +61,11 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) {
     for pattern in &config.exclude_patterns {
         let res = override_builder.add(pattern);
         if res.is_err() {
-            print_error_and_exit(&format!("Error: malformed exclude pattern '{}'", pattern));
+            print_error_and_exit!("Error: malformed exclude pattern '{}'", pattern);
         }
     }
     let overrides = override_builder.build().unwrap_or_else(|_| {
-        print_error_and_exit("Mismatch in exclude patterns");
+        print_error_and_exit!("Mismatch in exclude patterns");
     });
 
     let mut walker = WalkBuilder::new(first_path_buf.as_path());
@@ -90,11 +90,14 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) {
             match err {
                 ignore::Error::Partial(_) => (),
                 _ => {
-                    print_error(&format!(
-                        "Error while parsing custom ignore file '{}': {}.",
-                        ignore_file.to_string_lossy(),
-                        err.description()
-                    ));
+                    print_error!(
+                        "{}",
+                        format!(
+                            "Error while parsing custom ignore file '{}': {}.",
+                            ignore_file.to_string_lossy(),
+                            err.description()
+                        )
+                    );
                 }
             }
         }
@@ -190,7 +193,7 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) {
                         }
                     }
                     WorkerResult::Error(err) => {
-                        print_error(&format!("{}", err));
+                        print_error!("{}", err);
                     }
                 }
             }
@@ -310,7 +313,9 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) {
             let search_str_o = if config.search_full_path {
                 match fshelper::path_absolute_form(entry_path) {
                     Ok(path_abs_buf) => Some(path_abs_buf.to_string_lossy().into_owned().into()),
-                    Err(_) => print_error_and_exit("Error: unable to get full path."),
+                    Err(_) => {
+                        print_error_and_exit!("Error: unable to get full path.");
+                    }
                 }
             } else {
                 entry_path.file_name().map(|f| f.to_string_lossy())


### PR DESCRIPTION
This patch removes the `print_error` function which was just calling `eprintln!`. Instead of making the function call we use the macro instead.

The patch also replaces the `print_error_and_exit` function with a macro `eprintln_and_die!`. This is more consistent with the print macros provided by stdlib.