### PR TITLE
Sort search results when using -X option

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -170,13 +170,15 @@ impl CommandTemplate {
         cmd.stdout(Stdio::inherit());
         cmd.stderr(Stdio::inherit());
 
-        let mut paths = paths.map(|p| Self::prepare_path(&p));
+        let mut paths: Vec<String> = paths.map(|p| Self::prepare_path(&p)).collect();
         let mut has_path = false;
 
         for arg in &self.args[1..] {
             if arg.has_tokens() {
+                paths.sort();
+
                 // A single `Tokens` is expected
-                // So we can directy consume the iterator once and for all
+                // So we can directly consume the iterator once and for all
                 for path in &mut paths {
                     cmd.arg(arg.generate(&path).as_ref());
                     has_path = true;


### PR DESCRIPTION
This PR solves #441.

After reading [this](https://github.com/sharkdp/fd/issues/441#issuecomment-499675495) comment, me and [crash-g](https://github.com/crash-g) submitted pull request #513.
However, the solution was a little bit difficult to read, so @sharkdp said that he _"would like to start with an easy solution where we always sort the paths"_ because _"There is a limit to the number of paths for -X anyway (see #410)"_.

Therefore, since sorting time is not an issue, we preferred to create another pull request without all the noise of the old commits, where the paths are always sorted.