### PR TITLE
walk: `fd -L` should include broken symlinks

### DIFF
--- a/src/fshelper/mod.rs
+++ b/src/fshelper/mod.rs
@@ -13,7 +13,7 @@ use std::io;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
-use ignore::DirEntry;
+use crate::walk;
 
 pub fn path_absolute_form(path: &Path) -> io::Result<PathBuf> {
     if path.is_absolute() {
@@ -55,7 +55,7 @@ pub fn is_executable(_: &fs::Metadata) -> bool {
     false
 }
 
-pub fn is_empty(entry: &DirEntry) -> bool {
+pub fn is_empty(entry: &walk::DirEntry) -> bool {
     if let Some(file_type) = entry.file_type() {
         if file_type.is_dir() {
             if let Ok(mut entries) = fs::read_dir(entry.path()) {

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -65,6 +65,7 @@ impl TryFrom<WorkerResult> for PathBuf {
                             && fs::symlink_metadata(&path)
                                 .map_or(false, |m| m.file_type().is_symlink())
                         {
+                            // Broken symlink
                             return Ok(path.to_path_buf());
                         }
                     }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -303,7 +303,7 @@ fn spawn_senders(
             }
 
             let entry = match entry_o {
-                Ok(e) if e.depth() == 0 => {
+                Ok(ref e) if e.depth() == 0 => {
                     // Skip the root directory entry.
                     return ignore::WalkState::Continue;
                 }
@@ -316,6 +316,7 @@ fn spawn_senders(
                         if io_error.kind() == io::ErrorKind::NotFound
                             && path
                                 .symlink_metadata()
+                                .ok()
                                 .map_or(false, |m| m.file_type().is_symlink()) =>
                     {
                         DirEntry::BrokenSymlink(path.to_owned())

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -13,10 +13,8 @@ use crate::internal::{opts::FdOptions, osstr_to_bytes, MAX_BUFFER_LENGTH};
 use crate::output;
 
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::error::Error;
 use std::ffi::OsStr;
-use std::fs;
 use std::io;
 use std::path::PathBuf;
 use std::process;
@@ -44,36 +42,6 @@ enum ReceiverMode {
 pub enum WorkerResult {
     Entry(PathBuf),
     Error(ignore::Error),
-}
-
-/// Converts a WorkerResult to a PathBuf. This is required as in some cases,
-/// the underlying `ignore` libary will return an error when we actually
-/// still want to show the path.
-///
-/// Currently, the cases supported are:
-///   - a broken symlink should still be found and the path returned
-impl TryFrom<WorkerResult> for PathBuf {
-    type Error = ignore::Error;
-
-    fn try_from(worker_result: WorkerResult) -> Result<PathBuf, Self::Error> {
-        match worker_result {
-            WorkerResult::Entry(value) => return Ok(value),
-            WorkerResult::Error(ignore_error) => {
-                if let ignore::Error::WithPath { path, err } = &ignore_error {
-                    if let ignore::Error::Io(ref io_err) = **err {
-                        if io_err.kind() == io::ErrorKind::NotFound
-                            && fs::symlink_metadata(&path)
-                                .map_or(false, |m| m.file_type().is_symlink())
-                        {
-                            // Broken symlink
-                            return Ok(path.to_path_buf());
-                        }
-                    }
-                }
-                return Err(ignore_error);
-            }
-        }
-    }
 }
 
 /// Recursively scan the given search path for files / pathnames matching the pattern.
@@ -233,8 +201,8 @@ fn spawn_receiver(
             let mut stdout = stdout.lock();
 
             for worker_result in rx {
-                match PathBuf::try_from(worker_result) {
-                    Ok(value) => {
+                match worker_result {
+                    WorkerResult::Entry(value) => {
                         match mode {
                             ReceiverMode::Buffering => {
                                 buffer.push(value);
@@ -263,7 +231,7 @@ fn spawn_receiver(
                             }
                         }
                     }
-                    Err(err) => {
+                    WorkerResult::Error(err) => {
                         if show_filesystem_errors {
                             print_error!("{}", err);
                         }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -61,12 +61,11 @@ impl TryFrom<WorkerResult> for PathBuf {
             WorkerResult::Error(ignore_error) => {
                 if let ignore::Error::WithPath { path, err } = &ignore_error {
                     if let ignore::Error::Io(ref io_err) = **err {
-                        if io_err.kind() == io::ErrorKind::NotFound {
-                            if let Ok(metadata) = fs::symlink_metadata(&path) {
-                                if metadata.file_type().is_symlink() {
-                                    return Ok(path.to_path_buf());
-                                }
-                            }
+                        if io_err.kind() == io::ErrorKind::NotFound
+                            && fs::symlink_metadata(&path)
+                                .map_or(false, |m| m.file_type().is_symlink())
+                        {
+                            return Ok(path.to_path_buf());
                         }
                     }
                 }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -312,7 +312,12 @@ fn spawn_senders(
                     path,
                     err: inner_err,
                 }) => match inner_err.as_ref() {
-                    ignore::Error::Io(io_error) if io_error.kind() == io::ErrorKind::NotFound => {
+                    ignore::Error::Io(io_error)
+                        if io_error.kind() == io::ErrorKind::NotFound
+                            && path
+                                .symlink_metadata()
+                                .map_or(false, |m| m.file_type().is_symlink()) =>
+                    {
                         DirEntry::BrokenSymlink(path.to_owned())
                     }
                     _ => {

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -162,6 +162,25 @@ impl TestEnv {
         }
     }
 
+    /// Create a broken symlink at the given path in the temp_dir.
+    pub fn create_broken_symlink<P: AsRef<Path>>(
+        &mut self,
+        link_path: P,
+    ) -> Result<PathBuf, io::Error> {
+        let root = self.test_root();
+        let broken_symlink_link = root.join(link_path);
+        {
+            let temp_target_dir = TempDir::new("fd-tests-broken-symlink")?;
+            let broken_symlink_target = temp_target_dir.path().join("broken_symlink_target");
+            fs::File::create(&broken_symlink_target)?;
+            #[cfg(unix)]
+            unix::fs::symlink(&broken_symlink_target, &broken_symlink_link)?;
+            #[cfg(windows)]
+            windows::fs::symlink_file(&broken_symlink_target, &broken_symlink_link)?;
+        }
+        Ok(broken_symlink_link)
+    }
+
     /// Get the root directory for the tests.
     pub fn test_root(&self) -> PathBuf {
         self.temp_dir.path().to_path_buf()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -604,7 +604,24 @@ fn test_follow_broken_symlink() {
     te.create_broken_symlink("broken_symlink")
         .expect("Failed to create broken symlink.");
 
-    te.assert_output(&["--follow", "--type", "f", "symlink"], "broken_symlink");
+    te.assert_output(
+        &["symlink"],
+        "broken_symlink
+        symlink",
+    );
+    te.assert_output(
+        &["--type", "symlink", "symlink"],
+        "broken_symlink
+        symlink",
+    );
+
+    te.assert_output(&["--type", "file", "symlink"], "");
+
+    te.assert_output(
+        &["--follow", "--type", "symlink", "symlink"],
+        "broken_symlink",
+    );
+    te.assert_output(&["--follow", "--type", "file", "symlink"], "");
 }
 
 /// Null separator (--print0)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -598,6 +598,15 @@ fn test_file_system_boundaries() {
     );
 }
 
+#[test]
+fn test_follow_broken_symlink() {
+    let mut te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+    te.create_broken_symlink("broken_symlink")
+        .expect("Failed to create broken symlink.");
+
+    te.assert_output(&["--follow", "--type", "f", "symlink"], "broken_symlink");
+}
+
 /// Null separator (--print0)
 #[test]
 fn test_print0() {
@@ -878,7 +887,9 @@ fn test_extension() {
 /// Symlink as search directory
 #[test]
 fn test_symlink_as_root() {
-    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+    let mut te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+    te.create_broken_symlink("broken_symlink")
+        .expect("Failed to create broken symlink.");
 
     // From: http://pubs.opengroup.org/onlinepubs/9699919799/functions/getcwd.html
     // The getcwd() function shall place an absolute pathname of the current working directory in
@@ -899,6 +910,7 @@ fn test_symlink_as_root() {
         &["", parent_parent],
         &format!(
             "{dir}/a.foo
+            {dir}/broken_symlink
             {dir}/e1 e2
             {dir}/one
             {dir}/one/b.foo
@@ -990,7 +1002,6 @@ fn test_symlink_and_full_path_abs_path() {
         ),
     );
 }
-
 /// Exclude patterns (--exclude)
 #[test]
 fn test_excludes() {


### PR DESCRIPTION
There is a dead PR #366 already submitted for issue #357. I thought I would propose a smaller change that's more likely to be accepted into the codebase.

Happy to take feedback and change the design if needed in the interest of getting this closed!

Closes #357