### PR TITLE
Add global fdignore support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ humantime = "2.0"
 lscolors = "0.7"
 globset = "0.4"
 anyhow = "1.0"
+dirs = "2.0"
 
 [dependencies.clap]
 version = "2.31.2"

--- a/README.md
+++ b/README.md
@@ -451,6 +451,10 @@ To make exclude-patterns like these permanent, you can create a `.fdignore` file
 ```
 Note: `fd` also supports `.ignore` files that are used by other programs such as `rg` or `ag`.
 
+If you want `fd` to ignore these patterns globally, you can put them in `fd`'s global ignore file.
+This is usually located in `~/.config/fd/ignore` in macOS or Linux, and `%APPDATA%\fd\ignore` in
+Windows.
+
 ### Using fd with `xargs` or `parallel`
 
 If we want to run a command on all search results, we can pipe the output to `xargs`:

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -33,10 +33,9 @@ Include hidden files and directories in the search results
 .B \-I, \-\-no\-ignore
 Show search results from files and directories that would otherwise be ignored by
 .IR .gitignore ,
-.I .ignore
-or
-.I .fdignore
-files.
+.IR .ignore ,
+.IR .fdignore ,
+or the global ignore file.
 .TP
 .B \-u, \-\-unrestricted
 Alias for '--no-ignore'. Can be repeated; '-uu' is an alias for '--no-ignore --hidden'.
@@ -273,6 +272,14 @@ The glob syntax is documented here:
 .B LS_COLORS
 Determines how to colorize search results, see
 .BR dircolors (1) .
+.TP
+.B XDG_CONFIG_HOME, HOME
+Used to locate the global ignore file. If
+.B XDG_CONFIG_HOME
+is set, use
+.IR $XDG_CONFIG_HOME/fd/ignore .
+Otherwise, use
+.IR $HOME/.config/fd/ignore .
 .SH EXAMPLES
 .TP
 .RI "Find files and directories that match the pattern '" needle "':"

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .help("Do not respect .(git|fd)ignore files")
                 .long_help(
                     "Show search results from files and directories that would otherwise be \
-                         ignored by '.gitignore', '.ignore' or '.fdignore' files.",
+                         ignored by '.gitignore', '.ignore', '.fdignore', or the global ignore file.",
                 ),
         )
         .arg(
@@ -42,6 +42,12 @@ pub fn build_app() -> App<'static, 'static> {
                     "Show search results from files and directories that would otherwise be \
                          ignored by '.gitignore' files.",
                 ),
+        )
+        .arg(
+            Arg::with_name("no-global-ignore-file")
+                .long("no-global-ignore-file")
+                .hidden(true)
+                .long_help("Do not respect the global ignore file."),
         )
         .arg(
             Arg::with_name("rg-alias-hidden-ignore")

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,9 @@ fn run() -> Result<ExitCode> {
         read_vcsignore: !(matches.is_present("no-ignore")
             || matches.is_present("rg-alias-hidden-ignore")
             || matches.is_present("no-ignore-vcs")),
+        read_global_ignore: !(matches.is_present("no-ignore")
+            || matches.is_present("rg-alias-hidden-ignore")
+            || matches.is_present("no-global-ignore-file")),
         follow_links: matches.is_present("follow"),
         one_file_system: matches.is_present("one-file-system"),
         null_separator: matches.is_present("null_separator"),

--- a/src/options.rs
+++ b/src/options.rs
@@ -25,6 +25,9 @@ pub struct Options {
     /// Whether to respect VCS ignore files (`.gitignore`, ..) or not.
     pub read_vcsignore: bool,
 
+    /// Whether to respect the global ignore file or not.
+    pub read_global_ignore: bool,
+
     /// Whether to follow symlinks or not.
     pub follow_links: bool,
 

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -190,7 +190,7 @@ impl TestEnv {
         // Setup *fd* command.
         let mut cmd = process::Command::new(&self.fd_exe);
         cmd.current_dir(self.temp_dir.path().join(path));
-        cmd.args(args);
+        cmd.arg("--no-global-ignore-file").args(args);
 
         // Run *fd*.
         let output = cmd.output().expect("fd output");
@@ -251,7 +251,7 @@ impl TestEnv {
         // Setup *fd* command.
         let mut cmd = process::Command::new(&self.fd_exe);
         cmd.current_dir(self.temp_dir.path().join(path));
-        cmd.args(args);
+        cmd.arg("--no-global-ignore-file").args(args);
 
         // Run *fd*.
         let output = cmd.output().expect("fd output");


### PR DESCRIPTION
Rust newbie here :-)

This implements global fdignore support in `~/.config/fd/ignore` as mentioned [here](https://github.com/sharkdp/fd/issues/485#issuecomment-532869261).

I have some questions:
- I'm using `std::env::home_dir()` (which is deprecated) instead of using the `dirs` crate, because this is what the `ignore` crate does. Which would you prefer?
- I'm not too sure how to handle the tests. If I have, say, `*` in my `~/.config/fd/ignore`, the tests will break. The simplest way I can think of to deal with this is to add a `!*` using `--ignore-file`.
- Are there parts of the doc I should change?