### PR TITLE
Add option to limit walk to one file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,20 +285,20 @@ USAGE:
     fd [FLAGS/OPTIONS] [<pattern>] [<path>...]
 
 FLAGS:
-    -H, --hidden              Search hidden files and directories
-    -I, --no-ignore           Do not respect .(git|fd)ignore files
-        --no-ignore-vcs       Do not respect .gitignore files
-    -s, --case-sensitive      Case-sensitive search (default: smart case)
-    -i, --ignore-case         Case-insensitive search (default: smart case)
-    -g, --glob                Glob-based search (default: regular expression)
-    -F, --fixed-strings       Treat the pattern as a literal string
-    -a, --absolute-path       Show absolute instead of relative paths
-    -L, --follow              Follow symbolic links
-        --same-file-system    Don't cross file system boundaries (only Unix/Windows)
-    -p, --full-path           Search full path (default: file-/dirname only)
-    -0, --print0              Separate results by the null character
-    -h, --help                Prints help information
-    -V, --version             Prints version information
+    -H, --hidden             Search hidden files and directories
+    -I, --no-ignore          Do not respect .(git|fd)ignore files
+        --no-ignore-vcs      Do not respect .gitignore files
+    -s, --case-sensitive     Case-sensitive search (default: smart case)
+    -i, --ignore-case        Case-insensitive search (default: smart case)
+    -g, --glob               Glob-based search (default: regular expression)
+    -F, --fixed-strings      Treat the pattern as a literal string
+    -a, --absolute-path      Show absolute instead of relative paths
+    -L, --follow             Follow symbolic links
+        --one-file-system    Don't cross file system boundaries (only Unix/Windows)
+    -p, --full-path          Search full path (default: file-/dirname only)
+    -0, --print0             Separate results by the null character
+    -h, --help               Prints help information
+    -V, --version            Prints version information
 
 OPTIONS:
     -d, --max-depth <depth>            Set maximum search depth (default: none)

--- a/README.md
+++ b/README.md
@@ -285,19 +285,20 @@ USAGE:
     fd [FLAGS/OPTIONS] [<pattern>] [<path>...]
 
 FLAGS:
-    -H, --hidden            Search hidden files and directories
-    -I, --no-ignore         Do not respect .(git|fd)ignore files
-        --no-ignore-vcs     Do not respect .gitignore files
-    -s, --case-sensitive    Case-sensitive search (default: smart case)
-    -i, --ignore-case       Case-insensitive search (default: smart case)
-    -g, --glob              Glob-based search (default: regular expression)
-    -F, --fixed-strings     Treat the pattern as a literal string
-    -a, --absolute-path     Show absolute instead of relative paths
-    -L, --follow            Follow symbolic links
-    -p, --full-path         Search full path (default: file-/dirname only)
-    -0, --print0            Separate results by the null character
-    -h, --help              Prints help information
-    -V, --version           Prints version information
+    -H, --hidden              Search hidden files and directories
+    -I, --no-ignore           Do not respect .(git|fd)ignore files
+        --no-ignore-vcs       Do not respect .gitignore files
+    -s, --case-sensitive      Case-sensitive search (default: smart case)
+    -i, --ignore-case         Case-insensitive search (default: smart case)
+    -g, --glob                Glob-based search (default: regular expression)
+    -F, --fixed-strings       Treat the pattern as a literal string
+    -a, --absolute-path       Show absolute instead of relative paths
+    -L, --follow              Follow symbolic links
+        --same-file-system    Don't cross file system boundaries (only Unix/Windows)
+    -p, --full-path           Search full path (default: file-/dirname only)
+    -0, --print0              Separate results by the null character
+    -h, --help                Prints help information
+    -V, --version             Prints version information
 
 OPTIONS:
     -d, --max-depth <depth>            Set maximum search depth (default: none)

