### PR TITLE
Detailed help visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,17 +100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,7 +155,6 @@ dependencies = [
  "anyhow",
  "atty",
  "clap",
- "colored",
  "ctrlc",
  "diff",
  "dirs-next",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +166,7 @@ dependencies = [
  "anyhow",
  "atty",
  "clap",
+ "colored",
  "ctrlc",
  "diff",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ path = "src/main.rs"
 [build-dependencies]
 clap = "2.31.2"
 version_check = "0.9"
+lazy_static = "1.1.0"
+colored = "2.0.0"
 
 [dependencies]
 ansi_term = "0.12"
@@ -47,6 +49,7 @@ lscolors = "0.7"
 globset = "0.4"
 anyhow = "1.0"
 dirs-next = "2.0"
+colored = "2.0.0"
 
 [dependencies.clap]
 version = "2.31.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/main.rs"
 clap = "2.31.2"
 version_check = "0.9"
 lazy_static = "1.1.0"
-colored = "2.0.0"
+ansi_term = "0.12"
 
 [dependencies]
 ansi_term = "0.12"
@@ -49,7 +49,6 @@ lscolors = "0.7"
 globset = "0.4"
 anyhow = "1.0"
 dirs-next = "2.0"
-colored = "2.0.0"
 
 [dependencies.clap]
 version = "2.31.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,18 @@ pub fn build_app() -> App<'static, 'static> {
             "Note: `fd -h` prints a short and concise overview while `fd --help` gives all \
                  details.",
         )
+        // Help: Short and detailed
+        .arg(
+            Arg::with_name("help")
+                .short("h")
+                .help("Prints a short and concise overview")
+        )
+        .arg(
+            Arg::with_name("help_long")
+                .long("help")
+                .help("Prints detailed help information")
+        )
+        // Other flags
         .arg(
             Arg::with_name("hidden")
                 .long("hidden")

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,15 +1,16 @@
+use ansi_term::Colour::{Purple, Yellow};
 use clap::{crate_version, App, AppSettings, Arg};
-use colored::Colorize;
 use lazy_static::lazy_static;
 
 lazy_static! {
     static ref AFTER_HELP: String = format!(
-        "{} {} {} {} {} {}",
-        "Note:".yellow(),
-        "Use `fd",
-        "--help".purple(),
-        "` to get",
-        "detailed help".purple(),
+        "{} {} `{} {}` {} {} {}",
+        Yellow.paint("Note:"),
+        "Use",
+        "fd",
+        Purple.paint("--help"),
+        "to get",
+        Purple.paint("detailed help"),
         "information. `fd -h` only prints a short and concise overview.\n",
     );
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ lazy_static! {
         "--help".purple(),
         "` to get",
         "detailed help".purple(),
-        "information. `fd -h` only prints a short an concise overview.\n",
+        "information. `fd -h` only prints a short and concise overview.\n",
     );
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,18 @@
 use clap::{crate_version, App, AppSettings, Arg};
+use colored::Colorize;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref AFTER_HELP: String = format!(
+        "{} {} {} {} {} {}",
+        "Note:".yellow(),
+        "Use `fd",
+        "--help".purple(),
+        "` to get",
+        "detailed help".purple(),
+        "information. `fd -h` only prints a short an concise overview.\n",
+    );
+}
 
 pub fn build_app() -> App<'static, 'static> {
     let clap_color_setting = if std::env::var_os("NO_COLOR").is_none() {
@@ -12,10 +26,7 @@ pub fn build_app() -> App<'static, 'static> {
         .usage("fd [FLAGS/OPTIONS] [<pattern>] [<path>...]")
         .setting(clap_color_setting)
         .setting(AppSettings::DeriveDisplayOrder)
-        .after_help(
-            "Note: `fd -h` prints a short and concise overview while `fd --help` gives all \
-                 details.",
-        )
+        .after_help(AFTER_HELP.as_str())
         // Help: Short and detailed
         .arg(
             Arg::with_name("help")

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,19 +64,19 @@ fn run() -> Result<ExitCode> {
     // Print short and long help
     if matches.is_present("help") {
         let _ = app.print_help();
-        // WORKAROUND: It seems like `clap` does not add a newline after the
-        //     help output when using `print_help`. Therefore add a newline
-        //     here.  Note, that the `after_help` string already adds a newline
-        //     to generate an empty line before the next prompt
+        // WORKAROUND: `clap` does currently not add a newline after the output
+        //     of `print_help` and `print_long_help`. According to this issue
+        //     (https://github.com/clap-rs/clap/issues/1536), this is a bug and
+        //     it will be fixed in version 3.
         println!("");
         return Ok(ExitCode::Success);
     }
     if matches.is_present("help_long") {
         let _ = app.print_long_help();
-        // WORKAROUND: It seems like `clap` does not add a newline after the
-        //     help output when using `print_long_help`. Therefore add a newline
-        //     here Note, that the `after_help` string already adds a newline to
-        //     generate an empty line before the next prompt
+        // WORKAROUND: `clap` does currently not add a newline after the output
+        //     of `print_help` and `print_long_help`. According to this issue
+        //     (https://github.com/clap-rs/clap/issues/1536), this is a bug and
+        //     it will be fixed in version 3.
         println!("");
         return Ok(ExitCode::Success);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,15 @@ ow=0:or=0;38;5;16;48;5;203:no=0:ex=1;38;5;203:cd=0;38;5;203;48;5;236:mi=0;38;5;1
 
 fn run() -> Result<ExitCode> {
     let mut app = app::build_app();
-    let matches = app.get_matches_from_safe_borrow(env::args_os())?;
+
+    // When encountering parsing errors, print error message and exit
+    let matches = match app.get_matches_from_safe_borrow(env::args_os()) {
+        Ok(matches) => matches,
+        Err(err) => {
+            eprintln!("{}", err);
+            return Ok(ExitCode::GeneralError)
+        }
+    };
 
     // Print short and long help
     if matches.is_present("help") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,8 @@ fn run() -> Result<ExitCode> {
         let _ = app.print_help();
         // HACK: It seems like `clap` does not add a newline after the help
         //       output when using `print_help`. Therefore add a newline here.
+        //       Note, that the `after_help` string already adds a newline to generate
+        //       an empty line before the next prompt
         println!("");
         return Ok(ExitCode::Success);
     }
@@ -65,6 +67,8 @@ fn run() -> Result<ExitCode> {
         let _ = app.print_long_help();
         // HACK: It seems like `clap` does not add a newline after the help
         //       output when using `print_long_help`. Therefore add a newline here
+        //       Note, that the `after_help` string already adds a newline to generate
+        //       an empty line before the next prompt
         println!("");
         return Ok(ExitCode::Success);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn run() -> Result<ExitCode> {
         Ok(matches) => matches,
         Err(err) => {
             eprintln!("{}", err);
-            return Ok(ExitCode::GeneralError)
+            return Ok(ExitCode::GeneralError);
         }
     };
 
@@ -80,7 +80,6 @@ fn run() -> Result<ExitCode> {
         println!("");
         return Ok(ExitCode::Success);
     }
-
 
     // Set the current working directory of the process
     if let Some(base_directory) = matches.value_of_os("base-directory") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,19 +64,19 @@ fn run() -> Result<ExitCode> {
     // Print short and long help
     if matches.is_present("help") {
         let _ = app.print_help();
-        // HACK: It seems like `clap` does not add a newline after the help
-        //       output when using `print_help`. Therefore add a newline here.
-        //       Note, that the `after_help` string already adds a newline to generate
-        //       an empty line before the next prompt
+        // WORKAROUND: It seems like `clap` does not add a newline after the
+        //     help output when using `print_help`. Therefore add a newline
+        //     here.  Note, that the `after_help` string already adds a newline
+        //     to generate an empty line before the next prompt
         println!("");
         return Ok(ExitCode::Success);
     }
     if matches.is_present("help_long") {
         let _ = app.print_long_help();
-        // HACK: It seems like `clap` does not add a newline after the help
-        //       output when using `print_long_help`. Therefore add a newline here
-        //       Note, that the `after_help` string already adds a newline to generate
-        //       an empty line before the next prompt
+        // WORKAROUND: It seems like `clap` does not add a newline after the
+        //     help output when using `print_long_help`. Therefore add a newline
+        //     here Note, that the `after_help` string already adds a newline to
+        //     generate an empty line before the next prompt
         println!("");
         return Ok(ExitCode::Success);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,25 @@ ow=0:or=0;38;5;16;48;5;203:no=0:ex=1;38;5;203:cd=0;38;5;203;48;5;236:mi=0;38;5;1
 ";
 
 fn run() -> Result<ExitCode> {
-    let matches = app::build_app().get_matches_from(env::args_os());
+    let mut app = app::build_app();
+    let matches = app.get_matches_from_safe_borrow(env::args_os())?;
+
+    // Print short and long help
+    if matches.is_present("help") {
+        let _ = app.print_help();
+        // HACK: It seems like `clap` does not add a newline after the help
+        //       output when using `print_help`. Therefore add a newline here.
+        println!("");
+        return Ok(ExitCode::Success);
+    }
+    if matches.is_present("help_long") {
+        let _ = app.print_long_help();
+        // HACK: It seems like `clap` does not add a newline after the help
+        //       output when using `print_long_help`. Therefore add a newline here
+        println!("");
+        return Ok(ExitCode::Success);
+    }
+
 
     // Set the current working directory of the process
     if let Some(base_directory) = matches.value_of_os("base-directory") {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 
-use regex::escape;
+use regex::{Regex, escape};
 
 use crate::testenv::TestEnv;
 
@@ -1792,4 +1792,12 @@ fn test_error_if_hidden_not_set_and_pattern_starts_with_dot() {
     te.assert_output(&["--hidden", "^\\.gitignore"], ".gitignore");
     te.assert_output(&["--hidden", "--glob", ".gitignore"], ".gitignore");
     te.assert_output(&[".gitignore"], "");
+}
+#[test]
+fn test_output_ends_with_empty_line() {
+    let (te, _) = get_test_env_with_abs_path(DEFAULT_DIRS, DEFAULT_FILES);
+    let ends_with_empty_line = Regex::new(r"[^\n]\n\n$").unwrap();
+
+    te.assert_output_matches_re(&[ "-h" ], &ends_with_empty_line);
+    te.assert_output_matches_re(&[ "--help" ], &ends_with_empty_line);
 }


### PR DESCRIPTION
This PR aims to make it more visible that the `-h` and `--help` flags do different things.

As described in https://github.com/sharkdp/fd/issues/714#issuecomment-805752730, with the changes of this PR, the `-h` and `--help` flags are separated and moved to the beginning of the `FLAGS` section. The note at the bottom has been updated and is colorized. Also an empty line is inserted after the note:

![2021-03-24--12-50-35--746](https://user-images.githubusercontent.com/2268851/112306773-75909e00-8ca0-11eb-98bd-d0a14d22bded.png)

For comparison, this is how it currently looks like:

![2021-03-24--12-46-23--853__Code](https://user-images.githubusercontent.com/2268851/112306760-70cbea00-8ca0-11eb-8768-54ef4b26a3af.png)