### PR TITLE
No buffering of command output when running on a single thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Upcoming release
 
 ## Features
+- Don't buffer command output from `--exec` when using a single thread. See #522
 
 ## Bugfixes
 
@@ -455,7 +456,7 @@ I'd also like to take this chance to say a special Thank You to a few people tha
 * Add option to force colored output: `--color always`, see #49 (@Detegr)
 * Generate Shell completions for Bash, ZSH, Fish and Powershell, see #64 (@ImbaKnugel)
 * Better & extended `--help` text (@abaez and @Detegr)
-* Proper Windows support, see #70 
+* Proper Windows support, see #70
 
 ## Changes
 
@@ -483,9 +484,9 @@ I'd also like to take this chance to say a special Thank You to a few people tha
 
 * Changed `--sensitive` to `--case-sensitive`
 * Changed `--absolute` to `--absolute-path`
-* Throw an error if root directory is not existent, see #39 
-* Use absolute paths if the root dir is an absolute path, see #40 
-* Handle invalid UTF-8, see #34 #38 
+* Throw an error if root directory is not existent, see #39
+* Use absolute paths if the root dir is an absolute path, see #40
+* Handle invalid UTF-8, see #34 #38
 * Support `-V`, `--version` by switching from `getopts` to `clap`.
 
 Misc:
@@ -493,8 +494,8 @@ Misc:
 
 # v1.1.0
 
-- Windows compatibility (@sebasv), see #29 #35 
-- Safely exit on broken output pipes (e.g.: usage with `head`, `tail`, ..), see #24 
+- Windows compatibility (@sebasv), see #29 #35
+- Safely exit on broken output pipes (e.g.: usage with `head`, `tail`, ..), see #24
 - Backport for rust 1.16, see #23
 
 # v1.0.0
@@ -506,17 +507,17 @@ Misc:
 
 # v0.3.0
 
--  Parse dircolors files, closes #20 
--  Colorize each path component, closes #19 
--  Add short command line option for --hidden, see #18 
+-  Parse dircolors files, closes #20
+-  Colorize each path component, closes #19
+-  Add short command line option for --hidden, see #18
 
 # v0.2.0
 
--  Option to follow symlinks, disable colors, closes #16, closes #17 
+-  Option to follow symlinks, disable colors, closes #16, closes #17
 - `--filename` instead of `--full-path`
--  Option to search hidden directories, closes #12 
--  Configurable search depth, closes #13 
--  Detect interactive terminal, closes #11 
+-  Option to search hidden directories, closes #12
+-  Configurable search depth, closes #13
+-  Detect interactive terminal, closes #11
 
 # v0.1.0
 

--- a/src/exec/command.rs
+++ b/src/exec/command.rs
@@ -7,26 +7,19 @@ use crate::error::print_error;
 use crate::exit_codes::ExitCode;
 
 /// Executes a command.
-pub fn execute_command(mut cmd: Command, out_perm: &Mutex<()>) -> ExitCode {
+pub fn execute_command(mut cmd: Command, out_perm: &Mutex<()>, is_multithread: bool) -> ExitCode {
+    let output;
     // Spawn the supplied command.
-    /* let output = cmd.output(); */
-    // This sort of works:
-    let child = cmd.spawn().expect("failed to wait on child");
-    let output = child
-    .wait_with_output()
-    .expect("failed to wait on child"); 
-    ExitCode::Success
-    /* let child_handle = cmd.spawn();
-    match child_handle {
-        Ok(output) => {
-            let exit_code = output.wait();
-        }
-        Err() => {
-
-        }
-    } */
+    if is_multithread {
+        output = cmd.output();
+    } else {
+        // This sort of works:
+        let child = cmd.spawn().expect("Failed to execute command");
+        output = child.wait_with_output();
+    }
+    
     // Then wait for the command to exit, if it was spawned.
-    /* match output {
+    match output {
         Ok(output) => {
             // While this lock is active, this thread will be the only thread allowed
             // to write its outputs.
@@ -35,8 +28,8 @@ pub fn execute_command(mut cmd: Command, out_perm: &Mutex<()>) -> ExitCode {
             let stdout = io::stdout();
             let stderr = io::stderr();
 
-            //let _ = stdout.lock().write_all(&output.stdout);
-            //let _ = stderr.lock().write_all(&output.stderr);
+            let _ = stdout.lock().write_all(&output.stdout);
+            let _ = stderr.lock().write_all(&output.stderr);
 
             if output.status.code() == Some(0) {
                 ExitCode::Success
@@ -52,5 +45,5 @@ pub fn execute_command(mut cmd: Command, out_perm: &Mutex<()>) -> ExitCode {
             print_error(format!("Problem while executing command: {}", why));
             ExitCode::GeneralError
         }
-    } */
+    }
 }

