### PR TITLE
Add test with multiple tokens in an argument

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -217,4 +217,21 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn tokens_multiple() {
+        assert_eq!(
+            CommandTemplate::new(&["cp", "{}", "{/.}.ext"]),
+            CommandTemplate {
+                args: vec![
+                    ArgumentTemplate::Text("cp".into()),
+                    ArgumentTemplate::Tokens(vec![Token::Placeholder]),
+                    ArgumentTemplate::Tokens(vec![
+                        Token::BasenameNoExt,
+                        Token::Text(".ext".into())
+                    ]),
+                ],
+            }
+        );
+    }
 }


### PR DESCRIPTION
Added a test that results in multiple `Token`s within one `ArgumentTemplate` (as it took me some time to figure out the purpose of the `Vec` here).