--- a/README.md
+++ b/README.md
@@ -294,7 +294,6 @@ FLAGS:
     -F, --fixed-strings      Treat the pattern as a literal string
     -a, --absolute-path      Show absolute instead of relative paths
     -L, --follow             Follow symbolic links
-        --one-file-system    Don't cross file system boundaries (only Unix/Windows)
     -p, --full-path          Search full path (default: file-/dirname only)
     -0, --print0             Separate results by the null character
     -h, --help               Prints help information

--- a/src/app.rs
+++ b/src/app.rs
@@ -286,9 +286,14 @@ pub fn build_app() -> App<'static, 'static> {
 
     // Make `--one-file-system` available only on Unix and Windows platforms, as per the
     // restrictions on the corresponding option in the `ignore` crate.
+    // Provide aliases `mount` and `xdev` for people coming from `find`.
     // It's not pretty, but I'm unaware of a way to make just part of a builder chain conditional
     if cfg!(unix) || cfg!(windows) {
-        app.arg(arg("one-file-system").long("one-file-system"))
+        app.arg(
+            arg("one-file-system")
+                .long("one-file-system")
+                .aliases(&["mount", "xdev"]),
+        )
     } else {
         app
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -477,7 +477,7 @@ fn usage() -> HashMap<&'static str, Help> {
             , "Don't cross file system boundaries"
             , "By default, fd will traverse the file system tree as far as other options dictate. \
                With this flag, fd ensures that it does not descend into a different file system \
-               than the one it started in.");
+               than the one it started in. Comparable to the -mount or -xdev filters of find(1).");
     }
 
     h

