### PR TITLE
Disable jemalloc on Android (fixes #636 and #642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Improved the usability of the time-based options, see #624 and #645 (@gorogoroumaru)
 
 ## Bugfixes
+
+- Disable jemalloc on Android, see #662
+
 ## Changes
 ## Other
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ libc = "0.2"
 # FIXME: Re-enable jemalloc on macOS
 # jemalloc is currently disabled on macOS due to a bug in jemalloc in combination with macOS
 # Catalina. See https://github.com/sharkdp/fd/issues/498 for details.
-[target.'cfg(all(not(windows), not(target_os = "macos"), not(target_env = "musl")))'.dependencies]
+[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_env = "musl")))'.dependencies]
 jemallocator = "0.3.0"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ use crate::regex_helper::pattern_has_uppercase_char;
 
 // We use jemalloc for performance reasons, see https://github.com/sharkdp/fd/pull/481
 // FIXME: re-enable jemalloc on macOS, see comment in Cargo.toml file for more infos
-#[cfg(all(not(windows), not(target_os = "macos"), not(target_env = "musl")))]
+#[cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_env = "musl")))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
Disabling jemalloc for Android fixes a build failure since jemalloc does not build out of the box for that platform on older API versions.

Android started using jemalloc as the system allocator around 2014 for most devices. In the latest Android version (11) the system allocator has been switched to Scudo, which while not being jemalloc is modern and actively maintained and should be used for most software on Android.

See:
- https://android-developers.googleblog.com/2020/06/system-hardening-in-android-11.html
- https://blog.nsogroup.com/a-tale-of-two-mallocs-on-android-libc-allocators-part-2-jemalloc/
- https://stackoverflow.com/questions/2266762/android-libc-version-and-malloc-implementation