### PR TITLE
Use jemalloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ ctrlc = "3.1"
 humantime = "1.1.1"
 lscolors = "0.6"
 globset = "0.4"
+jemallocator = "0.3.0"
 
 [dependencies.clap]
 version = "2.31.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ features = ["suggestions", "color", "wrap_help"]
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
 libc = "0.2"
 
-[target.'cfg(all(unix, not(target_os = "redox"), not(target_env = "musl")))'.dependencies]
+[target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]
 jemallocator = "0.3.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ ctrlc = "3.1"
 humantime = "1.1.1"
 lscolors = "0.6"
 globset = "0.4"
-jemallocator = "0.3.0"
 
 [dependencies.clap]
 version = "2.31.2"
@@ -52,6 +51,9 @@ features = ["suggestions", "color", "wrap_help"]
 
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
 libc = "0.2"
+
+[target.'cfg(all(unix, not(target_os = "redox"), not(target_env = "musl")))'.dependencies]
+jemallocator = "0.3.0"
 
 [dev-dependencies]
 diff = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,7 @@ use crate::internal::{
 };
 
 // We use jemalloc for performance reasons, see https://github.com/sharkdp/fd/pull/481
-#[cfg(not(windows))]
-#[cfg(not(target_env = "musl"))]
+#[cfg(all(not(windows), not(target_env = "musl")))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,10 @@ use crate::internal::{
     pattern_has_uppercase_char, transform_args_with_exec, FileTypes,
 };
 
+// We use jemalloc for performance reasons, see https://github.com/sharkdp/fd/pull/480
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 fn main() {
     let checked_args = transform_args_with_exec(env::args_os());
     let matches = app::build_app().get_matches_from(checked_args);

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,8 @@ use crate::internal::{
     pattern_has_uppercase_char, transform_args_with_exec, FileTypes,
 };
 
-// We use jemalloc for performance reasons, see https://github.com/sharkdp/fd/pull/480
+// We use jemalloc for performance reasons, see https://github.com/sharkdp/fd/pull/481
+#[cfg(not(windows))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ use crate::internal::{
 
 // We use jemalloc for performance reasons, see https://github.com/sharkdp/fd/pull/481
 #[cfg(not(windows))]
+#[cfg(not(target_env = "musl"))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
I keep (compiled) old versions of `fd` around to find performance regressions.

I noticed that there was a drop in performance between my `fd-7.0.0` and the `fd-7.1.0` binary. However, when re-compiling these old versions with the current version of Rust (1.37), *both* of them were slow.

So this had to do something with the version of Rust I was using at that time. The only thing that came to my mind was the change from jemalloc to the system allocator.

Turns out this makes a pretty big difference (23%):

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./fd-sys-alloc '[0-9]\.jpg$'` | 246.8 ± 3.4 | 244.1 | 257.1 | 1.2 |
| `./fd-jemalloc '[0-9]\.jpg$'` | 201.0 ± 3.0 | 196.1 | 206.9 | 1.0 |

This PR re-enables jemalloc for `fd`.