### PR TITLE
Edition upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ name = "fd-find"
 readme = "README.md"
 repository = "https://github.com/sharkdp/fd"
 version = "7.2.0"
+edition= "2018"
 
 [[bin]]
 name = "fd"

--- a/build.rs
+++ b/build.rs
@@ -6,10 +6,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-#[macro_use]
-extern crate clap;
-extern crate version_check;
-
 use clap::Shell;
 use std::fs;
 use std::io::{self, Write};

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@
 // according to those terms.
 use std::collections::HashMap;
 
-use clap::{App, AppSettings, Arg};
+use clap::{crate_version, App, AppSettings, Arg};
 
 struct Help {
     short: &'static str,

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -7,10 +7,10 @@
 // according to those terms.
 
 use super::CommandTemplate;
+use crate::walk::WorkerResult;
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
-use crate::walk::WorkerResult;
 
 /// An event loop that listens for inputs from the `rx` receiver. Each received input will
 /// generate a command with the supplied command template. The generated command will then

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -10,7 +10,7 @@ use super::CommandTemplate;
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
-use walk::WorkerResult;
+use crate::walk::WorkerResult;
 
 /// An event loop that listens for inputs from the `rx` receiver. Each received input will
 /// generate a command with the supplied command template. The generated command will then

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 
+use lazy_static::lazy_static;
 use regex::Regex;
 
 use self::command::execute_command;

--- a/src/internal/filter/size.rs
+++ b/src/internal/filter/size.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use regex::Regex;
 
 lazy_static! {

--- a/src/internal/opts.rs
+++ b/src/internal/opts.rs
@@ -1,5 +1,5 @@
-use exec::CommandTemplate;
-use internal::{
+use crate::exec::CommandTemplate;
+use crate::internal::{
     filter::{SizeFilter, TimeFilter},
     FileTypes,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,21 +6,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate ansi_term;
-extern crate atty;
-#[macro_use]
-extern crate clap;
-extern crate ignore;
-#[macro_use]
-extern crate lazy_static;
-extern crate humantime;
-#[cfg(all(unix, not(target_os = "redox")))]
-extern crate libc;
-extern crate lscolors;
-extern crate num_cpus;
-extern crate regex;
-extern crate regex_syntax;
-
 #[macro_use]
 mod internal;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,8 @@ use atty::Stream;
 use lscolors::LsColors;
 use regex::{RegexBuilder, RegexSetBuilder};
 
-use exec::CommandTemplate;
-use internal::{
+use crate::exec::CommandTemplate;
+use crate::internal::{
     filter::{SizeFilter, TimeFilter},
     opts::FdOptions,
     pattern_has_uppercase_char, transform_args_with_exec, FileTypes,

--- a/src/output.rs
+++ b/src/output.rs
@@ -6,8 +6,8 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use exit_codes::ExitCode;
-use internal::opts::FdOptions;
+use crate::exit_codes::ExitCode;
+use crate::internal::opts::FdOptions;
 use lscolors::{LsColors, Style};
 
 use std::io::{self, Write};

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -8,11 +8,11 @@
 
 extern crate ctrlc;
 
-use exec;
-use exit_codes::ExitCode;
-use fshelper;
-use internal::{opts::FdOptions, MAX_BUFFER_LENGTH};
-use output;
+use crate::exec;
+use crate::exit_codes::ExitCode;
+use crate::fshelper;
+use crate::internal::{opts::FdOptions, MAX_BUFFER_LENGTH};
+use crate::output;
 
 use std::error::Error;
 use std::path::PathBuf;

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -6,8 +6,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate ctrlc;
-
 use crate::exec;
 use crate::exit_codes::ExitCode;
 use crate::fshelper;

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -20,10 +20,7 @@ use std::os::unix;
 #[cfg(windows)]
 use std::os::windows;
 
-extern crate diff;
-extern crate tempdir;
-
-use self::tempdir::TempDir;
+use tempdir::TempDir;
 
 /// Environment for the integration tests.
 pub struct TestEnv {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,18 +8,14 @@
 
 //! Integration tests for the CLI interface of fd.
 
-extern crate filetime;
-extern crate humantime;
-extern crate regex;
-
 mod testenv;
 
+use crate::testenv::TestEnv;
 use regex::escape;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 use std::time::{Duration, SystemTime};
-use crate::testenv::TestEnv;
 
 static DEFAULT_DIRS: &'static [&'static str] = &["one/two/three", "one/two/three/directory_foo"];
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -19,7 +19,7 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 use std::time::{Duration, SystemTime};
-use testenv::TestEnv;
+use crate::testenv::TestEnv;
 
 static DEFAULT_DIRS: &'static [&'static str] = &["one/two/three", "one/two/three/directory_foo"];
 


### PR DESCRIPTION
This is just a minimal set of changes for the 2018 edition (since recently 1.31 is the minimum supported version).

This does not also change the `mod.rs` files into `$module_name.rs` files. Please let me know if you think this should also be done in the same PR.