### PR TITLE
Use short options for ls command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - fd doesn't show substituted drive on Windows, see #365
 - Properly handle write errors to devices that are full, see #737
 - Use local time zone for time functions (`--change-newer-than`, `--change-older-than`), see #631 (@jacobmischka)
-- Uses short options for ls regardless of the operating system, see #783
+- Support `--list-details` on more platforms (like BusyBox), see #783
 
 ## Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fd cannot search files under a RAM disk, see #752
 - fd doesn't show substituted drive on Windows, see #365
 - Properly handle write errors to devices that are full, see #737
+- Uses short options for ls regardless of the operating system, see #783
 
 ## Changes
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ use anyhow::{anyhow, Context, Result};
 use atty::Stream;
 use globset::GlobBuilder;
 use lscolors::LsColors;
-use regex::bytes::{RegexBuilder, RegexSetBuilder};
 use normpath::PathExt;
+use regex::bytes::{RegexBuilder, RegexSetBuilder};
 
 use crate::error::print_error;
 use crate::exec::CommandTemplate;
@@ -212,9 +212,9 @@ fn run() -> Result<ExitCode> {
         let gnu_ls = |command_name| {
             vec![
                 command_name,
-                "-l",               // long listing format
-                "--human-readable", // human readable file sizes
-                "--directory",      // list directories themselves, not their contents
+                "-l", // long listing format
+                "-h", // human readable file sizes
+                "-d", // list directories themselves, not their contents
                 &color_arg,
             ]
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,6 +210,8 @@ fn run() -> Result<ExitCode> {
 
         #[allow(unused)]
         let gnu_ls = |command_name| {
+            // Note: we use short options here (instead of --long-options) to support more
+            // platforms (like BusyBox).
             vec![
                 command_name,
                 "-l", // long listing format


### PR DESCRIPTION
Closes #783 

I don't think it's possible to create a regression test as that would require complex CI environments with different `ls` versions.