### PR TITLE
Fix "unnecessary braces" warning

### DIFF
--- a/src/filter/size.rs
+++ b/src/filter/size.rs
@@ -2,7 +2,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 
 lazy_static! {
-    static ref SIZE_CAPTURES: Regex = { Regex::new(r"(?i)^([+-])(\d+)(b|[kmgt]i?b?)$").unwrap() };
+    static ref SIZE_CAPTURES: Regex = Regex::new(r"(?i)^([+-])(\d+)(b|[kmgt]i?b?)$").unwrap();
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
Hey fd team! 👋 

I love fd and wanted to learn more about it so I cloned it locally. While building it, I noticed it had a warning, so this PR simply fixes the warning.

## Problem
Original warning:
```rust
warning: unnecessary braces around block return value
 --> src/filter/size.rs:5:39
  |
5 |     static ref SIZE_CAPTURES: Regex = { Regex::new(r"(?i)^([+-])(\d+)(b|[kmgt]i?b?)$").unwrap() };
  |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these braces
  |
  = note: `#[warn(unused_braces)]` on by default

warning: 1 warning emitted
```

## Solution
Remove the unneeded braces.