### PR TITLE
Split executable and empty file "types" into seperate "prop" flag

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -267,18 +267,38 @@ pub fn build_app() -> App<'static, 'static> {
                 ])
                 .hide_possible_values(true)
                 .help(
-                    "Filter by type: file (f), directory (d), symlink (l),\nexecutable (x), \
-                         empty (e), socket (s), pipe (p)",
+                    "Filter by type: file (f), directory (d), symlink (l),\n \
+                         socket (s), pipe (p)",
                 )
                 .long_help(
                     "Filter the search by type (multiple allowable filetypes can be specified):\n  \
                        'f' or 'file':         regular files\n  \
                        'd' or 'directory':    directories\n  \
                        'l' or 'symlink':      symbolic links\n  \
-                       'x' or 'executable':   executables\n  \
-                       'e' or 'empty':        empty files or directories\n  \
                        's' or 'socket':       socket\n  \
                        'p' or 'pipe':         named pipe (FIFO)",
+                ),
+        )
+        .arg(
+            Arg::with_name("file-prop")
+                .long("prop")
+                .short("P")
+                .multiple(true)
+                .number_of_values(1)
+                .takes_value(true)
+                .value_name("fileprop")
+                .possible_values(&[
+                    "x",
+                    "executable",
+                    "e",
+                    "empty",
+                ])
+                .hide_possible_values(true)
+                .help("Filter by property of file: empty (e), executable (x)")
+                .long_help(
+                    "Filter the search by a property of the file (multiple allowable properties can be specified):\n \
+                       'x' or 'executable':   executables\n  \
+                       'e' or 'empty':        empty files or directories",
                 ),
         )
         .arg(

--- a/src/filetypes.rs
+++ b/src/filetypes.rs
@@ -49,4 +49,17 @@ impl FileTypes {
             true
         }
     }
+
+    /// Return a FileTypes that filters to files
+    pub fn files() -> FileTypes {
+        FileTypes {
+            files: true,
+            directories: false,
+            symlinks: false,
+            sockets: false,
+            pipes: false,
+            executables_only: false,
+            empty_only: false,
+        }
+    }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1034,6 +1034,55 @@ fn test_type_empty() {
     te.assert_output(&["--type", "empty", "--type", "directory"], "dir_empty");
 }
 
+/// Test `--prop executable`
+#[cfg(unix)]
+#[test]
+fn test_prop_executable() {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .mode(0o777)
+        .open(te.test_root().join("executable-file.sh"))
+        .unwrap();
+
+    te.assert_output(&["--prop", "executable"], "executable-file.sh");
+
+    te.assert_output(
+        &["--prop", "executable", "--type", "directory"],
+        "one
+        one/two
+        one/two/three
+        one/two/three/directory_foo",
+    );
+}
+
+/// Test `--prop empty`
+#[test]
+fn test_prop_empty() {
+    let te = TestEnv::new(&["dir_empty", "dir_nonempty"], &[]);
+
+    create_file_with_size(te.test_root().join("0_bytes.foo"), 0);
+    create_file_with_size(te.test_root().join("5_bytes.foo"), 5);
+
+    create_file_with_size(te.test_root().join("dir_nonempty").join("2_bytes.foo"), 2);
+
+    te.assert_output(&["--prop", "empty"], "0_bytes.foo");
+
+    te.assert_output(
+        &["--prop", "empty", "--type", "file", "--type", "directory"],
+        "0_bytes.foo
+        dir_empty",
+    );
+
+    te.assert_output(&["--prop", "empty", "--type", "file"], "0_bytes.foo");
+
+    te.assert_output(&["--prop", "empty", "--type", "directory"], "dir_empty");
+}
+
 /// File extension (--extension)
 #[test]
 fn test_extension() {


### PR DESCRIPTION
But keep the old file types for backwards compatibility.

Fixes #823

This is a work in progress. I haven't added anything to the changelog yet, and the documentation could probably be a little better. I'm also not entirely sure if this is something we want to do.

Note that the new `--prop` options behave slightly differently than the old file types. In particular:

- If no `--type` option is given, then `empty` defaults to just empty files, not files and directories. That makes it more consistent with the way `executable` works, seems more useful to me, and is simpler to implement, but I could be convinced to change this to default to files and directories.
- The `executables` property no longer always includes `files`, so you can search for just executable directories. I'm not really sure when that would be useful, but it seems more consistent and logical to me.