### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ You can install [the fd-find package](https://www.freshports.org/sysutils/fd) fr
 pkg install fd-find
 ```
 
-### From NPM
+### From npm
 
 On linux and macOS, you can install the [fd-find](https://npm.im/fd-find) package:
 

--- a/contrib/completion/_fd
+++ b/contrib/completion/_fd
@@ -220,7 +220,7 @@ _fd() {
 _fd "$@"
 
 # ------------------------------------------------------------------------------
-# Copyright (c) 2011 Github zsh-users - http://github.com/zsh-users
+# Copyright (c) 2011 GitHub zsh-users - http://github.com/zsh-users
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
A couple of minor typo/capitalization fixes: `Github` -> `GitHub` and `NPM` -> `npm`.