### PR TITLE
Add path-separator option.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -210,8 +210,9 @@ pub fn build_app() -> App<'static, 'static> {
         .arg(
             arg("path-separator")
                 .takes_value(true)
+                .value_name("separator")
                 .long("path-separator")
-                .number_of_values(1),
+                .hidden_short_help(true),
         )
         .arg(arg("path").multiple(true))
         .arg(

--- a/src/app.rs
+++ b/src/app.rs
@@ -207,6 +207,12 @@ pub fn build_app() -> App<'static, 'static> {
                 .hidden_short_help(true),
         )
         .arg(arg("pattern"))
+        .arg(
+            arg("path-separator")
+                .takes_value(true)
+                .long("path-separator")
+                .number_of_values(1),
+        )
         .arg(arg("path").multiple(true))
         .arg(
             arg("search-path")
@@ -249,6 +255,10 @@ fn usage() -> HashMap<&'static str, Help> {
     doc!(h, "absolute-path"
         , "Show absolute instead of relative paths"
         , "Shows the full path starting from the root as opposed to relative paths.");
+    doc!(h, "path-separator"
+        , "Set the path separator to use when printing file paths."
+        , "Set the path separator to use when printing file paths. \
+           A path separator is limited to a single byte.");
     doc!(h, "follow"
         , "Follow symbolic links"
         , "By default, fd does not descend into symlinked directories. Using this flag, symbolic \

--- a/src/app.rs
+++ b/src/app.rs
@@ -258,7 +258,8 @@ fn usage() -> HashMap<&'static str, Help> {
         , "Shows the full path starting from the root as opposed to relative paths.");
     doc!(h, "path-separator"
         , "Set the path separator to use when printing file paths."
-        , "Set the path separator to use when printing file paths.");
+        , "Set the path separator to use when printing file paths. The default is the OS-specific \
+           separator ('/' on Unix, '\\' on Windows).");
     doc!(h, "follow"
         , "Follow symbolic links"
         , "By default, fd does not descend into symlinked directories. Using this flag, symbolic \

--- a/src/app.rs
+++ b/src/app.rs
@@ -258,8 +258,7 @@ fn usage() -> HashMap<&'static str, Help> {
         , "Shows the full path starting from the root as opposed to relative paths.");
     doc!(h, "path-separator"
         , "Set the path separator to use when printing file paths."
-        , "Set the path separator to use when printing file paths. \
-           A path separator is limited to a single byte.");
+        , "Set the path separator to use when printing file paths.");
     doc!(h, "follow"
         , "Follow symbolic links"
         , "By default, fd does not descend into symlinked directories. Using this flag, symbolic \

--- a/src/internal/opts.rs
+++ b/src/internal/opts.rs
@@ -75,4 +75,7 @@ pub struct FdOptions {
 
     /// Whether or not to display filesystem errors
     pub show_filesystem_errors: bool,
+
+    /// The separator used to print file paths.
+    pub path_separator: Option<u8>,
 }

--- a/src/internal/opts.rs
+++ b/src/internal/opts.rs
@@ -77,5 +77,5 @@ pub struct FdOptions {
     pub show_filesystem_errors: bool,
 
     /// The separator used to print file paths.
-    pub path_separator: Option<u8>,
+    pub path_separator: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,20 @@ fn main() {
         _ => atty::is(Stream::Stdout),
     };
 
+    let path_separator: Option<u8> = match matches.value_of("path-separator") {
+        Some(sep_str) => {
+            let sep = sep_str.as_bytes();
+            if sep.len() != 1 {
+                print_error_and_exit!(
+                    "'{}' is not a valid path separator. See 'fd --help'.",
+                    sep_str
+                );
+            }
+            Some(sep[0])
+        }
+        None => None,
+    };
+
     #[cfg(windows)]
     let colored_output = colored_output && ansi_term::enable_ansi_support().is_ok();
 
@@ -243,6 +257,7 @@ fn main() {
         size_constraints: size_limits,
         time_constraints,
         show_filesystem_errors: matches.is_present("show-errors"),
+        path_separator,
     };
 
     match RegexBuilder::new(&pattern_regex)

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,19 +113,8 @@ fn main() {
         _ => atty::is(Stream::Stdout),
     };
 
-    let path_separator: Option<u8> = match matches.value_of("path-separator") {
-        Some(sep_str) => {
-            let sep = sep_str.as_bytes();
-            if sep.len() != 1 {
-                print_error_and_exit!(
-                    "'{}' is not a valid path separator. See 'fd --help'.",
-                    sep_str
-                );
-            }
-            Some(sep[0])
-        }
-        None => None,
-    };
+    let path_separator: Option<String> =
+        matches.value_of("path-separator").map(|str| str.to_owned());
 
     #[cfg(windows)]
     let colored_output = colored_output && ansi_term::enable_ansi_support().is_ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,8 +113,7 @@ fn main() {
         _ => atty::is(Stream::Stdout),
     };
 
-    let path_separator: Option<String> =
-        matches.value_of("path-separator").map(|str| str.to_owned());
+    let path_separator = matches.value_of("path-separator").map(|str| str.to_owned());
 
     #[cfg(windows)]
     let colored_output = colored_output && ansi_term::enable_ansi_support().is_ok();

--- a/src/output.rs
+++ b/src/output.rs
@@ -53,10 +53,12 @@ pub fn print_entry(
     }
 }
 
-fn replace_path_separator<'a>(config: &FdOptions, str: Cow<'a, str>) -> Cow<'a, str> {
+fn replace_path_separator<'a>(config: &FdOptions, path: &mut Cow<'a, str>) {
     match &config.path_separator {
-        None => str,
-        Some(sep) => Cow::from(str.replace(std::path::MAIN_SEPARATOR, &sep)),
+        None => {}
+        Some(sep) => {
+            *path.to_mut() = path.replace(std::path::MAIN_SEPARATOR, &sep);
+        }
     }
 }
 
