### PR TITLE
Add OpenBSD installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ You can install [the fd-find package](https://www.freshports.org/sysutils/fd) fr
 pkg install fd-find
 ```
 
+### On OpenBSD
+You can install the [fd-find](https://gitlab.com/epbsd/ports/tree/master/sysutils/fd) package from the [EPBSD](https://epbsd.org/) repo:
+```
+ftp -o /etc/signify/epbsd-pkg.pub https://epbsd.org/epbsd-pkg.pub
+export PKG_PATH=https://repo.epbsd.org/pub/OpenBSD/$(arch -s):${PKG_PATH}
+pkg_add fd
+```
+
 ### From source
 
 With Rust's package manager [cargo](https://github.com/rust-lang/cargo), you can install *fd* via:


### PR DESCRIPTION
Added a link to the OpenBSD port and information on how to use it since its in a third party repo for the time being, as it likely won't be merged into the official tree.