### PR TITLE
Disable jemalloc for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       rust: stable
       env: TARGET=i686-unknown-linux-musl
     - os: osx
+      osx_image: xcode11.4 # Catalina
       rust: stable
       env: TARGET=x86_64-apple-darwin
     - os: linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,10 @@ users = "0.10.0"
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
 libc = "0.2"
 
-[target.'cfg(all(not(windows), not(target_env = "musl")))'.dependencies]
+# FIXME: Re-enable jemalloc on macOS
+# jemalloc is currently disabled on macOS due to a bug in jemalloc in combination with macOS
+# Catalina. See https://github.com/sharkdp/fd/issues/498 for details.
+[target.'cfg(all(not(windows), not(target_os = "macos"), not(target_env = "musl")))'.dependencies]
 jemallocator = "0.3.0"
 
 [dev-dependencies]

--- a/ci/script.bash
+++ b/ci/script.bash
@@ -7,5 +7,5 @@ cargo build --target "$TARGET" --verbose
 
 # We cannot run arm executables on linux
 if [[ $TARGET != arm-unknown-linux-* ]]; then
-    cargo test --target "$TARGET" --verbose --release
+    cargo test --target "$TARGET" --verbose
 fi

--- a/ci/script.bash
+++ b/ci/script.bash
@@ -7,5 +7,5 @@ cargo build --target "$TARGET" --verbose
 
 # We cannot run arm executables on linux
 if [[ $TARGET != arm-unknown-linux-* ]]; then
-    cargo test --target "$TARGET" --verbose
+    cargo test --target "$TARGET" --verbose --release
 fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,8 @@ use crate::options::Options;
 use crate::regex_helper::pattern_has_uppercase_char;
 
 // We use jemalloc for performance reasons, see https://github.com/sharkdp/fd/pull/481
-#[cfg(all(not(windows), not(target_env = "musl")))]
+// FIXME: re-enable jemalloc on macOS, see comment in Cargo.toml file for more infos
+#[cfg(all(not(windows), not(target_os = "macos"), not(target_env = "musl")))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
This PR configures TravisCI to use macOS Catalina for the fd build and tests. If this works as expected, the first build should fail during the integration test phase due to #498. The second commit disables jemalloc for macOS.

closes #498 