### PR TITLE
Add `search-path` option

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -183,6 +183,14 @@ pub fn build_app() -> App<'static, 'static> {
         )
         .arg(arg("pattern"))
         .arg(arg("path").multiple(true))
+        .arg(
+            arg("search-path")
+                .long("search-path")
+                .takes_value(true)
+                .conflicts_with("path")
+                .multiple(true)
+                .number_of_values(1),
+        )
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -314,5 +322,9 @@ fn usage() -> HashMap<&'static str, Help> {
         , "Limit results based on modification time within the duration provided:\n    \
              using a duration: <NUM>d <NUM>h <NUM>m <NUM>s (e.g. 10h, 1d, 35min...)\n    \
              or a date and time: YYYY-MM-DD HH:MM:SS");
+    doc!(h, "search-path"
+        , "Provide paths to search as flag arguments rather than positional arguments."
+        , "Provide paths to search as flag arguments, preventing the usage of any positional `path` arugments.\n\
+           Changes the usage to `fd [FLAGS/OPTIONS] --search-path <path> --search-path <path2> [<pattern>]`");
     h
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,10 @@ fn main() {
     }
 
     // Get one or more root directories to search.
-    let mut dir_vec: Vec<_> = match matches.values_of("path") {
+    let mut dir_vec: Vec<_> = match matches
+        .values_of("path")
+        .or(matches.values_of("search-path"))
+    {
         Some(paths) => paths
             .map(|path| {
                 let path_buffer = PathBuf::from(path);


### PR DESCRIPTION
Fixes #277

 * Multiple `--search-path` arguments can be supplied which replace the positional `path` argument for providing directories which will be searched.
 * When a `--search-path` argument is provided, positional `path` arguments will not be allowed

I didn't set this argument to hidden as was suggested in the issue because I feel that users wouldn't be able to know about this functionality otherwise.

Also, I didn't change the official `usage` because I feel that it would add unnecessary confusion for users that aren't looking for this specialized functionality.