### PR TITLE
Do not exit immediately if one of the search paths is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add new `--owner [user][:group]` filter. See #307 (pull #581) (@alexmaco)
 - Add support for a global ignore file (`~/.config/fd/ignore` on Unix), see #575 (@soedirgo)
+- Do not exit immediately if one of the search paths is missing, see #587 (@DJRHails)
 
 ## Bugfixes
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn run() -> Result<ExitCode> {
 
     // Check if we have no valid search paths.
     if dir_vec.is_empty() {
-      anyhow!("No valid search paths given.");
+      return Err(anyhow!("No valid search paths given."));
     }
 
     if matches.is_present("absolute-path") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,14 +91,17 @@ fn run() -> Result<ExitCode> {
                 dir_vec.push(path_buffer);
             }
             else {
-                print_error(format!("Search path '{}' is not a directory.", path_buffer.to_string_lossy()));
+                print_error(format!(
+                    "Search path '{}' is not a directory.",
+                    path_buffer.to_string_lossy()
+                ));
             }
         }
     }
 
     // Check if we have no valid search paths.
     if dir_vec.is_empty() {
-      return Err(anyhow!("No valid search paths given."));
+        return Err(anyhow!("No valid search paths given."));
     }
 
     if matches.is_present("absolute-path") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,31 +75,26 @@ fn run() -> Result<ExitCode> {
         .unwrap_or("");
 
     // Get one or more root directories to search.
-    let mut dir_vec: Vec<_> = match matches
+    let passed_arguments = matches
         .values_of_os("path")
-        .or_else(|| matches.values_of_os("search-path"))
-    {
-        Some(paths) => paths
-            .map(|path| {
-                let path_buffer = PathBuf::from(path);
-                if filesystem::is_dir(&path_buffer) {
-                    Ok(path_buffer)
-                } else {
-                    Err(anyhow!(
-                        "Search path '{}' is not a directory.",
-                        path_buffer.to_string_lossy()
-                    ))
-                }
-            })
-            .inspect(|res| {
-                if let Err(e) = res {
-                    print_error(format!("{}", e))
-                }
-            })
-            .filter_map(Result::ok)
-            .collect::<Vec<_>>(),
-        None => vec![current_directory.to_path_buf()],
-    };
+        .or_else(|| matches.values_of_os("search-path"));
+
+    // Assign current directory to search vector.
+    let mut dir_vec: Vec<_> = vec![current_directory.to_path_buf()];
+
+    // Assign any valid arguments to search vector.
+    if let Some(paths) = passed_arguments {
+        dir_vec = vec![];
+        for path in paths {
+            let path_buffer = PathBuf::from(path);
+            if filesystem::is_dir(&path_buffer) {
+                dir_vec.push(path_buffer);
+            }
+            else {
+                print_error(format!("Search path '{}' is not a directory.", path_buffer.to_string_lossy()));
+            }
+        }
+    }
 
     if matches.is_present("absolute-path") {
         dir_vec = dir_vec

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,11 @@ fn run() -> Result<ExitCode> {
         }
     }
 
+    // Check if we have no valid search paths.
+    if dir_vec.is_empty() {
+      anyhow!("No valid search paths given.");
+    }
+
     if matches.is_present("absolute-path") {
         dir_vec = dir_vec
             .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use globset::GlobBuilder;
 use lscolors::LsColors;
 use regex::bytes::{RegexBuilder, RegexSetBuilder};
 
+use crate::error::print_error;
 use crate::exec::CommandTemplate;
 use crate::exit_codes::ExitCode;
 use crate::filetypes::FileTypes;
@@ -90,7 +91,13 @@ fn run() -> Result<ExitCode> {
                     ))
                 }
             })
