### PR TITLE
Adds path separator checking and hint for automatic `/` expansion 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,18 +177,21 @@ fn run() -> Result<ExitCode> {
         .value_of("path-separator")
         .map_or_else(filesystem::default_path_separator, |s| Some(s.to_owned()));
 
-    if let Some(ref sep) = path_separator {
-        if sep.len() > 1 {
-            return Err(anyhow!(
-                "A path separator must be exactly one byte, but \
+    #[cfg(windows)]
+    {
+        if let Some(ref sep) = path_separator {
+            if sep.len() > 1 {
+                return Err(anyhow!(
+                    "A path separator must be exactly one byte, but \
                  the given separator is {} bytes: '{}'.\n\
                  In some shells on Windows, '/' is automatically \
                  expanded. Try to use '//' instead.",
-                sep.len(),
-                sep
-            ));
+                    sep.len(),
+                    sep
+                ));
+            };
         };
-    };
+    }
 
     let ls_colors = if colored_output {
         Some(LsColors::from_env().unwrap_or_else(|| LsColors::from_string(DEFAULT_LS_COLORS)))

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,9 +180,9 @@ fn run() -> Result<ExitCode> {
         if sep.len() > 1 {
             return Err(anyhow!(
                 "A path separator must be exactly one byte, but \
-                 the given separator is {} bytes: {}\n\
-                 In some shells on Windows '/' is automatically \
-                 expanded. Use '//' instead.",
+                 the given separator is {} bytes: '{}'.\n\
+                 In some shells on Windows, '/' is automatically \
+                 expanded. Try to use '//' instead.",
                 sep.len(),
                 sep
             ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,8 @@ fn run() -> Result<ExitCode> {
     let path_separator = matches
         .value_of("path-separator")
         .map_or_else(filesystem::default_path_separator, |s| Some(s.to_owned()));
-    if let Some(sep) = path_separator.clone() {
+
+    if let Some(ref sep) = path_separator {
         if sep.len() > 1 {
             return Err(anyhow!(
                 "A path separator must be exactly one byte, but \

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,18 @@ fn run() -> Result<ExitCode> {
     let path_separator = matches
         .value_of("path-separator")
         .map_or_else(filesystem::default_path_separator, |s| Some(s.to_owned()));
+    if let Some(sep) = path_separator.clone() {
+        if sep.len() > 1 {
+            return Err(anyhow!(
+                "A path separator must be exactly one byte, but \
+                 the given separator is {} bytes: {}\n\
+                 In some shells on Windows '/' is automatically \
+                 expanded. Use '//' instead.",
+                sep.len(),
+                sep
+            ));
+        };
+    };
 
     let ls_colors = if colored_output {
         Some(LsColors::from_env().unwrap_or_else(|| LsColors::from_string(DEFAULT_LS_COLORS)))


### PR DESCRIPTION
Posix compatibility shells on windows like msys2 treat `\` as an escape character which makes pasting the paths from `fd`s output annoying when using the platform default path separator. The immediate solution would be to set an alias for `fd` in these shells to use `/` as the path separator using `--path-separator`. However these shells will automatically expand `/` to be the absolute path to the shell's installation directory.  This leads to some surprising results you see paths output from `fd --path-separator /` in these shells.

This patch copies ripgrep's [approach](https://github.com/BurntSushi/ripgrep/blob/9f924ee187d4c62aa6ebe4903d0cfc6507a5adb5/crates/core/args.rs#L1348) of preventing multi-byte path separators entirely and provides a hint about how to avoid the expansion (by supplying `//` instead). 