### PR TITLE
Added missing help messages to various options

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -44,6 +44,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("no-ignore-vcs")
                 .overrides_with("no-ignore-vcs")
                 .hidden_short_help(true)
+                .help("Do not respect .gitignore files")
                 .long_help(
                     "Show search results from files and directories that would otherwise be \
                          ignored by '.gitignore' files.",
@@ -54,6 +55,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("no-ignore-parent")
                 .overrides_with("no-ignore-parent")
                 .hidden_short_help(true)
+                .help("Do not respect .(git|fd)ignore files in parent directories")
                 .long_help(
                     "Show search results from files and directories that would otherwise be \
                         ignored by '.gitignore', '.ignore', or '.fdignore' files in parent directories.",
@@ -63,6 +65,7 @@ pub fn build_app() -> App<'static, 'static> {
             Arg::with_name("no-global-ignore-file")
                 .long("no-global-ignore-file")
                 .hidden(true)
+                .help("Do not respect the global ignore file")
                 .long_help("Do not respect the global ignore file."),
         )
         .arg(
@@ -71,6 +74,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("unrestricted")
                 .multiple(true)
                 .hidden_short_help(true)
+                .help("Alias for '--no-ignore', and '--hidden' when given twice")
                 .long_help(
                     "Alias for '--no-ignore'. Can be repeated. '-uu' is an alias for \
                          '--no-ignore --hidden'.",
@@ -114,6 +118,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("regex")
                 .overrides_with_all(&["glob", "regex"])
                 .hidden_short_help(true)
+                .help("Regular-expression based search (default)")
                 .long_help(
                     "Perform a regular-expression based search (default). This can be used to \
                          override --glob.",
@@ -126,6 +131,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .alias("literal")
                 .overrides_with("fixed-strings")
                 .hidden_short_help(true)
+                .help("Treat pattern as literal string instead of regex")
                 .long_help(
                     "Treat the pattern as a literal string instead of a regular expression. Note \
                      that this also performs substring comparison. If you want to match on an \
@@ -210,6 +216,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("maxdepth")
                 .hidden(true)
                 .takes_value(true)
+                .help("Set maximum search depth (default: none)")
         )
         .arg(
             Arg::with_name("min-depth")
@@ -217,6 +224,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .takes_value(true)
                 .value_name("depth")
                 .hidden_short_help(true)
+                .help("Only show results starting at given depth")
                 .long_help(
                     "Only show search results starting at the given depth. \
                      See also: '--max-depth' and '--exact-depth'",
@@ -229,6 +237,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .value_name("depth")
                 .hidden_short_help(true)
                 .conflicts_with_all(&["max-depth", "min-depth"])
+                .help("Only show results at exact given depth")
                 .long_help(
                     "Only show search results at the exact given depth. This is an alias for \
                      '--min-depth <depth> --max-depth <depth>'.",
@@ -239,6 +248,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("prune")
                 .conflicts_with_all(&["size", "exact-depth"])
                 .hidden_short_help(true)
+                .help("Do not traverse into matching directories")
                 .long_help("Do not traverse into matching directories.")
         )
         .arg(
@@ -381,6 +391,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .number_of_values(1)
                 .multiple(true)
                 .hidden_short_help(true)
+                .help("Add custom ignore-file in '.gitignore' format")
                 .long_help(
                     "Add a custom ignore-file in '.gitignore' format. These files have a low \
                          precedence.",
@@ -409,6 +420,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .takes_value(true)
                 .value_name("num")
                 .hidden_short_help(true)
+                .help("Set number of threads")
                 .long_help(
                     "Set number of threads to use for searching & executing (default: number \
                          of available CPU cores)",
@@ -422,7 +434,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .number_of_values(1)
                 .allow_hyphen_values(true)
                 .multiple(true)
-                .help("Limit results based on the size of files.")
+                .help("Limit results based on the size of files")
                 .long_help(
                     "Limit results based on the size of files using the format <+-><NUM><UNIT>.\n   \
                         '+': file size must be greater than or equal to this\n   \
@@ -447,6 +459,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("max-buffer-time")
                 .takes_value(true)
                 .hidden(true)
+                .help("Milliseconds to buffer before streaming search results to console")
                 .long_help(
                     "Amount of time in milliseconds to buffer, before streaming the search \
                          results to the console.",
@@ -503,6 +516,7 @@ pub fn build_app() -> App<'static, 'static> {
                 // the files they saw in the previous search.
                 .conflicts_with_all(&["exec", "exec-batch", "list-details"])
                 .hidden_short_help(true)
+                .help("Limit number of search results")
                 .long_help("Limit the number of search results to 'count' and quit immediately."),
         )
         .arg(
@@ -511,6 +525,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .hidden_short_help(true)
                 .overrides_with("max-results")
                 .conflicts_with_all(&["exec", "exec-batch", "list-details"])
+                .help("Limit search to a single result")
                 .long_help("Limit the search to a single result and quit immediately. \
                                 This is an alias for '--max-results=1'.")
         )
@@ -521,6 +536,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .alias("has-results")
                 .hidden_short_help(true)
                 .conflicts_with_all(&["exec", "exec-batch", "list-details", "max-results"])
+                .help("Print nothing, exit code 0 if match found, 1 otherwise")
                 .long_help(
                     "When the flag is present, the program does not print anything and will \
                      return with an exit code of 0 if there is at least one match. Otherwise, the \
@@ -533,6 +549,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("show-errors")
                 .hidden_short_help(true)
                 .overrides_with("show-errors")
+                .help("Show filesystem errors")
                 .long_help(
                     "Enable the display of filesystem errors for situations such as \
                          insufficient permissions or dead symlinks.",
@@ -545,6 +562,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .value_name("path")
                 .number_of_values(1)
                 .hidden_short_help(true)
+                .help("Change current working directory")
                 .long_help(
                     "Change the current working directory of fd to the provided path. This \
                          means that search results will be shown with respect to the given base \
@@ -568,6 +586,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .value_name("separator")
                 .long("path-separator")
                 .hidden_short_help(true)
+                .help("Set path separator when printing file paths")
                 .long_help(
                     "Set the path separator to use when printing file paths. The default is \
                          the OS-specific separator ('/' on Unix, '\\' on Windows).",
@@ -590,6 +609,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .multiple(true)
                 .hidden_short_help(true)
                 .number_of_values(1)
+                .help("Provide paths to search as an alternative to the positional <path>")
                 .long_help(
                     "Provide paths to search as an alternative to the positional <path> \
                          argument. Changes the usage to `fd [FLAGS/OPTIONS] --search-path <path> \
@@ -626,6 +646,7 @@ pub fn build_app() -> App<'static, 'static> {
                 .long("one-file-system")
                 .aliases(&["mount", "xdev"])
                 .hidden_short_help(true)
+                .help("Do not descend into a different file system")
                 .long_help(
                     "By default, fd will traverse the file system tree as far as other options \
                      dictate. With this flag, fd ensures that it does not descend into a \


### PR DESCRIPTION
This PR adds missing help messages to various command line options.

Despite they have `hidden_short_help` set to `true`, a short help message is still useful for auto-generated completions. For example the fish shell auto completions were lacking half of the descriptions.