### PR TITLE
Add --max-results=<count> option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Features
 
+- Added `--max-results=<count>` option to limit the number of search results, see #472 and #476
+  This can be useful to speed up searches in cases where you know that there are only N results.
+  Using this option is also (slightly) faster than piping to `head -n <count>` where `fd` can only
+  exit when it finds the search results `<count> + 1`.
 - Support additional ANSI font styles in `LS_COLORS`: faint, slow blink, rapid blink, dimmed, hidden and strikethrough.
 
 ## Bugfixes

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -80,6 +80,9 @@ is matched against the full path.
 Separate search results by the null character (instead of newlines). Useful for piping results to
 .IR xargs .
 .TP
+.B \-\-max\-results count
+Limit the number of search results to 'count' and quit immediately.
+.TP
 .B \-\-show-errors
 Enable the display of filesystem errors for situations such as insufficient
 permissions or dead symlinks.

--- a/src/app.rs
+++ b/src/app.rs
@@ -252,6 +252,14 @@ pub fn build_app() -> App<'static, 'static> {
                 .number_of_values(1),
         )
         .arg(
+            arg("max-results")
+                .long("max-results")
+                .takes_value(true)
+                .value_name("count")
+                .conflicts_with_all(&["exec", "exec-batch"])
+                .hidden_short_help(true),
+        )
+        .arg(
             arg("show-errors")
                 .long("show-errors")
                 .hidden_short_help(true)
@@ -457,6 +465,9 @@ fn usage() -> HashMap<&'static str, Help> {
            Examples:\n    \
                --changed-before '2018-10-27 10:00:00'\n    \
                --change-older-than 2weeks");
+    doc!(h, "max-results"
+        , "(hidden)"
+        , "Limit the number of search results to 'count' and quit immediately.");
     doc!(h, "show-errors"
         , "Enable display of filesystem errors"
         , "Enable the display of filesystem errors for situations such as insufficient permissions \

--- a/src/internal/opts.rs
+++ b/src/internal/opts.rs
@@ -81,4 +81,7 @@ pub struct FdOptions {
 
     /// The separator used to print file paths.
     pub path_separator: Option<String>,
+
+    /// The maximum number of search results
+    pub max_results: Option<usize>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,6 +279,10 @@ fn main() {
         time_constraints,
         show_filesystem_errors: matches.is_present("show-errors"),
         path_separator,
+        max_results: matches
+            .value_of("max-results")
+            .and_then(|n| usize::from_str_radix(n, 10).ok())
+            .filter(|&n| n != 0),
     };
 
     match RegexBuilder::new(&pattern_regex)

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -199,6 +199,8 @@ fn spawn_receiver(
             let stdout = io::stdout();
             let mut stdout = stdout.lock();
 
+            let mut num_results = 0;
+
             for worker_result in rx {
                 match worker_result {
                     WorkerResult::Entry(value) => {
@@ -229,11 +231,19 @@ fn spawn_receiver(
                                 output::print_entry(&mut stdout, &value, &config, &wants_to_quit);
                             }
                         }
+
+                        num_results += 1;
                     }
                     WorkerResult::Error(err) => {
                         if show_filesystem_errors {
                             print_error!("{}", err);
                         }
+                    }
+                }
+
+                if let Some(max_results) = config.max_results {
+                    if num_results >= max_results {
+                        break;
                     }
                 }
             }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1470,3 +1470,28 @@ fn test_base_directory() {
         ),
     );
 }
+
+#[test]
+fn test_max_results() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    // Unrestricted
+    te.assert_output(
+        &["--max-results=0", "c.foo"],
+        "one/two/C.Foo2
+         one/two/c.foo",
+    );
+
+    // Limited to two results
+    te.assert_output(
+        &["--max-results=2", "c.foo"],
+        "one/two/C.Foo2
+         one/two/c.foo",
+    );
+
+    // Limited to one result. We could find either C.Foo2 or c.foo
+    let output = te.assert_success_and_get_output(".", &["--max-results=1", "c.foo"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = stdout.trim();
+    assert!(stdout == "one/two/C.Foo2" || stdout == "one/two/c.foo");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1493,5 +1493,6 @@ fn test_max_results() {
     let output = te.assert_success_and_get_output(".", &["--max-results=1", "c.foo"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stdout = stdout.trim();
+    let stdout = stdout.replace(&std::path::MAIN_SEPARATOR.to_string(), "/");
     assert!(stdout == "one/two/C.Foo2" || stdout == "one/two/c.foo");
 }


### PR DESCRIPTION
This new option can be used instead of piping to `head -n <count>` for improved performance:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `fd --max-buffer-time=0`<br>`flow.yaml` | 153.9 ± 2.5 | 151.3 | 170.3 | 4.21 ± 5.86 |
| `fd --max-buffer-time=0`<br>`flow.yaml \| head -n 1` | 145.3 ± 17.4 | 111.0 | 180.2 | 3.98 ± 5.55 |
| `fd --max-results=1 flow.yaml` | 36.5 ± 50.8 | 7.2 | 145.7 | 1.00 |

Note: there is a large standard deviation on the last result due to the non-deterministic (parallelized) file system traversal. With `--max-results`, we don't have to traverse the whole filesystem tree, so it's all about luck (the same is true when piping to `head -n1`).

We can also see this by taking a look at the histogram of timings:

![image](https://user-images.githubusercontent.com/4209276/78276144-eaf4e300-7512-11ea-86fc-f83e27f837cc.png)

`--max-results=1` is really fast most of the time, but there is second peak around 125 ms.

The benchmark above was done for a hot disk cache. For a cold cache, the performance difference is even larger (in this particular example):

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `fd --max-buffer-time=0`<br>`flow.yaml` | 869.9 ± 9.2 | 853.1 | 891.1 | 10.29 ± 0.29 |
| `fd --max-buffer-time=0`<br>`flow.yaml \| head -n 1` | 684.3 ± 4.0 | 677.6 | 691.1 | 8.10 ± 0.22 |
| `fd --max-results=1 flow.yaml` | 84.5 ± 2.2 | 81.4 | 87.7 | 1.00 |

Interestingly, we see very small standard deviation values now. It looks like the cold-cache traversal is more deterministic(?).


closes #472
closes #476