### PR TITLE
--glob: '*' does not match on path separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 ## Changes
 
+- When using `--glob` in combination with `--full-path`, a `*` character does not match a path
+  separation character (`/` or `\\`) anymore. You can use `**` for that. This allows things like
+  `fd -p -g '/some/base/path/*/*/*.txt'` which would previously match to arbitrary depths (instead
+  of exactly two folders below `/some/base/path`. See #404.
 
 
 ## Other

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use std::time;
 
 use anyhow::{anyhow, Context, Result};
 use atty::Stream;
-use globset::Glob;
+use globset::GlobBuilder;
 use lscolors::LsColors;
 use regex::bytes::{RegexBuilder, RegexSetBuilder};
 
@@ -123,7 +123,7 @@ fn run() -> Result<ExitCode> {
     }
 
     let pattern_regex = if matches.is_present("glob") {
-        let glob = Glob::new(pattern)?;
+        let glob = GlobBuilder::new(pattern).literal_separator(true).build()?;
         glob.regex().to_owned()
     } else if matches.is_present("fixed-strings") {
         // Treat pattern as literal string if '--fixed-strings' is used
@@ -296,7 +296,13 @@ fn run() -> Result<ExitCode> {
             .value_of("max-results")
             .and_then(|n| usize::from_str_radix(n, 10).ok())
             .filter(|&n| n != 0)
-            .or_else(|| if matches.is_present("max-one-result") { Some(1) } else { None }),
+            .or_else(|| {
+                if matches.is_present("max-one-result") {
+                    Some(1)
+                } else {
+                    None
+                }
+            }),
     };
 
     let re = RegexBuilder::new(&pattern_regex)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -272,6 +272,16 @@ fn test_full_path_glob_searches() {
         one/two/c.foo
         one/two/three/d.foo",
     );
+
+    te.assert_output(
+        &["--glob", "--full-path", "**/one/*/*.foo"],
+        " one/two/c.foo",
+    );
+
+    te.assert_output(
+        &["--glob", "--full-path", "**/one/*/*/*.foo"],
+        " one/two/three/d.foo",
+    );
 }
 
 #[test]


### PR DESCRIPTION
When using `--glob` in combination with `--full-path`, a `*` character does not match a path separation character (`/` or `\\`) anymore. You can use `**` for that. This allows things like `fd -p -g '/some/base/path/*/*/*.txt'` which would previously match to arbitrary depths (instead  of exactly two folders below `/some/base/path`. See #404. 