### PR TITLE
add --base-directory, --path-separator, and --search-path to the man page

### DIFF
--- a/doc/fd.1
+++ b/doc/fd.1
@@ -232,6 +232,20 @@ Examples:
   \-\-owner :students
   \-\-owner "!john:students"
 .TP
+.BI "\-\-base\-directory " path
+Change the current working directory of fd to the provided path. This means that search results will
+be shown with respect to the given base path. Note that relative paths which are passed to fd via the
+positional \fIpath\fR argument or the \fB\-\-search\-path\fR option will also be resolved relative to
+this directory.
+.TP
+.BI "\-\-path\-separator " separator
+Set the path separator to use when printinf file paths. The default is the OS-specific separator
+('/' on Unix, '\\' on Windows).
+.TP
+.BI "\-\-search\-path " search\-path
+Provide paths to search as an alternative to the positional \fIpath\fR argument. Changes the usage to
+\'fd [FLAGS/OPTIONS] \-\-search\-path PATH \-\-search\-path PATH2 [PATTERN]\'
+.TP
 .BI "\-x, \-\-exec " command
 Execute
 .I command

--- a/src/app.rs
+++ b/src/app.rs
@@ -483,7 +483,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .number_of_values(1)
                 .hidden_short_help(true)
                 .long_help(
-                    "Change the current working directory of fd to the provided path. The \
+                    "Change the current working directory of fd to the provided path. This \
                          means that search results will be shown with respect to the given base \
                          path. Note that relative paths which are passed to fd via the positional \
                          <path> argument or the '--search-path' option will also be resolved \


### PR DESCRIPTION
These options are in `fd --help` but missing from the man page.
Also fix a typo in the help text for --base-directory.