### PR TITLE
Fix --glob behavior with empty pattern

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ fn run() -> Result<ExitCode> {
         ));
     }
 
-    let pattern_regex = if matches.is_present("glob") {
+    let pattern_regex = if matches.is_present("glob") && pattern.len() > 0 {
         let glob = GlobBuilder::new(pattern).literal_separator(true).build()?;
         glob.regex().to_owned()
     } else if matches.is_present("fixed-strings") {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -52,7 +52,7 @@ fn create_file_with_size<P: AsRef<Path>>(path: P, size_in_bytes: usize) {
     f.write_all(content.as_bytes()).unwrap();
 }
 
-/// Simple tests
+/// Simple test
 #[test]
 fn test_simple() {
     let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
@@ -70,20 +70,35 @@ fn test_simple() {
         one/two/three/d.foo
         one/two/three/directory_foo",
     );
+}
+
+/// Test each pattern type with an empty pattern.
+#[test]
+fn test_empty_pattern() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+    let expected = "a.foo
+    e1 e2
+    one
+    one/b.foo
+    one/two
+    one/two/c.foo
+    one/two/C.Foo2
+    one/two/three
+    one/two/three/d.foo
+    one/two/three/directory_foo
+    symlink";
 
     te.assert_output(
-        &[],
-        "a.foo
-        e1 e2
-        one
-        one/b.foo
-        one/two
-        one/two/c.foo
-        one/two/C.Foo2
-        one/two/three
-        one/two/three/d.foo
-        one/two/three/directory_foo
-        symlink",
+        &["--regex"],
+        expected,
+    );
+    te.assert_output(
+        &["--fixed-strings"],
+        expected,
+    );
+    te.assert_output(
+        &["--glob"],
+        expected,
     );
 }
 


### PR DESCRIPTION
With an empty pattern, --glob results in no matches. This does not
align with the behavior of --fixed-strings or --regex. Update the
initialization code to handle globs with empty patterns.