### PR TITLE
Preserve non utf8 filenames

### DIFF
--- a/src/exec/input.rs
+++ b/src/exec/input.rs
@@ -1,70 +1,40 @@
-use std::path::MAIN_SEPARATOR;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+use crate::filesystem::strip_current_dir;
 
 /// Removes the parent component of the path
-pub fn basename(path: &str) -> &str {
-    let mut index = 0;
-    for (id, character) in path.char_indices() {
-        if character == MAIN_SEPARATOR {
-            index = id;
-        }
-    }
-
-    // FIXME: On Windows, should return what for C:file.txt D:file.txt and \\server\share ?
-    if index != 0 {
-        return &path[index + 1..];
-    }
-
-    path
+pub fn basename(path: &Path) -> &OsStr {
+    path.file_name().unwrap_or(path.as_os_str())
 }
 
 /// Removes the extension from the path
-pub fn remove_extension(path: &str) -> &str {
-    let mut has_dir = false;
-    let mut dir_index = 0;
-    let mut ext_index = 0;
+pub fn remove_extension(path: &Path) -> OsString {
+    let dirname = dirname(path);
+    let stem = path.file_stem().unwrap_or(path.as_os_str());
 
-    for (id, character) in path.char_indices() {
-        if character == MAIN_SEPARATOR {
-            has_dir = true;
-            dir_index = id;
-        }
-        if character == '.' {
-            ext_index = id;
-        }
-    }
+    let path = PathBuf::from(dirname).join(stem);
 
-    // Account for hidden files and directories
-    if ext_index != 0 && (!has_dir || dir_index + 2 <= ext_index) {
-        return &path[0..ext_index];
-    }
-
-    path
+    strip_current_dir(&path).to_owned().into_os_string()
 }
 
 /// Removes the basename from the path.
-pub fn dirname(path: &str) -> &str {
-    let mut has_dir = false;
-    let mut index = 0;
-    for (id, character) in path.char_indices() {
-        if character == MAIN_SEPARATOR {
-            has_dir = true;
-            index = id;
-        }
-    }
-
-    // FIXME: On Windows, return what for C:file.txt D:file.txt and \\server\share ?
-    if !has_dir {
-        "."
-    } else if index == 0 {
-        &path[..1]
-    } else {
-        &path[0..index]
-    }
+pub fn dirname(path: &Path) -> OsString {
+    path.parent()
+        .map(|p| {
+            if p == OsStr::new("") {
+                OsString::from(".")
+            } else {
+                p.as_os_str().to_owned()
+            }
+        })
+        .unwrap_or(path.as_os_str().to_owned())
 }
 
 #[cfg(test)]
 mod path_tests {
     use super::*;
+    use std::path::MAIN_SEPARATOR;
 
     fn correct(input: &str) -> String {
         input.replace('/', &MAIN_SEPARATOR.to_string())
@@ -75,7 +45,9 @@ mod path_tests {
             $(
                 #[test]
                 fn $name() {
-                    assert_eq!($func(&correct($input)), correct($output));
+                    let input_path = PathBuf::from(&correct($input));
+                    let output_string = OsString::from(correct($output));
+                    assert_eq!($func(&input_path), output_string);
                 }
             )+
         }
@@ -98,16 +70,18 @@ mod path_tests {
         dirname_dir:     dirname  for  "dir/foo.txt"  =>  "dir"
         dirname_utf8_0:  dirname  for  "💖/foo.txt"   =>  "💖"
         dirname_utf8_1:  dirname  for  "dir/💖.txt"   =>  "dir"
-        dirname_empty:   dirname  for  ""             =>  "."
     }
 
     #[test]
+    #[cfg(windows)]
     fn dirname_root() {
-        #[cfg(windows)]
-        assert_eq!(dirname("C:\\"), "C:");
-        #[cfg(windows)]
-        assert_eq!(dirname("\\"), "\\");
-        #[cfg(not(windows))]
-        assert_eq!(dirname("/"), "/");
+        assert_eq!(dirname(&PathBuf::from("C:\\")), OsString::from("C:"));
+        assert_eq!(dirname(&PathBuf::from("\\")), OsString::from("\\"));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn dirname_root() {
+        assert_eq!(dirname(&PathBuf::from("/")), OsString::from("/"));
     }
 }

--- a/src/exec/input.rs
+++ b/src/exec/input.rs
@@ -75,7 +75,7 @@ mod path_tests {
     #[test]
     #[cfg(windows)]
     fn dirname_root() {
-        assert_eq!(dirname(&PathBuf::from("C:\\")), OsString::from("C:"));
+        assert_eq!(dirname(&PathBuf::from("C:")), OsString::from("C:"));
         assert_eq!(dirname(&PathBuf::from("\\")), OsString::from("\\"));
     }
 

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -97,7 +97,7 @@ impl CommandTemplate {
                     "{/}" => tokens.push(Token::Basename),
                     "{//}" => tokens.push(Token::Parent),
                     "{/.}" => tokens.push(Token::BasenameNoExt),
-                    _ => panic!("Unhandled placeholder"),
+                    _ => unreachable!("Unhandled placeholder"),
                 }
 
                 has_placeholder = true;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::io;
 #[cfg(any(unix, target_os = "redox"))]
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use crate::walk;
 
@@ -84,13 +84,8 @@ pub fn osstr_to_bytes(input: &OsStr) -> Cow<[u8]> {
 }
 
 /// Remove the `./` prefix from a path.
-pub fn strip_current_dir(pathbuf: &PathBuf) -> &Path {
-    let mut iter = pathbuf.components();
-    let mut iter_next = iter.clone();
-    if iter_next.next() == Some(Component::CurDir) {
-        iter.next();
-    }
-    iter.as_path()
+pub fn strip_current_dir(path: &Path) -> &Path {
+    path.strip_prefix(".").unwrap_or(path)
 }
 
 pub fn replace_path_separator<'a>(path: &str, new_path_separator: &str) -> String {
@@ -100,18 +95,18 @@ pub fn replace_path_separator<'a>(path: &str, new_path_separator: &str) -> Strin
 #[cfg(test)]
 mod tests {
     use super::strip_current_dir;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
     #[test]
     fn strip_current_dir_basic() {
-        assert_eq!(strip_current_dir(&PathBuf::from("./foo")), Path::new("foo"));
-        assert_eq!(strip_current_dir(&PathBuf::from("foo")), Path::new("foo"));
+        assert_eq!(strip_current_dir(Path::new("./foo")), Path::new("foo"));
+        assert_eq!(strip_current_dir(Path::new("foo")), Path::new("foo"));
         assert_eq!(
-            strip_current_dir(&PathBuf::from("./foo/bar/baz")),
+            strip_current_dir(Path::new("./foo/bar/baz")),
             Path::new("foo/bar/baz")
         );
         assert_eq!(
-            strip_current_dir(&PathBuf::from("foo/bar/baz")),
+            strip_current_dir(Path::new("foo/bar/baz")),
             Path::new("foo/bar/baz")
         );
     }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -88,10 +88,6 @@ pub fn strip_current_dir(path: &Path) -> &Path {
     path.strip_prefix(".").unwrap_or(path)
 }
 
-pub fn replace_path_separator<'a>(path: &str, new_path_separator: &str) -> String {
-    path.replace(std::path::MAIN_SEPARATOR, &new_path_separator)
-}
-
 #[cfg(test)]
 mod tests {
     use super::strip_current_dir;

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,10 +137,11 @@ fn run() -> Result<ExitCode> {
     let case_sensitive = !matches.is_present("ignore-case")
         && (matches.is_present("case-sensitive") || pattern_has_uppercase_char(&pattern_regex));
 
+    let interactive_terminal = atty::is(Stream::Stdout);
     let colored_output = match matches.value_of("color") {
         Some("always") => true,
         Some("never") => false,
-        _ => env::var_os("NO_COLOR").is_none() && atty::is(Stream::Stdout),
+        _ => env::var_os("NO_COLOR").is_none() && interactive_terminal,
     };
 
     let path_separator = matches.value_of("path-separator").map(|str| str.to_owned());
@@ -240,6 +241,7 @@ fn run() -> Result<ExitCode> {
             .and_then(|n| u64::from_str_radix(n, 10).ok())
             .map(time::Duration::from_millis),
         ls_colors,
+        interactive_terminal,
         file_types: matches.values_of("file-type").map(|values| {
             let mut file_types = FileTypes::default();
             for value in values {

--- a/src/options.rs
+++ b/src/options.rs
@@ -52,6 +52,9 @@ pub struct Options {
     /// how to style different filetypes.
     pub ls_colors: Option<LsColors>,
 
+    /// Whether or not we are writing to an interactive terminal
+    pub interactive_terminal: bool,
+
     /// The type of file to search for. If set to `None`, all file types are displayed. If
     /// set to `Some(..)`, only the types that are specified are shown.
     pub file_types: Option<FileTypes>,

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -208,6 +208,12 @@ impl TestEnv {
         self.assert_output_subdirectory(".", args, expected)
     }
 
+    /// Similar to assert_output, but able to handle non-utf8 output
+    pub fn assert_output_raw(&self, args: &[&str], expected: &[u8]) {
+        let actual = self.raw_output_subdirectory(".", args);
+        assert_eq!(expected, actual.as_ref());
+    }
+
     /// Assert that calling *fd* in the specified path under the root working directory,
     /// and with the specified arguments produces the expected output.
     pub fn assert_output_subdirectory<P: AsRef<Path>>(
@@ -230,6 +236,23 @@ impl TestEnv {
         if expected != actual {
             panic!(format_output_error(args, &expected, &actual));
         }
+    }
+
+    fn raw_output_subdirectory<P: AsRef<Path>>(&self, path: P, args: &[&str]) -> Box<[u8]> {
+        // Setup *fd* command.
+        let mut cmd = process::Command::new(&self.fd_exe);
+        cmd.current_dir(self.temp_dir.path().join(path));
+        cmd.args(args);
+
+        // Run *fd*.
+        let output = cmd.output().expect("fd output");
+
+        // Check for exit status.
+        if !output.status.success() {
+            panic!(format_exit_error(args, &output));
+        }
+
+        output.stdout.into_boxed_slice()
     }
 
     /// Assert that calling *fd* with the specified arguments produces the expected error.


### PR DESCRIPTION
This PR fixes the handling of filesystem entries with invalid UTF-8 names (#295). It is an adapted version of #309 by @alexmaco (thank you for your initial work!).

Invalid UTF-8 filenames are properly passed to child-processes when using `--exec`, `--exec-batch` or `--list-details`:

![image](https://user-images.githubusercontent.com/4209276/78424207-117a6180-766c-11ea-9f2e-1b6fc08db378.png)

There are a few things to note:

- `fd -x echo` will print the actual invalid UTF-8 sequence, as expected
- if you call `fd -x echo`, you might still see "test_�invalid.txt" if your terminal emulator wants to save you from scrambled output.
- `fd -l` properly passes the filename to `ls`
- `fd … -x rm` properly passes the filename to `rm`

If not using `-x` or `-X`, we still make sure to print the "invalid UTF-8 sequence" character "�". However, if we pipe the output to another program (like `xargs`), we pass the filenames as is (on Unix):
```
> fd
test_�invalid.txt

> fd | xargs ls
'test_'$'\376''invalid.txt'
```

fixes #295 