### PR TITLE
Add -o/--owner to filter files by owner and/or group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-
+- Add new `--owner [user][:group]` filter. See #307 (pull #581) (@alexmaco)
 
 ## Bugfixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ dependencies = [
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -411,6 +412,15 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "users"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+"checksum users 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ anyhow = "1.0"
 version = "2.31.2"
 features = ["suggestions", "color", "wrap_help"]
 
+[target.'cfg(unix)'.dependencies]
+users = "0.10.0"
+
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
 libc = "0.2"
 

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -224,6 +224,15 @@ Examples:
   \-\-changed-before "2018-10-27 10:00:00"
   \-\-change-older-than 2weeks
 .TP
+.BI "-o, \-\-owner " [user][:group]
+Filter files by their user and/or group. Format: [(user|uid)][:(group|gid)]. Either side
+is optional. Precede either side with a '!' to exclude files instead.
+
+Examples:
+  \-\-owner john
+  \-\-owner :students
+  \-\-owner "!john:students"
+.TP
 .BI "\-x, \-\-exec " command
 Execute
 .I command

--- a/src/app.rs
+++ b/src/app.rs
@@ -529,7 +529,18 @@ pub fn build_app() -> App<'static, 'static> {
             Arg::with_name("owner")
                 .long("owner")
                 .short("o")
-                .takes_value(true),
+                .takes_value(true)
+                .value_name("user:group")
+                .help("Filter by owning user and/or group")
+                .long_help(
+                    "Filter files by their user and/or group. \
+                     Format: [(user|uid)][:(group|gid)]. Either side is optional. \
+                     Precede either side with a '!' to exclude files instead.\n\
+                     Examples:\n    \
+                         --owner john\n    \
+                         --owner :students\n    \
+                         --owner '!john:students'",
+                ),
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -524,6 +524,15 @@ pub fn build_app() -> App<'static, 'static> {
                 ),
         );
 
+    if cfg!(unix) {
+        app = app.arg(
+            Arg::with_name("owner")
+                .long("owner")
+                .short("o")
+                .takes_value(true),
+        );
+    }
+
     // Make `--one-file-system` available only on Unix and Windows platforms, as per the
     // restrictions on the corresponding option in the `ignore` crate.
     // Provide aliases `mount` and `xdev` for people coming from `find`.

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,5 +1,11 @@
 pub use self::size::SizeFilter;
 pub use self::time::TimeFilter;
 
+#[cfg(unix)]
+pub use self::owner::OwnerFilter;
+
 mod size;
 mod time;
+
+#[cfg(unix)]
+mod owner;

--- a/src/filter/owner.rs
+++ b/src/filter/owner.rs
@@ -1,0 +1,61 @@
+use anyhow::{anyhow, Result};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct OwnerFilter {
+    uid: Option<u32>,
+    gid: Option<u32>,
+}
+
+impl OwnerFilter {
+    pub fn from_string(input: &str) -> Result<Self> {
+        let mut it = input.split(':');
+        let (fst, snd) = (it.next(), it.next());
+
+        let uid = match fst {
+            Some("") | None => None,
+            Some(s) => Some(s.parse()?),
+        };
+        let gid = match snd {
+            Some("") | None => None,
+            Some(s) => Some(s.parse()?),
+        };
+
+        if uid.is_none() && gid.is_none() {
+            Err(anyhow!(
+                "'{}' is not a valid user/group specifier. See 'fd --help'.",
+                input
+            ))
+        } else {
+            Ok(OwnerFilter { uid, gid })
+        }
+    }
+}
+
+#[cfg(test)]
+mod owner_parsing {
+    use super::OwnerFilter;
+
+    macro_rules! owner_tests {
+        ($($name:ident: $value:expr => $result:pat,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let o = OwnerFilter::from_string($value);
+                    match o {
+                        $result => {},
+                        _ => panic!("{:?} does not match {}", o, stringify!($result)),
+                    }
+                }
+            )*
+        };
+    }
+
+    owner_tests! {
+        empty:      ""      => Err(_),
+        uid_only:   "5"     => Ok(OwnerFilter { uid: Some(5), gid: None   }),
+        uid_gid:    "9:3"   => Ok(OwnerFilter { uid: Some(9), gid: Some(3)}),
+        gid_only:   ":8"    => Ok(OwnerFilter { uid: None,    gid: Some(8)}),
+        colon_only: ":"     => Err(_),
+        trailing:   "5:"    => Ok(OwnerFilter { uid: Some(5), gid: None   }),
+    }
+}

