### PR TITLE
Silence unhelpful clippy warning

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -24,6 +24,7 @@ static DEFAULT_FILES: &[&str] = &[
     "e1 e2",
 ];
 
+#[allow(clippy::let_and_return)]
 fn get_absolute_root_path(env: &TestEnv) -> String {
     let path = env
         .test_root()


### PR DESCRIPTION
this keeps appearing in every single PR, so let's silence it.
```
warning: returning the result of a `let` binding from a block
  --> tests/tests.rs:41:5
   |
28 | /     let path = env
29 | |         .test_root()
30 | |         .normalize()
31 | |         .expect("absolute path")
...  |
34 | |         .expect("string")
35 | |         .to_string();
   | |_____________________- unnecessary `let` binding
...
41 |       path
   |       ^^^^
   |
   = note: `#[warn(clippy::let_and_return)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return
help: return the expression directly
   |
28 |     
29 | 
30 |     #[cfg(windows)]
31 |     #[allow(clippy::let_and_return)]
32 |     let path = path.trim_start_matches(r"\\?\").to_string();
33 | 
 ...
```