--- a/src/exec/command.rs
+++ b/src/exec/command.rs
@@ -9,10 +9,24 @@ use crate::exit_codes::ExitCode;
 /// Executes a command.
 pub fn execute_command(mut cmd: Command, out_perm: &Mutex<()>) -> ExitCode {
     // Spawn the supplied command.
-    let output = cmd.output();
+    /* let output = cmd.output(); */
+    // This sort of works:
+    let child = cmd.spawn().expect("failed to wait on child");
+    let output = child
+    .wait_with_output()
+    .expect("failed to wait on child"); 
+    ExitCode::Success
+    /* let child_handle = cmd.spawn();
+    match child_handle {
+        Ok(output) => {
+            let exit_code = output.wait();
+        }
+        Err() => {
 
+        }
+    } */
     // Then wait for the command to exit, if it was spawned.
-    match output {
+    /* match output {
         Ok(output) => {
             // While this lock is active, this thread will be the only thread allowed
             // to write its outputs.
@@ -21,8 +35,8 @@ pub fn execute_command(mut cmd: Command, out_perm: &Mutex<()>) -> ExitCode {
             let stdout = io::stdout();
             let stderr = io::stderr();
 
-            let _ = stdout.lock().write_all(&output.stdout);
-            let _ = stderr.lock().write_all(&output.stderr);
+            //let _ = stdout.lock().write_all(&output.stdout);
+            //let _ = stderr.lock().write_all(&output.stderr);
 
             if output.status.code() == Some(0) {
                 ExitCode::Success
@@ -38,5 +52,5 @@ pub fn execute_command(mut cmd: Command, out_perm: &Mutex<()>) -> ExitCode {
             print_error(format!("Problem while executing command: {}", why));
             ExitCode::GeneralError
         }
-    }
+    } */
 }

--- a/src/exec/command.rs
+++ b/src/exec/command.rs
@@ -13,7 +13,8 @@ pub fn execute_command(mut cmd: Command, out_perm: &Mutex<()>, is_multithread: b
     if is_multithread {
         output = cmd.output();
     } else {
-        // This sort of works:
+        // If running on only one thread, don't buffer output
+        // Allows for viewing and interacting with intermediate command output
         let child = cmd.spawn().expect("Failed to execute command");
         output = child.wait_with_output();
     }

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -16,6 +16,7 @@ pub fn job(
     cmd: Arc<CommandTemplate>,
     out_perm: Arc<Mutex<()>>,
     show_filesystem_errors: bool,
+    is_multithread: bool,
 ) -> ExitCode {
     let mut results: Vec<ExitCode> = Vec::new();
     loop {
@@ -34,11 +35,11 @@ pub fn job(
             }
             Err(_) => break,
         };
-
+        
         // Drop the lock so that other threads can read from the receiver.
         drop(lock);
         // Generate a command, execute it and store its exit code.
-        results.push(cmd.generate_and_execute(&value, Arc::clone(&out_perm)))
+        results.push(cmd.generate_and_execute(&value, Arc::clone(&out_perm), is_multithread))
     }
     // Returns error in case of any error.
     merge_exitcodes(&results)
@@ -48,6 +49,7 @@ pub fn batch(
     rx: Receiver<WorkerResult>,
     cmd: &CommandTemplate,
     show_filesystem_errors: bool,
+    is_multithread: bool,
 ) -> ExitCode {
     let paths = rx.iter().filter_map(|value| match value {
         WorkerResult::Entry(val) => Some(val),
@@ -58,5 +60,5 @@ pub fn batch(
             None
         }
     });
-    cmd.generate_and_execute_batch(paths)
+    cmd.generate_and_execute_batch(paths, is_multithread)
 }

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -16,7 +16,7 @@ pub fn job(
     cmd: Arc<CommandTemplate>,
     out_perm: Arc<Mutex<()>>,
     show_filesystem_errors: bool,
-    is_multithread: bool,
+    buffer_output: bool,
 ) -> ExitCode {
     let mut results: Vec<ExitCode> = Vec::new();
     loop {
@@ -35,11 +35,11 @@ pub fn job(
             }
             Err(_) => break,
         };
-        
+
         // Drop the lock so that other threads can read from the receiver.
         drop(lock);
         // Generate a command, execute it and store its exit code.
-        results.push(cmd.generate_and_execute(&value, Arc::clone(&out_perm), is_multithread))
+        results.push(cmd.generate_and_execute(&value, Arc::clone(&out_perm), buffer_output))
     }
     // Returns error in case of any error.
     merge_exitcodes(&results)
@@ -49,7 +49,7 @@ pub fn batch(
     rx: Receiver<WorkerResult>,
     cmd: &CommandTemplate,
     show_filesystem_errors: bool,
-    is_multithread: bool,
+    buffer_output: bool,
 ) -> ExitCode {
     let paths = rx.iter().filter_map(|value| match value {
         WorkerResult::Entry(val) => Some(val),
@@ -60,5 +60,5 @@ pub fn batch(
             None
         }
     });
-    cmd.generate_and_execute_batch(paths, is_multithread)
+    cmd.generate_and_execute_batch(paths, buffer_output)
 }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -139,7 +139,7 @@ impl CommandTemplate {
     ///
     /// Using the internal `args` field, and a supplied `input` variable, a `Command` will be
     /// build. Once all arguments have been processed, the command is executed.
-    pub fn generate_and_execute(&self, input: &Path, out_perm: Arc<Mutex<()>>) -> ExitCode {
+    pub fn generate_and_execute(&self, input: &Path, out_perm: Arc<Mutex<()>>, is_multithread: bool) -> ExitCode {
         let input = strip_current_dir(input);
 
         let mut cmd = Command::new(self.args[0].generate(&input, self.path_separator.as_deref()));
@@ -147,14 +147,14 @@ impl CommandTemplate {
             cmd.arg(arg.generate(&input, self.path_separator.as_deref()));
         }
 
-        execute_command(cmd, &out_perm)
+        execute_command(cmd, &out_perm, is_multithread)
     }
 
     pub fn in_batch_mode(&self) -> bool {
         self.mode == ExecutionMode::Batch
     }
 
-    pub fn generate_and_execute_batch<I>(&self, paths: I) -> ExitCode
+    pub fn generate_and_execute_batch<I>(&self, paths: I, is_multithread: bool) -> ExitCode
     where
         I: Iterator<Item = PathBuf>,
     {
@@ -182,7 +182,7 @@ impl CommandTemplate {
         }
 
         if has_path {
-            execute_command(cmd, &Mutex::new(()))
+            execute_command(cmd, &Mutex::new(()), is_multithread)
         } else {
             ExitCode::Success
         }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -139,7 +139,12 @@ impl CommandTemplate {
     ///
     /// Using the internal `args` field, and a supplied `input` variable, a `Command` will be
     /// build. Once all arguments have been processed, the command is executed.
-    pub fn generate_and_execute(&self, input: &Path, out_perm: Arc<Mutex<()>>, is_multithread: bool) -> ExitCode {
+    pub fn generate_and_execute(
+        &self,
+        input: &Path,
+        out_perm: Arc<Mutex<()>>,
+        buffer_output: bool,
+    ) -> ExitCode {
         let input = strip_current_dir(input);
 
         let mut cmd = Command::new(self.args[0].generate(&input, self.path_separator.as_deref()));
@@ -147,14 +152,14 @@ impl CommandTemplate {
             cmd.arg(arg.generate(&input, self.path_separator.as_deref()));
         }
 
-        execute_command(cmd, &out_perm, is_multithread)
+        execute_command(cmd, &out_perm, buffer_output)
     }
 
     pub fn in_batch_mode(&self) -> bool {
         self.mode == ExecutionMode::Batch
     }
 
-    pub fn generate_and_execute_batch<I>(&self, paths: I, is_multithread: bool) -> ExitCode
+    pub fn generate_and_execute_batch<I>(&self, paths: I, buffer_output: bool) -> ExitCode
     where
         I: Iterator<Item = PathBuf>,
     {
@@ -182,7 +187,7 @@ impl CommandTemplate {
         }
 
         if has_path {
-            execute_command(cmd, &Mutex::new(()), is_multithread)
+            execute_command(cmd, &Mutex::new(()), buffer_output)
         } else {
             ExitCode::Success
         }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -170,12 +170,16 @@ fn spawn_receiver(
 
     let show_filesystem_errors = config.show_filesystem_errors;
     let threads = config.threads;
-
+    let is_multithread: bool = if threads > 1 {
+        true
+    } else {
+        false
+    };
     thread::spawn(move || {
         // This will be set to `Some` if the `--exec` argument was supplied.
         if let Some(ref cmd) = config.command {
             if cmd.in_batch_mode() {
-                exec::batch(rx, cmd, show_filesystem_errors)
+                exec::batch(rx, cmd, show_filesystem_errors, is_multithread)
             } else {
                 let shared_rx = Arc::new(Mutex::new(rx));
 
@@ -190,7 +194,7 @@ fn spawn_receiver(
 
                     // Spawn a job thread that will listen for and execute inputs.
                     let handle =
-                        thread::spawn(move || exec::job(rx, cmd, out_perm, show_filesystem_errors));
+                        thread::spawn(move || exec::job(rx, cmd, out_perm, show_filesystem_errors, is_multithread));
 
                     // Push the handle of the spawned thread into the vector for later joining.
                     handles.push(handle);

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -170,6 +170,7 @@ fn spawn_receiver(
 
     let show_filesystem_errors = config.show_filesystem_errors;
     let threads = config.threads;
+    // This will be used to check if output should be buffered when only running a single thread
     let is_multithread: bool = if threads > 1 {
         true
     } else {

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -171,16 +171,12 @@ fn spawn_receiver(
     let show_filesystem_errors = config.show_filesystem_errors;
     let threads = config.threads;
     // This will be used to check if output should be buffered when only running a single thread
-    let is_multithread: bool = if threads > 1 {
-        true
-    } else {
-        false
-    };
+    let enable_output_buffering: bool = threads > 1;
     thread::spawn(move || {
         // This will be set to `Some` if the `--exec` argument was supplied.
         if let Some(ref cmd) = config.command {
             if cmd.in_batch_mode() {
-                exec::batch(rx, cmd, show_filesystem_errors, is_multithread)
+                exec::batch(rx, cmd, show_filesystem_errors, enable_output_buffering)
             } else {
                 let shared_rx = Arc::new(Mutex::new(rx));
 
@@ -194,8 +190,15 @@ fn spawn_receiver(
                     let out_perm = Arc::clone(&out_perm);
 
                     // Spawn a job thread that will listen for and execute inputs.
-                    let handle =
-                        thread::spawn(move || exec::job(rx, cmd, out_perm, show_filesystem_errors, is_multithread));
+                    let handle = thread::spawn(move || {
+                        exec::job(
+                            rx,
+                            cmd,
+                            out_perm,
+                            show_filesystem_errors,
+                            enable_output_buffering,
+                        )
+                    });
 
                     // Push the handle of the spawned thread into the vector for later joining.
                     handles.push(handle);


### PR DESCRIPTION
This is an implementation for #522 