-            .collect::<Result<Vec<_>>>()?,
+            .inspect(|res| {
+                if let Err(e) = res {
+                    print_error(format!("{}", e))
+                }
+            })
+            .filter_map(Result::ok)
+            .collect::<Vec<_>>(),
         None => vec![current_directory.to_path_buf()],
     };
 

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -265,9 +265,6 @@ impl TestEnv {
         // Run *fd*.
         let output = cmd.output().expect("fd output");
 
-
-
-        // Compare actual output to expected output.
         // Normalize both expected and actual output.
         let expected_error = normalize_output(expected, true, self.normalize_line);
         let actual_err = normalize_output(

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -256,7 +256,12 @@ impl TestEnv {
 
     /// Assert that calling *fd* in the specified path under the root working directory,
     /// and with the specified arguments produces an error with the expected message.
-    fn assert_error_subdirectory<P: AsRef<Path>>(&self, path: P, args: &[&str], expected: &str) -> process::ExitStatus {
+    fn assert_error_subdirectory<P: AsRef<Path>>(
+        &self,
+        path: P,
+        args: &[&str],
+        expected: &str,
+    ) -> process::ExitStatus {
         // Setup *fd* command.
         let mut cmd = process::Command::new(&self.fd_exe);
         cmd.current_dir(self.temp_dir.path().join(path));

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -117,6 +117,32 @@ fn test_multi_file() {
     te.assert_output(&["b.foo", "test1", "test2"], "test1/b.foo");
 }
 
+/// Test search over multiple directory with missing
+#[test]
+fn test_multi_file_with_missing() {
+    let dirs = &["real"];
+    let files = &["real/a.foo", "real/b.foo"];
+    let te = TestEnv::new(dirs, files);
+    te.assert_output(
+        &["a.foo", "real", "fake"],
+        "real/a.foo",
+    );
+
+    te.assert_output(
+        &["", "real", "fake"],
+        "real/a.foo
+        real/b.foo",
+    );
+
+    te.assert_output(&["a.foo", "real"], "real/a.foo");
+
+    te.assert_output(
+        &["", "real", "fake1", "fake2"],
+        "real/a.foo
+        real/b.foo",
+    );
+}
+
 /// Explicit root path
 #[test]
 fn test_explicit_root_path() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -123,10 +123,7 @@ fn test_multi_file_with_missing() {
     let dirs = &["real"];
     let files = &["real/a.foo", "real/b.foo"];
     let te = TestEnv::new(dirs, files);
-    te.assert_output(
-        &["a.foo", "real", "fake"],
-        "real/a.foo",
-    );
+    te.assert_output(&["a.foo", "real", "fake"], "real/a.foo");
 
     te.assert_error(
         &["a.foo", "real", "fake"],

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -134,8 +134,6 @@ fn test_multi_file_with_missing() {
         real/b.foo",
     );
 
-    te.assert_output(&["a.foo", "real"], "real/a.foo");
-
     te.assert_output(
         &["", "real", "fake1", "fake2"],
         "real/a.foo

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -128,6 +128,11 @@ fn test_multi_file_with_missing() {
         "real/a.foo",
     );
 
+    te.assert_error(
+        &["a.foo", "real", "fake"],
+        "[fd error]: Search path 'fake' is not a directory.",
+    );
+
     te.assert_output(
         &["", "real", "fake"],
         "real/a.foo
@@ -138,6 +143,19 @@ fn test_multi_file_with_missing() {
         &["", "real", "fake1", "fake2"],
         "real/a.foo
         real/b.foo",
+    );
+
+    te.assert_error(
+        &["", "real", "fake1", "fake2"],
+        "[fd error]: Search path 'fake1' is not a directory.
+        [fd error]: Search path 'fake2' is not a directory.",
+    );
+
+    te.assert_failure_with_error(
+        &["", "fake1", "fake2"],
+        "[fd error]: Search path 'fake1' is not a directory.
+        [fd error]: Search path 'fake2' is not a directory.
+        [fd error]: No valid search paths given.",
     );
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1238,22 +1238,22 @@ fn test_exec_batch() {
             "",
         );
 
-        te.assert_error(
+        te.assert_failure_with_error(
             &["foo", "--exec-batch", "echo", "{}", "{}"],
             "[fd error]: Only one placeholder allowed for batch commands",
         );
 
-        te.assert_error(
+        te.assert_failure_with_error(
             &["foo", "--exec-batch", "echo", "{/}", ";", "-x", "echo"],
             "error: The argument '--exec <cmd>' cannot be used with '--exec-batch <cmd>'",
         );
 
-        te.assert_error(
+        te.assert_failure_with_error(
             &["foo", "--exec-batch"],
             "error: The argument '--exec-batch <cmd>' requires a value but none was supplied",
         );
 
-        te.assert_error(
+        te.assert_failure_with_error(
             &["foo", "--exec-batch", "echo {}"],
             "[fd error]: First argument of exec-batch is expected to be a fixed executable",
         );


### PR DESCRIPTION
Closes #587

Allows for search to continue if some valid paths are given.

I've not done a lot with Rust before so I imagine there is a better way to do:
- `print_error(format!("{}",e))`
- Is there away within the testenv to check for stderror? `assert_error` expects the program to fail. Is this within scope of this PR to modify?