### PR TITLE
Added armhf build to CI.

### DIFF
--- a/ci/before_deploy.bash
+++ b/ci/before_deploy.bash
@@ -68,6 +68,10 @@ make_deb() {
         i686*)
             architecture=i386
             ;;
+        arm*hf)
+            architecture=armhf
+            gcc_prefix="arm-linux-gnueabihf-"
+            ;;
         *)
             echo "make_deb: skipping target '${TARGET}'" >&2
             return 0


### PR DESCRIPTION
Would this fix #443? It passed in Travis, but I have no idea how to find the build artifacts on Travis to actually test the debs.