### PR TITLE
Add armhf deb to releases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
       rust: stable
       env:
         - TARGET=arm-unknown-linux-gnueabihf
+        - CC_arm_unknown_linux_gnueabihf=/usr/bin/arm-linux-gnueabihf-gcc-4.8
         - CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc-4.8
     - os: linux
       rust: stable

--- a/ci/before_deploy.bash
+++ b/ci/before_deploy.bash
@@ -57,6 +57,7 @@ make_deb() {
     local conflictname
     local homepage
     local maintainer
+    local gcc_prefix
 
     homepage="https://github.com/sharkdp/fd"
     maintainer="David Peter <mail@david-peter.de>"
@@ -64,9 +65,11 @@ make_deb() {
     case $TARGET in
         x86_64*)
             architecture=amd64
+            gcc_prefix=""
             ;;
         i686*)
             architecture=i386
+            gcc_prefix=""
             ;;
         arm*hf)
             architecture=armhf
@@ -90,7 +93,7 @@ make_deb() {
 
     # copy the main binary
     install -Dm755 "target/$TARGET/release/$PROJECT_NAME" "$tempdir/usr/bin/$PROJECT_NAME"
-    strip "$tempdir/usr/bin/$PROJECT_NAME"
+    "${gcc_prefix}"strip "$tempdir/usr/bin/$PROJECT_NAME"
 
     # manpage
     install -Dm644 "doc/$PROJECT_NAME.1" "$tempdir/usr/share/man/man1/$PROJECT_NAME.1"

--- a/ci/before_deploy.bash
+++ b/ci/before_deploy.bash
@@ -68,6 +68,10 @@ make_deb() {
         i686*)
             architecture=i386
             ;;
+        arm*hf)
+            architecture=armhf
+            gcc_prefix="arm-linux-gnueabihf-"
+            ;;
         *)
             echo "make_deb: skipping target '${TARGET}'" >&2
             return 0


### PR DESCRIPTION
Adds an armhf deb to generated releases. Closes #443. Supercedes PRs #456 and #452 .