### PR TITLE
Dependency dirs is no longer mantained, use dirs-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,20 +137,21 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "dirs"
-version = "2.0.2"
+name = "dirs-next"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cbcf9241d9e8d106295bd496bbe2e9cffd5fa098f2a8c9e2bbcbf09773c11a8"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs-sys-next 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.4"
+name = "dirs-sys-next"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c60f7b8a8953926148223260454befb50c751d3c50e1c178c4fd1ace4083c9a"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ humantime = "2.0"
 lscolors = "0.7"
 globset = "0.4"
 anyhow = "1.0"
-dirs = "2.0"
+dirs-next = "1.0"
 
 [dependencies.clap]
 version = "2.31.2"

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -87,10 +87,10 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<Options>) -> 
         let config_dir_op = std::env::var_os("XDG_CONFIG_HOME")
             .map(PathBuf::from)
             .filter(|p| p.is_absolute())
-            .or_else(|| dirs::home_dir().map(|d| d.join(".config")));
+            .or_else(|| dirs_next::home_dir().map(|d| d.join(".config")));
 
         #[cfg(not(target_os = "macos"))]
-        let config_dir_op = dirs::config_dir();
+        let config_dir_op = dirs_next::config_dir();
 
         if let Some(global_ignore_file) = config_dir_op
             .map(|p| p.join("fd").join("ignore"))


### PR DESCRIPTION
All this does is change the manifest entry and usage of `dirs` to `dirs-next`. `dirs` is no longer maintained, so moving to `dirs-next` is encouraged. There are no user-facing changes (the crate is a drop-in replacement), so I didn't make a changelog entry, but I can if it's requested in a review. Thanks!