### PR TITLE
set default path separator to '/' in MSYS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,9 @@ fn run() -> Result<ExitCode> {
         _ => ansi_colors_support && env::var_os("NO_COLOR").is_none() && interactive_terminal,
     };
 
-    let path_separator = matches.value_of("path-separator").map(|str| str.to_owned());
+    let path_separator = matches
+        .value_of("path-separator")
+        .map_or_else(filesystem::default_path_separator, |s| Some(s.to_owned()));
 
     let ls_colors = if colored_output {
         Some(LsColors::from_env().unwrap_or_else(|| LsColors::from_string(DEFAULT_LS_COLORS)))


### PR DESCRIPTION
MSYS and MSYS2 environments (such as Git Bash) have a UNIX like
filesystem which uses '/' as the path separator rather than '\', but
Rust doesn't know about this by default.

On Windows, check the MSYSTEM environment variable and set the default
value of the --path-separator option to '/' for convenience.

There is no similar detection of Cygwin because there seems to be no way
for Rust (and any native Win32) programs to detect that they're being
called from a Cygwin environment. Cygwin users can use a shell
alias/function/script to wrap fd.

Fixes: https://github.com/sharkdp/fd/issues/537