### PR TITLE
Add exact size support to the --size filter (#669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improved the usability of the time-based options, see #624 and #645 (@gorogoroumaru)
 - Add new `--prune` flag, see #535 (@reima)
+- Add support for exact sizes in `--size` filter, see #669 (pull #696)
 
 ## Bugfixes
 

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -179,6 +179,8 @@ Limit results based on the size of files using the format
 file size must be greater than or equal to this
 .IP '-'
 file size must be less than or equal to this
+.P
+If neither '+' nor '-' is specified, file size must be exactly equal to this.
 .IP 'NUM'
 The numeric size (e.g. 500)
 .IP 'UNIT'

--- a/src/app.rs
+++ b/src/app.rs
@@ -390,7 +390,8 @@ pub fn build_app() -> App<'static, 'static> {
                 .long_help(
                     "Limit results based on the size of files using the format <+-><NUM><UNIT>.\n   \
                         '+': file size must be greater than or equal to this\n   \
-                        '-': file size must be less than or equal to this\n   \
+                        '-': file size must be less than or equal to this\n\
+                     If neither '+' nor '-' is specified, file size must be exactly equal to this.\n   \
                         'NUM':  The numeric size (e.g. 500)\n   \
                         'UNIT': The units for NUM. They are not case-sensitive.\n\
                      Allowed unit values:\n    \

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1387,6 +1387,9 @@ fn test_size() {
 
     // Zero sized files.
     te.assert_output(&["", "--size", "-0B"], "0_bytes.foo");
+    te.assert_output(&["", "--size", "0B"], "0_bytes.foo");
+    te.assert_output(&["", "--size=0B"], "0_bytes.foo");
+    te.assert_output(&["", "-S", "0B"], "0_bytes.foo");
 
     // Files with 2 bytes or more.
     te.assert_output(
@@ -1402,6 +1405,9 @@ fn test_size() {
 
     // Files with size between 1 byte and 11 bytes.
     te.assert_output(&["", "--size", "+1B", "--size", "-11B"], "11_bytes.foo");
+
+    // Files with size equal 11 bytes.
+    te.assert_output(&["", "--size", "11B"], "11_bytes.foo");
 
     // Files with size between 1 byte and 30 bytes.
     te.assert_output(
@@ -1434,6 +1440,7 @@ fn test_size() {
 
     // Files with size equal 4 kibibytes.
     te.assert_output(&["", "--size", "+4ki", "--size", "-4ki"], "4_kibibytes.foo");
+    te.assert_output(&["", "--size", "4ki"], "4_kibibytes.foo");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This will allow using `--size=100b` or `--size 100b` filters to search for files of that exact size.