### PR TITLE
Add armhf deb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
       rust: stable
       env:
         - TARGET=arm-unknown-linux-gnueabihf
+        - CC_arm_unknown_linux_gnueabihf=/usr/bin/arm-linux-gnueabihf-gcc-4.8
         - CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc-4.8
     - os: linux
       rust: stable

--- a/ci/before_deploy.bash
+++ b/ci/before_deploy.bash
@@ -68,6 +68,10 @@ make_deb() {
         i686*)
             architecture=i386
             ;;
+        arm*hf) 
+            architecture=armhf  
+            gcc_prefix="arm-linux-gnueabihf-"   
+            ;;
         *)
             echo "make_deb: skipping target '${TARGET}'" >&2
             return 0


### PR DESCRIPTION
#443 

Compared with the bat repository, I think `armhf` is now supported.
But I do not know where `$TARGET` is set, you have to notice that you add `armhf` to the CI process.