### PR TITLE
Multi exec parsing prototype

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -271,6 +271,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .allow_hyphen_values(true)
                 .value_terminator(";")
                 .value_name("cmd")
+                .multiple(true)
                 .conflicts_with("list-details")
                 .help("Execute a command for each search result")
                 .long_help(
@@ -294,6 +295,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .allow_hyphen_values(true)
                 .value_terminator(";")
                 .value_name("cmd")
+                .multiple(true)
                 .conflicts_with_all(&["exec", "list-details"])
                 .help("Execute a command with all search results at once")
                 .long_help(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1221,12 +1221,12 @@ fn test_exec_batch() {
 
         te.assert_error(
             &["foo", "--exec-batch", "echo", "{/}", ";", "-x", "echo"],
-            "error: The argument '--exec <cmd>' cannot be used with '--exec-batch <cmd>'",
+            "error: The argument '--exec <cmd>...' cannot be used with '--exec-batch <cmd>...'",
         );
 
         te.assert_error(
             &["foo", "--exec-batch"],
-            "error: The argument '--exec-batch <cmd>' requires a value but none was supplied",
+            "error: The argument '--exec-batch <cmd>...' requires a value but none was supplied",
         );
 
         te.assert_error(


### PR DESCRIPTION
This is a prototype for handling command line parameters for multiple --exec options (#406). The actual exec'ing is not implemented. All of the code is implemented in main, but the iterator would be moved elsewhere as part of exiting prototype.