### PR TITLE
[exploration] Use crossbeam MPMC channel instead of std::sync::mpsc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ ctrlc = "3.1"
 humantime = "1.1.1"
 lscolors = "0.6"
 globset = "0.4"
+crossbeam-channel = "0.3"
 
 [dependencies.clap]
 version = "2.31.2"


### PR DESCRIPTION
For issue #440, I've played a bit with `crossbeam` and `fd`.

The implementation of the `exec` method is as expected simpler as it doesn't need any mutex or arc.

In term of binary size (in release mode with musl target), the difference is quite small:

```
fd_crossbeam_bounded:   3605520
fd_crossbeam_unbounded: 3605512
fd_std_mpsc:            3611064
```

However, on my machine`mpsc` seems to perform better without `--exec` :

```
Benchmark #1: ./fd_std_mpsc -HI '.*[0-9]\.rs$' ~
  Time (mean ± σ):      1.018 s ±  0.004 s    [User: 10.319 s, System: 1.464 s]
  Range (min … max):    1.012 s …  1.029 s    10 runs

Benchmark #2: ./fd_crossbeam_bounded -HI '.*[0-9]\.rs$' ~
  Time (mean ± σ):      1.086 s ±  0.026 s    [User: 10.510 s, System: 2.048 s]
  Range (min … max):    1.046 s …  1.135 s    10 runs

Benchmark #3: ./fd_crossbeam_unbounded -HI '.*[0-9]\.rs$' ~
  Time (mean ± σ):      1.088 s ±  0.019 s    [User: 10.593 s, System: 1.994 s]
  Range (min … max):    1.066 s …  1.126 s    10 runs

Summary
  './fd_std_mpsc -HI '.*[0-9]\.rs$' ~' ran
    1.07 ± 0.03 times faster than './fd_crossbeam_bounded -HI '.*[0-9]\.rs$' ~'
    1.07 ± 0.02 times faster than './fd_crossbeam_unbounded -HI '.*[0-9]\.rs$' ~'
Benchmark #1: ./fd_std_mpsc -HI '.*
```

With `--exec`, it depends on the number of outputs of results. With a search that yields more than 5.000 results, `crossbeam` is a bit faster:

```
[0-9]\.rs$' ~ -x echo {}
  Time (mean ± σ):      7.374 s ±  1.901 s    [User: 18.191 s, System: 23.729 s]
  Range (min … max):    5.439 s … 10.620 s    10 runs

Benchmark #2: ./fd_crossbeam_bounded -HI '.*[0-9]\.rs$' ~ -x echo {}
  Time (mean ± σ):      7.005 s ±  1.426 s    [User: 18.130 s, System: 22.579 s]
  Range (min … max):    5.841 s … 10.711 s    10 runs

Benchmark #3: ./fd_crossbeam_unbounded -HI '.*[0-9]\.rs$' ~ -x echo {}
  Time (mean ± σ):      7.838 s ±  1.366 s    [User: 18.465 s, System: 26.202 s]
  Range (min … max):    5.794 s … 10.574 s    10 runs

Summary
  './fd_crossbeam_bounded -HI '.*[0-9]\.rs$' ~ -x echo {}' ran
    1.05 ± 0.35 times faster than './fd_std_mpsc -HI '.*[0-9]\.rs$' ~ -x echo {}'
    1.12 ± 0.30 times faster than './fd_crossbeam_unbounded -HI '.*[0-9]\.rs$' ~ -x echo {}'
```

But not anymore with a search that matches ~150 results,  

```
Benchmark #1: ./fd_std_mpsc -HI '.*[0-9]\.jpg$' ~ -x echo {}
  Time (mean ± σ):      1.210 s ±  0.020 s    [User: 11.063 s, System: 2.122 s]
  Range (min … max):    1.187 s …  1.252 s    10 runs

Benchmark #2: ./fd_crossbeam_bounded -HI '.*[0-9]\.jpg$' ~ -x echo {}
  Time (mean ± σ):      1.229 s ±  0.011 s    [User: 11.269 s, System: 2.123 s]
  Range (min … max):    1.207 s …  1.244 s    10 runs

Benchmark #3: ./fd_crossbeam_unbounded -HI '.*[0-9]\.jpg$' ~ -x echo {}
  Time (mean ± σ):      1.226 s ±  0.020 s    [User: 11.134 s, System: 2.256 s]
  Range (min … max):    1.196 s …  1.250 s    10 runs

Summary
  './fd_std_mpsc -HI '.*[0-9]\.jpg$' ~ -x echo {}' ran
    1.01 ± 0.02 times faster than './fd_crossbeam_unbounded -HI '.*[0-9]\.jpg$' ~ -x echo {}'
    1.02 ± 0.02 times faster than './fd_crossbeam_bounded -HI '.*[0-9]\.jpg$' ~ -x echo {}'
```

I can do more experiments if you'd like.

Cheers,