### PR TITLE
Faster colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - File metadata is now cached between the different filters that require it (e.g. `--owner`,
   `--size`), reducing the number of `stat` syscalls when multiple filters are used; see #863
 
+- Colorized output is now significantly faster, see #720 and #853 (@tavianator)
+
 ## Features
 - Don't buffer command output from `--exec` when using a single thread. See #522
 


### PR DESCRIPTION
This can give a significant performance benefit:

    $ hyperfine ./fd-{before,after}" --color=always -HI -j1 --search-path=../../linux >/dev/null"
    Benchmark #1: ./fd-before --color=always -HI -j1 --search-path=../../linux >/dev/null
      Time (mean ± σ):     802.3 ms ±   4.8 ms    [User: 360.0 ms, System: 531.7 ms]
      Range (min … max):   795.8 ms … 808.9 ms    10 runs
 
    Benchmark #2: ./fd-after --color=always -HI -j1 --search-path=../../linux >/dev/null
      Time (mean ± σ):     263.3 ms ±   3.0 ms    [User: 166.4 ms, System: 190.0 ms]
      Range (min … max):   259.0 ms … 268.0 ms    11 runs
 
    Summary
      './fd-after --color=always -HI -j1 --search-path=../../linux >/dev/null' ran
        3.05 ± 0.04 times faster than './fd-before --color=always -HI -j1 --search-path=../../linux >/dev/null'

Fixes #720.  On the other hand, it does lose the distinct colors for 
symlinks along the path, as you mentioned in
https://github.com/sharkdp/fd/issues/720#issuecomment-778680554.
