### PR TITLE
Add --no-ignore-parent flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Add new `--no-ignore-parent` flag, see #787 (@will459)
+
 ## Bugfixes
 
 - Set default path separator to `/` in MSYS, see #537 and #730 (@aswild)

--- a/src/app.rs
+++ b/src/app.rs
@@ -50,6 +50,16 @@ pub fn build_app() -> App<'static, 'static> {
                 ),
         )
         .arg(
+            Arg::with_name("no-ignore-parent")
+                .long("no-ignore-parent")
+                .overrides_with("no-ignore-parent")
+                .hidden_short_help(true)
+                .long_help(
+                    "Show search results from files and directories that would otherwise be \
+                        ignored by '.gitignore', '.ignore', or '.fdignore' files in parent directories.",
+                ),
+        )
+        .arg(
             Arg::with_name("no-global-ignore-file")
                 .long("no-global-ignore-file")
                 .hidden(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,6 +338,10 @@ fn run() -> Result<ExitCode> {
         read_vcsignore: !(matches.is_present("no-ignore")
             || matches.is_present("rg-alias-hidden-ignore")
             || matches.is_present("no-ignore-vcs")),
+        read_parent_ignore: !(matches.is_present("no-ignore")
+            || matches.is_present("rg-alias-hidden-ignore")
+            || matches.is_present("no-ignore-vcs")
+            || matches.is_present("no-ignore-parent")),
         read_global_ignore: !(matches.is_present("no-ignore")
             || matches.is_present("rg-alias-hidden-ignore")
             || matches.is_present("no-global-ignore-file")),

--- a/src/options.rs
+++ b/src/options.rs
@@ -24,6 +24,9 @@ pub struct Options {
     /// Whether to respect `.fdignore` files or not.
     pub read_fdignore: bool,
 
+    /// Whether to respect ignore files in parent directories or not.
+    pub read_parent_ignore: bool,
+
     /// Whether to respect VCS ignore files (`.gitignore`, ..) or not.
     pub read_vcsignore: bool,
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -68,7 +68,7 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<Options>) -> 
     walker
         .hidden(config.ignore_hidden)
         .ignore(config.read_fdignore)
-        .parents(config.read_fdignore || config.read_vcsignore)
+        .parents(config.read_parent_ignore)
         .git_ignore(config.read_vcsignore)
         .git_global(config.read_vcsignore)
         .git_exclude(config.read_vcsignore)


### PR DESCRIPTION
Closes #787 

Tested on my own machine and abides by any .gitignore rules in the current directory while ignoring any rules provided by the parent.  The flag works for both .gitignore and .ignore files rather than being specific to VCS or non-VCS files.