### PR TITLE
Lazy metadata

### DIFF
--- a/src/walk.rs
+++ b/src/walk.rs
@@ -281,7 +281,9 @@ fn spawn_senders(
             // Filter out unwanted file types.
 
             if let Some(ref file_types) = config.file_types {
-                if let Some(ref entry_type) = entry.file_type() {
+                if let Ok(metadata) = entry_metadata.get() {
+                    let entry_type = metadata.file_type();
+
                     if (!file_types.files && entry_type.is_file())
                         || (!file_types.directories && entry_type.is_dir())
                         || (!file_types.symlinks && entry_type.is_symlink())
@@ -321,8 +323,8 @@ fn spawn_senders(
 
             // Filter out unwanted sizes if it is a file and we have been given size constraints.
             if !config.size_constraints.is_empty() {
-                if entry_path.is_file() {
-                    if let Ok(metadata) = entry_metadata.get() {
+                if let Ok(metadata) = entry_metadata.get() {
+                    if metadata.is_file() {
                         let file_size = metadata.len();
                         if config
                             .size_constraints
@@ -342,8 +344,8 @@ fn spawn_senders(
             // Filter out unwanted modification times
             if !config.time_constraints.is_empty() {
                 let mut matched = false;
-                if entry_path.is_file() {
-                    if let Ok(metadata) = entry_metadata.get() {
+                if let Ok(metadata) = entry_metadata.get() {
+                    if metadata.is_file() {
                         if let Ok(modified) = metadata.modified() {
                             matched = config
                                 .time_constraints

--- a/src/walk/lazy.rs
+++ b/src/walk/lazy.rs
@@ -7,6 +7,7 @@
 // according to those terms.
 
 // inspired by https://www.reddit.com/r/rust/comments/9406rl/once_cell_a_lazy_static_without_macros_and_more/
+
 pub struct Lazy<T, F>
 where
     F: FnOnce() -> T,
@@ -42,4 +43,25 @@ where
 {
     Pending(Option<F>),
     Data(T),
+}
+
+#[test]
+fn evaluates_only_once() {
+    let mut x = 2;
+    let mut l = Lazy::new(|| {
+        x += 1;
+        x
+    });
+
+    assert_eq!(*l.get(), 3);
+    assert_eq!(*l.get(), 3);
+}
+
+#[test]
+fn no_evaluation_before_get() {
+    #[allow(unreachable_code)]
+    let _l = Lazy::new(|| {
+        panic!("must not call this");
+        3
+    });
 }

--- a/src/walk/lazy.rs
+++ b/src/walk/lazy.rs
@@ -8,6 +8,15 @@
 
 // inspired by https://www.reddit.com/r/rust/comments/9406rl/once_cell_a_lazy_static_without_macros_and_more/
 
+// There are several crates out there dealing with lazy initialization
+// in different ways. Pretty much all seem to use some form of additional
+// locking or atomic operations, or other kinds of overhead.
+//
+// For this usecase, what was needed was a low-overhead solution,
+// that only needed to support a single thread.
+//
+// TODO: maybe this should be polished/expanded and pulled out in a crate ?
+
 pub struct Lazy<T, F>
 where
     F: FnOnce() -> T,

--- a/src/walk/lazy.rs
+++ b/src/walk/lazy.rs
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 fd developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0>
+// or the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+// inspired by https://www.reddit.com/r/rust/comments/9406rl/once_cell_a_lazy_static_without_macros_and_more/
+pub struct Lazy<T, F>
+where
+    F: FnOnce() -> T,
+{
+    inner: LazyImpl<T, F>,
+}
+
+impl<T, F> Lazy<T, F>
+where
+    F: FnOnce() -> T,
+{
+    pub fn new(f: F) -> Self {
+        Self {
+            inner: LazyImpl::Pending(Some(f)),
+        }
+    }
+
+    pub fn get(&mut self) -> &T {
+        if let LazyImpl::Pending(ref mut obtain) = self.inner {
+            let obtain = obtain.take().unwrap();
+            self.inner = LazyImpl::Data(obtain());
+        }
+        match self.inner {
+            LazyImpl::Data(ref res) => res,
+            _ => panic!(),
+        }
+    }
+}
+
+enum LazyImpl<T, F>
+where
+    F: FnOnce() -> T,
+{
+    Pending(Option<F>),
+    Data(T),
+}


### PR DESCRIPTION
Functionality-wise, I think this is complete, but design-wise it might be considered experimental.

There are 2 issues i attempted to address with this:
* in scenarios with multiple filters, metadata was potentially fetched repeatedly (via `lstat`)
* some filters only apply on files, and for them the `is_file()` the check was performed on the `Path` object, which invokes `stat` (which can be even slower than `lstat`)

The proposed design only fetches the metadata once (on first use) from the entry provided by ignore. `lazy.rs` contains my rationale for slightly reinventing the wheel and not (yet) using a crate, but if anyone has better ideas suggestions are welcome.

DISCLAIMER: I did not test the performance before/after the change, nor did I count the actual syscalls performed. I am aware of `hyperfine` (awesome tool btw), but i'm looking to see if this design is acceptable first.

Let me know what you think.