--- a/src/app.rs
+++ b/src/app.rs
@@ -291,7 +291,8 @@ pub fn build_app() -> App<'static, 'static> {
         app = app.arg(
             arg("one-file-system")
                 .long("one-file-system")
-                .aliases(&["mount", "xdev"]),
+                .aliases(&["mount", "xdev"])
+                .hidden_short_help(true),
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -115,6 +115,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .alias("dereference")
                 .overrides_with("follow"),
         )
+        .arg(arg("same-file-system").long("same-file-system"))
         .arg(
             arg("full-path")
                 .long("full-path")
@@ -329,6 +330,11 @@ fn usage() -> HashMap<&'static str, Help> {
         , "Follow symbolic links"
         , "By default, fd does not descend into symlinked directories. Using this flag, symbolic \
            links are also traversed.");
+    doc!(h, "same-file-system"
+        , "Don't cross file system boundaries (only Unix/Windows)"
+        , "By default, fd will traverse the file system tree as far as other options dictate. \
+           With this flag, fd ensures that it does not descend into a different file system than \
+           the one it started in. Does nothing if not on Unix or Windows.");
     doc!(h, "full-path"
         , "Search full path (default: file-/dirname only)"
         , "By default, the search pattern is only matched against the filename (or directory \

--- a/src/app.rs
+++ b/src/app.rs
@@ -115,7 +115,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .alias("dereference")
                 .overrides_with("follow"),
         )
-        .arg(arg("same-file-system").long("same-file-system"))
+        .arg(arg("one-file-system").long("one-file-system"))
         .arg(
             arg("full-path")
                 .long("full-path")
@@ -330,7 +330,7 @@ fn usage() -> HashMap<&'static str, Help> {
         , "Follow symbolic links"
         , "By default, fd does not descend into symlinked directories. Using this flag, symbolic \
            links are also traversed.");
-    doc!(h, "same-file-system"
+    doc!(h, "one-file-system"
         , "Don't cross file system boundaries (only Unix/Windows)"
         , "By default, fd will traverse the file system tree as far as other options dictate. \
            With this flag, fd ensures that it does not descend into a different file system than \

--- a/src/app.rs
+++ b/src/app.rs
@@ -288,7 +288,7 @@ pub fn build_app() -> App<'static, 'static> {
     // restrictions on the corresponding option in the `ignore` crate.
     // Provide aliases `mount` and `xdev` for people coming from `find`.
     // It's not pretty, but I'm unaware of a way to make just part of a builder chain conditional
-    if cfg!(unix) || cfg!(windows) {
+    if cfg!(any(unix, windows)) {
         app.arg(
             arg("one-file-system")
                 .long("one-file-system")
@@ -472,7 +472,7 @@ fn usage() -> HashMap<&'static str, Help> {
            which are passed to fd via the positional <path> argument or the '--search-path' option \
            will also be resolved relative to this directory.");
 
-    if cfg!(unix) || cfg!(windows) {
+    if cfg!(any(unix, windows)) {
         doc!(h, "one-file-system"
             , "Don't cross file system boundaries"
             , "By default, fd will traverse the file system tree as far as other options dictate. \

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,7 +37,7 @@ pub fn build_app() -> App<'static, 'static> {
             .long_help(helps[name].long)
     };
 
-    let app = App::new("fd")
+    let mut app = App::new("fd")
         .version(crate_version!())
         .usage("fd [FLAGS/OPTIONS] [<pattern>] [<path>...]")
         .setting(AppSettings::ColoredHelp)
@@ -287,16 +287,15 @@ pub fn build_app() -> App<'static, 'static> {
     // Make `--one-file-system` available only on Unix and Windows platforms, as per the
     // restrictions on the corresponding option in the `ignore` crate.
     // Provide aliases `mount` and `xdev` for people coming from `find`.
-    // It's not pretty, but I'm unaware of a way to make just part of a builder chain conditional
     if cfg!(any(unix, windows)) {
-        app.arg(
+        app = app.arg(
             arg("one-file-system")
                 .long("one-file-system")
                 .aliases(&["mount", "xdev"]),
-        )
-    } else {
-        app
+        );
     }
+
+    app
 }
 
 #[rustfmt::skip]

--- a/src/internal/opts.rs
+++ b/src/internal/opts.rs
@@ -28,6 +28,9 @@ pub struct FdOptions {
     /// Whether to follow symlinks or not.
     pub follow_links: bool,
 
+    /// Whether to limit the search to starting file system or not.
+    pub same_file_system: bool,
+
     /// Whether elements of output should be separated by a null character
     pub null_separator: bool,
 

--- a/src/internal/opts.rs
+++ b/src/internal/opts.rs
@@ -29,7 +29,7 @@ pub struct FdOptions {
     pub follow_links: bool,
 
     /// Whether to limit the search to starting file system or not.
-    pub same_file_system: bool,
+    pub one_file_system: bool,
 
     /// Whether elements of output should be separated by a null character
     pub null_separator: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ fn main() {
             || matches.is_present("rg-alias-hidden-ignore")
             || matches.is_present("no-ignore-vcs")),
         follow_links: matches.is_present("follow"),
-        same_file_system: matches.is_present("same-file-system"),
+        one_file_system: matches.is_present("one-file-system"),
         null_separator: matches.is_present("null_separator"),
         max_depth: matches
             .value_of("depth")

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,7 @@ fn main() {
             || matches.is_present("rg-alias-hidden-ignore")
             || matches.is_present("no-ignore-vcs")),
         follow_links: matches.is_present("follow"),
+        same_file_system: matches.is_present("same-file-system"),
         null_separator: matches.is_present("null_separator"),
         max_depth: matches
             .value_of("depth")

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -78,6 +78,8 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) -
         .git_exclude(config.read_vcsignore)
         .overrides(overrides)
         .follow_links(config.follow_links)
+        // Same file system is only supported on Unix and Windows platforms
+        .same_file_system(config.same_file_system && (cfg!(unix) || cfg!(windows)))
         .max_depth(config.max_depth);
 
     if config.read_fdignore {

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -79,7 +79,7 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) -
         .overrides(overrides)
         .follow_links(config.follow_links)
         // Same file system is only supported on Unix and Windows platforms
-        .same_file_system(config.same_file_system && (cfg!(unix) || cfg!(windows)))
+        .same_file_system(config.one_file_system && (cfg!(unix) || cfg!(windows)))
         .max_depth(config.max_depth);
 
     if config.read_fdignore {

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -78,8 +78,8 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<FdOptions>) -
         .git_exclude(config.read_vcsignore)
         .overrides(overrides)
         .follow_links(config.follow_links)
-        // Same file system is only supported on Unix and Windows platforms
-        .same_file_system(config.one_file_system && (cfg!(unix) || cfg!(windows)))
+        // No need to check for supported platforms, option is unavailable on unsupported ones
+        .same_file_system(config.one_file_system)
         .max_depth(config.max_depth);
 
     if config.read_fdignore {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -555,7 +555,7 @@ fn test_follow() {
     );
 }
 
-// File system boundaries (--same-file-system)
+// File system boundaries (--one-file-system)
 // Limited to Unix because, to the best of my knowledge, there is no easy way to test a use case
 // file systems mounted into the tree on Windows.
 // Not limiting depth causes massive delay under Darwin, see BurntSushi/ripgrep#1429
@@ -572,7 +572,7 @@ fn test_file_system_boundaries() {
     );
     te.assert_output(
         &[
-            "--same-file-system",
+            "--one-file-system",
             "--full-path",
             "--max-depth",
             "2",

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -563,6 +563,7 @@ fn test_follow() {
 #[cfg(unix)]
 fn test_file_system_boundaries() {
     // Helper function to get the device ID for a given path
+    // Inspired by https://github.com/BurntSushi/ripgrep/blob/8892bf648cfec111e6e7ddd9f30e932b0371db68/ignore/src/walk.rs#L1693
     fn device_num(path: impl AsRef<Path>) -> u64 {
         use std::os::unix::fs::MetadataExt;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -555,6 +555,23 @@ fn test_follow() {
     );
 }
 
+// File system boundaries (--same-file-system)
+// Limited to Unix because, to the best of my knowledge, there is no easy way to test a use case
+// file systems mounted into the tree on Windows.
+#[test]
+#[cfg(unix)]
+fn test_file_system_boundaries() {
+    // Can't simulate file system boundaries
+    let te = TestEnv::new(&[], &[]);
+
+    // /dev/null should exist in all sane Unixes
+    te.assert_output(&["--full-path", "^/dev/null$", "/"], "/dev/null");
+    te.assert_output(
+        &["--same-file-system", "--full-path", "^/dev/null$", "/"],
+        "",
+    );
+}
+
 /// Null separator (--print0)
 #[test]
 fn test_print0() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -558,6 +558,7 @@ fn test_follow() {
 // File system boundaries (--same-file-system)
 // Limited to Unix because, to the best of my knowledge, there is no easy way to test a use case
 // file systems mounted into the tree on Windows.
+// Not limiting depth causes massive delay under Darwin, see BurntSushi/ripgrep#1429
 #[test]
 #[cfg(unix)]
 fn test_file_system_boundaries() {
@@ -565,9 +566,19 @@ fn test_file_system_boundaries() {
     let te = TestEnv::new(&[], &[]);
 
     // /dev/null should exist in all sane Unixes
-    te.assert_output(&["--full-path", "^/dev/null$", "/"], "/dev/null");
     te.assert_output(
-        &["--same-file-system", "--full-path", "^/dev/null$", "/"],
+        &["--full-path", "--max-depth", "2", "^/dev/null$", "/"],
+        "/dev/null",
+    );
+    te.assert_output(
+        &[
+            "--same-file-system",
+            "--full-path",
+            "--max-depth",
+            "2",
+            "^/dev/null$",
+            "/",
+        ],
         "",
     );
 }


### PR DESCRIPTION
As I described in #507, fd currently lacks a way to restrict a search to a single file system. Since, in my opinion, it's a very useful feature to have and the required code changes were fairly minimal, I decided to prepare this as a kind of "working draft" in case the feature is considered for addition.