--- a/src/filter/owner.rs
+++ b/src/filter/owner.rs
@@ -3,8 +3,15 @@ use std::fs;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OwnerFilter {
-    uid: Option<u32>,
-    gid: Option<u32>,
+    uid: Check<u32>,
+    gid: Check<u32>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum Check<T> {
+    Equal(T),
+    NotEq(T),
+    Ignore,
 }
 
 impl OwnerFilter {
@@ -39,7 +46,17 @@ impl OwnerFilter {
             }
         };
 
-        if uid.is_none() && gid.is_none() {
+        use self::Check::*;
+        let uid = match uid {
+            Some(u) => Equal(u),
+            _ => Ignore,
+        };
+        let gid = match gid {
+            Some(g) => Equal(g),
+            _ => Ignore,
+        };
+
+        if let (Ignore, Ignore) = (uid, gid) {
             Err(anyhow!(
                 "'{}' is not a valid user/group specifier. See 'fd --help'.",
                 input
@@ -52,10 +69,17 @@ impl OwnerFilter {
     pub fn matches(&self, md: &fs::Metadata) -> bool {
         use std::os::unix::fs::MetadataExt;
 
-        let uid_ok = self.uid.map(|u| u == md.uid()).unwrap_or(true);
-        let gid_ok = self.gid.map(|g| g == md.gid()).unwrap_or(true);
+        self.uid.check(md.uid()) && self.gid.check(md.gid())
+    }
+}
 
-        uid_ok && gid_ok
+impl<T: PartialEq> Check<T> {
+    fn check(&self, v: T) -> bool {
+        match self {
+            Check::Equal(x) => v == *x,
+            Check::NotEq(x) => v != *x,
+            Check::Ignore => true,
+        }
     }
 }
 
@@ -78,12 +102,13 @@ mod owner_parsing {
         };
     }
 
+    use super::Check::*;
     owner_tests! {
         empty:      ""      => Err(_),
-        uid_only:   "5"     => Ok(OwnerFilter { uid: Some(5), gid: None   }),
-        uid_gid:    "9:3"   => Ok(OwnerFilter { uid: Some(9), gid: Some(3)}),
-        gid_only:   ":8"    => Ok(OwnerFilter { uid: None,    gid: Some(8)}),
+        uid_only:   "5"     => Ok(OwnerFilter { uid: Equal(5), gid: Ignore    }),
+        uid_gid:    "9:3"   => Ok(OwnerFilter { uid: Equal(9), gid: Equal(3)  }),
+        gid_only:   ":8"    => Ok(OwnerFilter { uid: Ignore,   gid: Equal(8)  }),
         colon_only: ":"     => Err(_),
-        trailing:   "5:"    => Ok(OwnerFilter { uid: Some(5), gid: None   }),
+        trailing:   "5:"    => Ok(OwnerFilter { uid: Equal(5), gid: Ignore    }),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ use regex::bytes::{RegexBuilder, RegexSetBuilder};
 use crate::exec::CommandTemplate;
 use crate::exit_codes::ExitCode;
 use crate::filetypes::FileTypes;
+#[cfg(unix)]
+use crate::filter::OwnerFilter;
 use crate::filter::{SizeFilter, TimeFilter};
 use crate::options::Options;
 use crate::regex_helper::pattern_has_uppercase_char;
@@ -275,6 +277,13 @@ fn run() -> Result<ExitCode> {
         }
     }
 
+    #[cfg(unix)]
+    let owner_constraint = if let Some(s) = matches.value_of("owner") {
+        Some(OwnerFilter::from_string(s)?)
+    } else {
+        None
+    };
+
     let config = Options {
         case_sensitive,
         search_full_path: matches.is_present("full-path"),
@@ -358,6 +367,8 @@ fn run() -> Result<ExitCode> {
             .unwrap_or_else(|| vec![]),
         size_constraints: size_limits,
         time_constraints,
+        #[cfg(unix)]
+        owner_constraint,
         show_filesystem_errors: matches.is_present("show-errors"),
         path_separator,
         max_results: matches

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,7 +279,7 @@ fn run() -> Result<ExitCode> {
 
     #[cfg(unix)]
     let owner_constraint = if let Some(s) = matches.value_of("owner") {
-        Some(OwnerFilter::from_string(s)?)
+        OwnerFilter::from_string(s)?
     } else {
         None
     };

--- a/src/options.rs
+++ b/src/options.rs
@@ -5,6 +5,8 @@ use regex::bytes::RegexSet;
 
 use crate::exec::CommandTemplate;
 use crate::filetypes::FileTypes;
+#[cfg(unix)]
+use crate::filter::OwnerFilter;
 use crate::filter::{SizeFilter, TimeFilter};
 
 /// Configuration options for *fd*.
@@ -81,6 +83,10 @@ pub struct Options {
 
     /// Constraints on last modification time of files
     pub time_constraints: Vec<TimeFilter>,
+
+    #[cfg(unix)]
+    /// User/group ownership constraint
+    pub owner_constraint: Option<OwnerFilter>,
 
     /// Whether or not to display filesystem errors
     pub show_filesystem_errors: bool,

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -411,6 +411,19 @@ fn spawn_senders(
                 }
             }
 
+            #[cfg(unix)]
+            {
+                if let Some(ref owner_constraint) = config.owner_constraint {
+                    if let Ok(ref metadata) = entry_path.metadata() {
+                        if !owner_constraint.matches(&metadata) {
+                            return ignore::WalkState::Continue;
+                        }
+                    } else {
+                        return ignore::WalkState::Continue;
+                    }
+                }
+            }
+
             // Filter out unwanted sizes if it is a file and we have been given size constraints.
             if !config.size_constraints.is_empty() {
                 if entry_path.is_file() {


### PR DESCRIPTION
Closes #307

This implements a single constraint.
Implementation is unix-specific for now. ~~It can easily be extended to cover redox, but I think it needs some testing first: the `users` crate makes no mention of redox support, and there is also [redox_users](https://crates.io/crates/redox_users)~~

Possible questions:
- should this PR also add support for multiple `--owner` arguments (like with time_constraints)
- help text refinements

Edit: it seems redox uses the unix `target_family` as of https://github.com/rust-lang/rust/issues/60139, so no special handling is needed.