### PR TITLE
Change time comparisons to exclusive by default, add `--time-inclusive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fd doesn't show substituted drive on Windows, see #365
 - Properly handle write errors to devices that are full, see #737
 - Use local time zone for time functions (`--change-newer-than`, `--change-older-than`), see #631 (@jacobmischka)
+- Change time comparisons to exclusive by default, add `--time-inclusive` for previous behavior, see #794 (@jacobmischka)
 
 ## Changes
 

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -217,7 +217,9 @@ tebibytes
 .TP
 .BI "\-\-changed-within " date|duration
 Filter results based on the file modification time.
-Files with modification times greater than or equal to the argument will be returned.
+Files with modification times greater the argument will be returned.
+If \-\-time-inclusive is also specified, files with modification times greater than or
+equal to the argument will be returned.
 The argument can be provided as a duration (\fI10h, 1d, 35min\fR) or as a specific point
 in time in either full RFC3339 format with time zone, or as a date or datetime in the
 local time zone (\fIYYYY-MM-DD\fR or \fIYYYY-MM-DD HH:MM:SS\fR).
@@ -230,7 +232,9 @@ Examples:
 .TP
 .BI "\-\-changed-before " date|duration
 Filter results based on the file modification time.
-Files with modification times less than or equal to the argument will be returned.
+Files with modification times less than the argument will be returned.
+If \-\-time-inclusive is also specified, files with modification times less than or
+equal to the argument will be returned.
 The argument can be provided as a duration (\fI10h, 1d, 35min\fR) or as a specific point
 in time in either full RFC3339 format with time zone, or as a date or datetime in the
 local time zone (\fIYYYY-MM-DD\fR or \fIYYYY-MM-DD HH:MM:SS\fR).

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -243,7 +243,7 @@ tebibytes
 .TP
 .BI "\-\-changed-within " date|duration
 Filter results based on the file modification time.
-Files with modification times greater the argument will be returned.
+Files with modification times greater than the argument will be returned.
 If \-\-time-inclusive is also specified, files with modification times greater than or
 equal to the argument will be returned.
 The argument can be provided as a duration (\fI10h, 1d, 35min\fR) or as a specific point

--- a/src/app.rs
+++ b/src/app.rs
@@ -482,6 +482,12 @@ pub fn build_app() -> App<'static, 'static> {
                 ),
         )
         .arg(
+            Arg::with_name("time-inclusive")
+                .long("time-inclusive")
+                .alias("inclusive")
+                .help("Make time comparisons inclusive (greater/less than or equal to)"),
+        )
+        .arg(
             Arg::with_name("max-results")
                 .long("max-results")
                 .takes_value(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ use anyhow::{anyhow, Context, Result};
 use atty::Stream;
 use globset::GlobBuilder;
 use lscolors::LsColors;
-use regex::bytes::{RegexBuilder, RegexSetBuilder};
 use normpath::PathExt;
+use regex::bytes::{RegexBuilder, RegexSetBuilder};
 
 use crate::error::print_error;
 use crate::exec::CommandTemplate;
@@ -301,7 +301,7 @@ fn run() -> Result<ExitCode> {
     let now = time::SystemTime::now();
     let mut time_constraints: Vec<TimeFilter> = Vec::new();
     if let Some(t) = matches.value_of("changed-within") {
-        if let Some(f) = TimeFilter::after(&now, t) {
+        if let Some(f) = TimeFilter::after(&now, t, matches.is_present("time-inclusive")) {
             time_constraints.push(f);
         } else {
             return Err(anyhow!(
@@ -311,7 +311,7 @@ fn run() -> Result<ExitCode> {
         }
     }
     if let Some(t) = matches.value_of("changed-before") {
-        if let Some(f) = TimeFilter::before(&now, t) {
+        if let Some(f) = TimeFilter::before(&now, t, matches.is_present("time-inclusive")) {
             time_constraints.push(f);
         } else {
             return Err(anyhow!(


### PR DESCRIPTION
As the names imply, `--change-newer-than` and `--change-before` now are
exclusive (`>` or `<`) by default. A new flag `--time-inclusive`
(aliased to simply `--inclusive`) is added to opt into the previous
inclusive (`>=` or `<=`) behavior.

Fixes #794