### PR TITLE
Update FreeBSD install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ nix-env -i fd
 
 ### On FreeBSD
 
-You can install `sysutils/fd` via portmaster:
+You can install [the fd-find package](https://www.freshports.org/sysutils/fd) from the official repo:
 ```
-portmaster sysutils/fd
+pkg install fd-find
 ```
 
 ### From source


### PR DESCRIPTION
Installing fd does not require using portmaster (it will also build
fd from source).  IMHO this is pretty misleading.  Let's update the
FreeBSD install instructions to recommend using the binary package
in the official repository like on other systems.