### PR TITLE
Add Scarf install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,16 @@ On linux and macOS, you can install the [fd-find](https://npm.im/fd-find) packag
 npm install -g fd-find
 ```
 
+### From Scarf
+
+If you would like to support this project, please consider installing `fd`
+with the [Scarf package manager](https://scarf.sh/package/scarf/fd), which will
+send anonymized usage statistics to help with development:
+
+```
+scarf install fd
+```
+
 ### From source
 
 With Rust's package manager [cargo](https://github.com/rust-lang/cargo), you can install *fd* via:


### PR DESCRIPTION
Hello @sharkdp, 

This change adds instructions to install with (Scarf)[https://scarf.sh]. Disclaimer: I'm the author of Scarf. I'd be happy to transfer package ownership to you or add you as a co-maintainer, so you can see `fd`'s usage statistics and, if you're interested, monetize `fd` when it is used by companies. I see this project uses GitHub Sponsors; Scarf could be another source of revenue. 