### PR TITLE
Enable link-time optimization in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,7 @@ libc = "0.2"
 diff = "0.1"
 tempdir = "0.3"
 filetime = "0.2.1"
+
+[profile.release]
+lto = true
+codegen-units = 1


### PR DESCRIPTION
For release builds, it's probably worth enabling link-time optimization (LTO). The performance gains can be moderately significant: In the [`warm-cache-simple-pattern`](https://github.com/sharkdp/fd-benchmarks/blob/master/warm-cache-simple-pattern.sh) benchmark I observed an 8% improvement in the case of the `[0-9]\.jpg$` pattern, and an 11% improvement in the case of the  `.*[0-9]\.jpg$` pattern. (Of course, much like [the example benchmark in the README](https://github.com/sharkdp/fd#benchmark), this is one particular benchmark on one particular machine. I do wish there was a standardized set of files to run the benchmarks against, as I see was discussed (but not resolved) in issue #36.)

The main downside of LTO is that it makes the compile times longer. I feel that it's worth making that tradeoff in a tool like `fd`, for which (runtime) speed is one of its major selling points.