### PR TITLE
Add instructions for habitat

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,15 @@ On linux and macOS, you can install the [fd-find](https://npm.im/fd-find) packag
 npm install -g fd-find
 ```
 
+### From habitat
+
+On linux, you can install the [core/fd](https://bldr.habitat.sh/#/pkgs/core/fd/latest) package:
+
+```
+hab pkg install core/fd
+hab pkg binlink core/fd
+```
+
 ### From source
 
 With Rust's package manager [cargo](https://github.com/rust-lang/cargo), you can install *fd* via:


### PR DESCRIPTION
Habitat is a way to... Codify how the application is built, how it runs, and all of its dependencies to free the app from underlying infrastructure and make updates easy.

It's a way to install packages completely decoupled from the underlying OS and its package manager (if it even has one).