### PR TITLE
Support colored output on older Windows versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Features
 ## Bugfixes
+
+- Support colored output on older Windows versions if either (1) `--color=always` is set or (2) the `TERM` environment variable is set. See #469
+
 ## Changes
 ## Other
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,9 +148,9 @@ fn run() -> Result<ExitCode> {
     let case_sensitive = !matches.is_present("ignore-case")
         && (matches.is_present("case-sensitive") || pattern_has_uppercase_char(&pattern_regex));
 
-
     #[cfg(windows)]
-    let ansi_colors_support = ansi_term::enable_ansi_support().is_ok();
+    let ansi_colors_support =
+        ansi_term::enable_ansi_support().is_ok() || std::env::var_os("TERM").is_some();
 
     #[cfg(not(windows))]
     let ansi_colors_support = true;


### PR DESCRIPTION
Support colored output on older Windows versions if either (1) `--color=always` is set or (2) the `TERM` environment variable is set.

closes #469