### PR TITLE
Add `-l`/`--list-details` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Features
 
-- Added `--max-results=<count>` option to limit the number of search results, see #472 and #476
+- Add a new `-l`/`--list` option to show more details about the search results. This is basically
+  an alias for `--exec-batch ls -l` with some additional `ls` options.
+  This can be used in order to:
+    * see metadata like permissions, owner, file size, modification times (#491)
+    * see symlink targets (#482)
+    * achieve a deterministic output order (#324, #196, #159)
+    * avoid duplicate search results when multiple search paths are given (#405)
+- Add a new `--max-results=<count>` option to limit the number of search results, see #472 and #476
   This can be useful to speed up searches in cases where you know that there are only N results.
   Using this option is also (slightly) faster than piping to `head -n <count>` where `fd` can only
   exit when it finds the search results `<count> + 1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Features
 
-- Add a new `-l`/`--list` option to show more details about the search results. This is basically
-  an alias for `--exec-batch ls -l` with some additional `ls` options.
+- Add a new `-l`/`--list-details` option to show more details about the search results. This is
+  basically an alias for `--exec-batch ls -l` with some additional `ls` options.
   This can be used in order to:
     * see metadata like permissions, owner, file size, modification times (#491)
     * see symlink targets (#482)

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -66,6 +66,12 @@ Treat the pattern as a literal string instead of a regular expression.
 .B \-a, \-\-absolute\-path
 Shows the full path starting from the root as opposed to relative paths.
 .TP
+.B \-l, \-\-list
+Use a detailed listing format like 'ls -l'. This is basically an alias
+for '--exec-batch ls -l' with some additional 'ls' options. This can be used
+to see more metadata, to show symlink targets, to achieve a deterministic
+sort order and to avoid duplicate search results when using multiple search paths.
+.TP
 .B \-L, \-\-follow
 By default, fd does not descend into symlinked directories. Using this flag, symbolic links are
 also traversed.

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -66,7 +66,7 @@ Treat the pattern as a literal string instead of a regular expression.
 .B \-a, \-\-absolute\-path
 Shows the full path starting from the root as opposed to relative paths.
 .TP
-.B \-l, \-\-list
+.B \-l, \-\-list\-details
 Use a detailed listing format like 'ls -l'. This is basically an alias
 for '--exec-batch ls -l' with some additional 'ls' options. This can be used
 to see more metadata, to show symlink targets, to achieve a deterministic

--- a/src/app.rs
+++ b/src/app.rs
@@ -109,6 +109,12 @@ pub fn build_app() -> App<'static, 'static> {
                 .overrides_with("absolute-path"),
         )
         .arg(
+            arg("list")
+                .long("list")
+                .short("l")
+                .conflicts_with("absolute-path"),
+        )
+        .arg(
             arg("follow")
                 .long("follow")
                 .short("L")
@@ -125,7 +131,8 @@ pub fn build_app() -> App<'static, 'static> {
             arg("null_separator")
                 .long("print0")
                 .short("0")
-                .overrides_with("print0"),
+                .overrides_with("print0")
+                .conflicts_with("list"),
         )
         .arg(arg("depth").long("max-depth").short("d").takes_value(true))
         // support --maxdepth as well, for compatibility with rg
@@ -173,7 +180,8 @@ pub fn build_app() -> App<'static, 'static> {
                 .min_values(1)
                 .allow_hyphen_values(true)
                 .value_terminator(";")
-                .value_name("cmd"),
+                .value_name("cmd")
+                .conflicts_with("list"),
         )
         .arg(
             arg("exec-batch")
@@ -183,7 +191,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .allow_hyphen_values(true)
                 .value_terminator(";")
                 .value_name("cmd")
-                .conflicts_with("exec"),
+                .conflicts_with_all(&["exec", "list"]),
         )
         .arg(
             arg("exclude")
@@ -343,6 +351,12 @@ fn usage() -> HashMap<&'static str, Help> {
     doc!(h, "absolute-path"
         , "Show absolute instead of relative paths"
         , "Shows the full path starting from the root as opposed to relative paths.");
+    doc!(h, "list"
+        , "Use a detailed listing format"
+        , "Use a detailed listing format like 'ls -l'. This is basically an alias \
+           for '--exec-batch ls -l' with some additional 'ls' options. This can be used \
+           to see more metadata, to show symlink targets, to achieve a deterministic \
+           sort order and to avoid duplicate search results when using multiple search paths.");
     doc!(h, "path-separator"
         , "Set the path separator to use when printing file paths."
         , "Set the path separator to use when printing file paths. The default is the OS-specific \

--- a/src/app.rs
+++ b/src/app.rs
@@ -109,8 +109,8 @@ pub fn build_app() -> App<'static, 'static> {
                 .overrides_with("absolute-path"),
         )
         .arg(
-            arg("list")
-                .long("list")
+            arg("list-details")
+                .long("list-details")
                 .short("l")
                 .conflicts_with("absolute-path"),
         )
@@ -132,7 +132,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("print0")
                 .short("0")
                 .overrides_with("print0")
-                .conflicts_with("list"),
+                .conflicts_with("list-details"),
         )
         .arg(arg("depth").long("max-depth").short("d").takes_value(true))
         // support --maxdepth as well, for compatibility with rg
@@ -181,7 +181,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .allow_hyphen_values(true)
                 .value_terminator(";")
                 .value_name("cmd")
-                .conflicts_with("list"),
+                .conflicts_with("list-details"),
         )
         .arg(
             arg("exec-batch")
@@ -191,7 +191,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .allow_hyphen_values(true)
                 .value_terminator(";")
                 .value_name("cmd")
-                .conflicts_with_all(&["exec", "list"]),
+                .conflicts_with_all(&["exec", "list-details"]),
         )
         .arg(
             arg("exclude")
@@ -351,8 +351,8 @@ fn usage() -> HashMap<&'static str, Help> {
     doc!(h, "absolute-path"
         , "Show absolute instead of relative paths"
         , "Shows the full path starting from the root as opposed to relative paths.");
-    doc!(h, "list"
-        , "Use a detailed listing format"
+    doc!(h, "list-details"
+        , "Show details like permissions, owner, size and modification time."
         , "Use a detailed listing format like 'ls -l'. This is basically an alias \
            for '--exec-batch ls -l' with some additional 'ls' options. This can be used \
            to see more metadata, to show symlink targets, to achieve a deterministic \

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,25 @@ fn main() {
                     print_error_and_exit!("{}", e);
                 })
             })
+        })
+        .or_else(|| {
+            if matches.is_present("list") {
+                let color = matches.value_of("color").unwrap_or("auto");
+                let color_arg = ["--color=", color].concat();
+
+                Some(
+                    CommandTemplate::new_batch(&[
+                        "ls",
+                        "-l",               // long listing format
+                        "--human-readable", // human readable file sizes
+                        "--directory",      // list directories themselves, not their contents
+                        &color_arg,         // enable colorized output, if enabled
+                    ])
+                    .unwrap(),
+                )
+            } else {
+                None
+            }
         });
 
     let size_limits: Vec<SizeFilter> = matches

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ fn main() {
             })
         })
         .or_else(|| {
-            if matches.is_present("list") {
+            if matches.is_present("list-details") {
                 let color = matches.value_of("color").unwrap_or("auto");
                 let color_arg = ["--color=", color].concat();
 


### PR DESCRIPTION
Add a new `-l`/`--list-details` option to show more details about the search results. This is basically
an alias for `--exec-batch ls -l` with some additional `ls` options.
This can be used in order to:
* see metadata like permissions, owner, file size, modification times (#491)
* see symlink targets (#482)
* achieve a deterministic output order (#324, #196, #159)
* avoid duplicate search results when multiple search paths are given (#405)

![image](https://user-images.githubusercontent.com/4209276/78294819-4df27400-752b-11ea-9aab-1f7ca7925ec6.png)

It calls `ls` in this way:

``` rust
let color = matches.value_of("color").unwrap_or("auto");
let color_arg = ["--color=", color].concat();

Some(
    CommandTemplate::new_batch(&[
        "ls",
        "-l",               // long listing format
        "--human-readable", // human readable file sizes
        "--directory",      // list directories themselves, not their contents
        &color_arg,         // enable colorized output, if enabled
    ])
    .unwrap(),
)
```

closes #491 
closes #482
closes #324
closes #196
closes #159
closes #405 