### PR TITLE
Fix a link to ubuntu official page

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The number of threads used for command execution can be set with the `--threads`
 *... and other Debian-based Linux distributions.*
 
 If you run Ubuntu 19.04 (Disco Dingo) or newer, you can install the
-[officially maintained package](https://packages.ubuntu.com/disco/fd-find):
+[officially maintained package](https://packages.ubuntu.com/fd-find):
 ```
 sudo apt install fd-find
 ```


### PR DESCRIPTION
Currently, https://packages.ubuntu.com/disco/fd-find shows an error.
This is because of the package page that unsupported version was removed.

So I removed the version from the link. That link shows a search result of `fd-find` and can find OSs that can install `fd-find`.