@@ -75,8 +77,8 @@ fn print_entry_colorized(
             .map(Style::to_ansi_term_style)
             .unwrap_or(default_style);
 
-        let path_string = component.to_string_lossy();
-        let path_string = replace_path_separator(&config, path_string);
+        let mut path_string = component.to_string_lossy();
+        replace_path_separator(&config, &mut path_string);
         write!(stdout, "{}", style.paint(path_string))?;
 
         if wants_to_quit.load(Ordering::Relaxed) {
@@ -99,7 +101,7 @@ fn print_entry_uncolorized(
 ) -> io::Result<()> {
     let separator = if config.null_separator { "\0" } else { "\n" };
 
-    let path_str = path.to_string_lossy();
-    let path_str = replace_path_separator(&config, path_str);
+    let mut path_str = path.to_string_lossy();
+    replace_path_separator(&config, &mut path_str);
     write!(stdout, "{}{}", path_str, separator)
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -67,7 +67,21 @@ fn print_entry_colorized(
             .map(Style::to_ansi_term_style)
             .unwrap_or(default_style);
 
-        write!(stdout, "{}", style.paint(component.to_string_lossy()))?;
+        let path_string = component.to_string_lossy();
+
+        match config.path_separator {
+            None => write!(stdout, "{}", style.paint(path_string))?,
+            Some(sep) => {
+                let mut path_bytes = path_string.as_bytes().to_vec();
+                for b in &mut path_bytes {
+                    if *b == b'/' || (cfg!(windows) && *b == b'\\') {
+                        *b = sep;
+                    }
+                }
+                let path_string = String::from_utf8_lossy(&path_bytes);
+                write!(stdout, "{}", style.paint(path_string))?
+            }
+        }
 
         if wants_to_quit.load(Ordering::Relaxed) {
             writeln!(stdout)?;

--- a/src/output.rs
+++ b/src/output.rs
@@ -69,16 +69,10 @@ fn print_entry_colorized(
 
         let path_string = component.to_string_lossy();
 
-        match config.path_separator {
+        match &config.path_separator {
             None => write!(stdout, "{}", style.paint(path_string))?,
             Some(sep) => {
-                let mut path_bytes = path_string.as_bytes().to_vec();
-                for b in &mut path_bytes {
-                    if *b == b'/' || (cfg!(windows) && *b == b'\\') {
-                        *b = sep;
-                    }
-                }
-                let path_string = String::from_utf8_lossy(&path_bytes);
+                let path_string = path_string.replace(std::path::MAIN_SEPARATOR, &sep);
                 write!(stdout, "{}", style.paint(path_string))?
             }
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1231,3 +1231,17 @@ fn test_modified_asolute() {
         "30dec2017",
     );
 }
+
+#[test]
+fn test_custom_path_separator() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(
+        &["foo", "one", "--path-separator", "="],
+        "one=b.foo
+        one=two=c.foo
+        one=two=C.Foo2
+        one=two=three=d.foo
+        one=two=three=directory_foo",
+    );
+}


### PR DESCRIPTION
Example usage: `fd.exe --path-separator /` on windows.

- [x] add tests
- [x] measure performance impact without path-separator option
- [x] measure performance impact with path-separator option

## benchmarks

Average over 15 runs (with warm cache), using the command `fd . %userprofile%` [(full results):](https://docs.google.com/spreadsheets/d/1IApnoBDVvL873xqoI8CkaXjE4Y0n0stEZyDgKP9Lfjc/edit?usp=sharing)

  | feature, sep=default | feature, sep='=' | master
-- | -- | -- | --
avg | 5942.6667 | 6363.6000 | 5885.4000
std | 105.8730 | 109.2185 | 115.7299
std / avg | 0.0178 | 0.0172 | 0.0197
  |   |   |  
compared to master | 1.01 | 1.08 | 1.00



without changing the separator, the change does not impact performance; when changing it, it seems to be ~8% slower. 


see #428 