### PR TITLE
(tentatively) add install instructions for OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,13 @@ You can install [the fd-find package](https://www.freshports.org/sysutils/fd) fr
 pkg install fd-find
 ```
 
+### On OpenBSD
+
+You can install the [fd-find](https://openports.se/sysutils/fd) package from the official repo:
+```
+pkg_add fd
+```
+
 ### From NPM
 
 On linux and macOS, you can install the [fd-find](https://npm.im/fd-find) package:


### PR DESCRIPTION
I've resurrected this port and submitted it to the [mailing list](https://marc.info/?l=openbsd-ports&m=159894566930877&w=2). The instructions lie a bit, as it won't enter general availability until the next OS release around October. But given the the time between releases in the 7.x.x series, I think that'll work out nicely ;).