### PR TITLE
Insert line break to display url in macos

### DIFF
--- a/doc/fd.1
+++ b/doc/fd.1
@@ -286,13 +286,11 @@ basename without file extension
 .SH PATTERN SYNTAX
 The regular expression syntax used by fd is documented here:
 
-.UR https://docs.rs/regex/1.0.0/regex/#syntax
-.UE
+    https://docs.rs/regex/1.0.0/regex/#syntax
 
 The glob syntax is documented here:
 
-.UR https://docs.rs/globset/#syntax
-.UE
+    https://docs.rs/globset/#syntax
 .SH ENVIRONMENT
 .TP
 .B LS_COLORS


### PR DESCRIPTION
Addresses #687

Macos seems to have an issue with having the url on the same line as .UR.

As troff describes the url to be the text between .UR and .UE, this should still be according to conventions and now support macos.


-----

![image](https://user-images.githubusercontent.com/35100156/98295526-fe3cc500-1fb1-11eb-898d-9499ff410e47.png)
