### PR TITLE
Sort search results when using -X option if results are not many. Solve Issue #441

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -182,13 +182,13 @@ impl CommandTemplate {
                 // A single `Tokens` is expected
                 // So we can directly consume the iterator once and for all
 
-                // It would be too expansive to collect all the paths at once, so we take
+                // It would be too expensive to collect all the paths at once, so we take
                 // only the first ones.
                 let mut first_paths = take(&mut paths, SORT_THRESHOLD);
                 has_path = !first_paths.is_empty();
 
                 if first_paths.len() < SORT_THRESHOLD {
-                    // sort the paths because they are not too much
+                    // sort the paths because they are not too many
                     first_paths.sort();
                     CommandTemplate::add_to_cmd(&mut cmd, arg, &mut first_paths.into_iter());
                 } else {

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -182,13 +182,13 @@ impl CommandTemplate {
                 // A single `Tokens` is expected
                 // So we can directly consume the iterator once and for all
 
-                // It would be too expansive to collect all the paths at once, so I take
+                // It would be too expansive to collect all the paths at once, so we take
                 // only the first ones.
                 let mut first_paths = take(&mut paths, SORT_THRESHOLD);
                 has_path = !first_paths.is_empty();
 
                 if first_paths.len() < SORT_THRESHOLD {
-                    // I sort the paths because they are not too much
+                    // sort the paths because they are not too much
                     first_paths.sort();
                     CommandTemplate::add_to_cmd(&mut cmd, arg, &mut first_paths.into_iter());
                 } else {

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -181,14 +181,20 @@ impl CommandTemplate {
             if arg.has_tokens() {
                 // A single `Tokens` is expected
                 // So we can directly consume the iterator once and for all
+
+                // It would be too expansive to collect all the paths at once, so I take
+                // only the first ones.
                 let mut first_paths = take(&mut paths, SORT_THRESHOLD);
                 has_path = !first_paths.is_empty();
 
                 if first_paths.len() < SORT_THRESHOLD {
+                    // I sort the paths because they are not too much
                     first_paths.sort();
                     CommandTemplate::add_to_cmd(&mut cmd, arg, &mut first_paths.into_iter());
                 } else {
                     CommandTemplate::add_to_cmd(&mut cmd, arg, &mut first_paths.into_iter());
+
+                    // add remaining paths
                     CommandTemplate::add_to_cmd(&mut cmd, arg, &mut paths);
                 }
             } else {


### PR DESCRIPTION
[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)

This PR solves #441.

As suggested by @sharkdp in [this](https://github.com/sharkdp/fd/issues/441#issuecomment-499675495) comment we created a constant called SORT_THRESHOLD. If the found paths are < SORT_THRESHOLD, then the paths are sorted.

Feel free to propose changes if you have ideas to clean the code or to set a proper value for the SORT_THRESHOLD constant.