### PR TITLE
Remove deprecated trim_left(_matches)?

### DIFF
--- a/src/fshelper/mod.rs
+++ b/src/fshelper/mod.rs
@@ -32,7 +32,7 @@ pub fn absolute_path(path: &Path) -> io::Result<PathBuf> {
         path_buf
             .as_path()
             .to_string_lossy()
-            .trim_left_matches(r"\\?\"),
+            .trim_start_matches(r"\\?\"),
     )
     .to_path_buf();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,7 +219,7 @@ fn main() {
         }),
         extensions: matches.values_of("extension").map(|exts| {
             let patterns = exts
-                .map(|e| e.trim_left_matches('.'))
+                .map(|e| e.trim_start_matches('.'))
                 .map(|e| format!(r".\.{}$", regex::escape(e)));
             match RegexSetBuilder::new(patterns)
                 .case_insensitive(true)

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -121,13 +121,13 @@ fn format_output_error(args: &[&str], expected: &str, actual: &str) -> String {
 }
 
 /// Normalize the output for comparison.
-fn normalize_output(s: &str, trim_left: bool, normalize_line: bool) -> String {
+fn normalize_output(s: &str, trim_start: bool, normalize_line: bool) -> String {
     // Split into lines and normalize separators.
     let mut lines = s
         .replace('\0', "NULL\n")
         .lines()
         .map(|line| {
-            let line = if trim_left { line.trim_left() } else { line };
+            let line = if trim_start { line.trim_start() } else { line };
             let line = line.replace('/', &std::path::MAIN_SEPARATOR.to_string());
             if normalize_line {
                 let mut words: Vec<_> = line.split_whitespace().collect();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -41,7 +41,7 @@ fn get_absolute_root_path(env: &TestEnv) -> String {
         .to_string();
 
     #[cfg(windows)]
-    let path = path.trim_left_matches(r"\\?\").to_string();
+    let path = path.trim_start_matches(r"\\?\").to_string();
 
     path
 }


### PR DESCRIPTION
```
warning: use of deprecated item 'core::str::<impl str>::trim_left_matches': superseded by `trim_start_matches`
   --> src/main.rs:222:28
    |
222 |                 .map(|e| e.trim_left_matches('.'))
    |                            ^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(deprecated)] on by default
```