### PR TITLE
improve time option usage

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -411,7 +411,7 @@ pub fn build_app() -> App<'static, 'static> {
         .arg(
             Arg::with_name("changed-within")
                 .long("changed-within")
-                .alias("change-newer-than")
+                .alias("newer")
                 .takes_value(true)
                 .value_name("date|dur")
                 .number_of_values(1)
@@ -428,7 +428,7 @@ pub fn build_app() -> App<'static, 'static> {
         .arg(
             Arg::with_name("changed-before")
                 .long("changed-before")
-                .alias("change-older-than")
+                .alias("older")
                 .takes_value(true)
                 .value_name("date|dur")
                 .number_of_values(1)

--- a/src/app.rs
+++ b/src/app.rs
@@ -411,6 +411,7 @@ pub fn build_app() -> App<'static, 'static> {
         .arg(
             Arg::with_name("changed-within")
                 .long("changed-within")
+                .alias("change-newer-than")
                 .alias("newer")
                 .takes_value(true)
                 .value_name("date|dur")
@@ -428,6 +429,7 @@ pub fn build_app() -> App<'static, 'static> {
         .arg(
             Arg::with_name("changed-before")
                 .long("changed-before")
+                .alias("change-older-than")
                 .alias("older")
                 .takes_value(true)
                 .value_name("date|dur")

--- a/src/filter/time.rs
+++ b/src/filter/time.rs
@@ -12,6 +12,7 @@ impl TimeFilter {
         humantime::parse_duration(s)
             .map(|duration| *ref_time - duration)
             .or_else(|_| humantime::parse_rfc3339_weak(s))
+            .or_else(|_| humantime::parse_rfc3339_weak(&(s.to_owned() + " 00:00:00")))
             .ok()
     }
 


### PR DESCRIPTION
issue #624 

Currently, aliases for fd's time option are not so memorable and we have to specify full timestamp.

So, I changed the aliases for time option into more memorable ones and default the time component to 00:00:00 when only a date is given