### PR TITLE
walk: Add a cache for DirEntry metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Upcoming release
 
+## Performance improvements
+
+- File metadata is now cached between the different filters that require it (e.g. `--owner`,
+  `--size`), reducing the number of `stat` syscalls when multiple filters are used; see #863
+
 ## Features
 - Don't buffer command output from `--exec` when using a single thread. See #522
 
@@ -15,6 +20,8 @@
 - Properly handle write errors to devices that are full, see #737
 - Use local time zone for time functions (`--change-newer-than`, `--change-older-than`), see #631 (@jacobmischka)
 - Support `--list-details` on more platforms (like BusyBox), see #783
+- The filters `--owner`, `--size`, and `--changed-{within,before}` now apply to symbolic links
+  themselves, rather than the link target, except when `--follow` is specified; see #863
 
 ## Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "lscolors",
  "normpath",
  "num_cpus",
+ "once_cell",
  "regex",
  "regex-syntax",
  "tempdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ anyhow = "1.0"
 dirs-next = "2.0"
 normpath = "0.3"
 chrono = "0.4"
+once_cell = "1.8.0"
 
 [dependencies.clap]
 version = "2.31.3"

--- a/src/filetypes.rs
+++ b/src/filetypes.rs
@@ -37,7 +37,7 @@ impl FileTypes {
                 || (self.executables_only
                     && !entry
                         .metadata()
-                        .map(|m| filesystem::is_executable(&m))
+                        .map(|m| filesystem::is_executable(m))
                         .unwrap_or(false))
                 || (self.empty_only && !filesystem::is_empty(entry))
                 || !(entry_type.is_file()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1652,9 +1652,22 @@ fn create_file_with_modified<P: AsRef<Path>>(path: P, duration_in_secs: u64) {
     filetime::set_file_times(&path, ft, ft).expect("time modification failed");
 }
 
+#[cfg(test)]
+fn remove_symlink<P: AsRef<Path>>(path: P) {
+    #[cfg(unix)]
+    fs::remove_file(path).expect("remove symlink");
+
+    // On Windows, symlinks remember whether they point to files or directories, so try both
+    #[cfg(windows)]
+    fs::remove_file(path.as_ref())
+        .or_else(|_| fs::remove_dir(path.as_ref()))
+        .expect("remove symlink");
+}
+
 #[test]
 fn test_modified_relative() {
     let te = TestEnv::new(&[], &[]);
+    remove_symlink(te.test_root().join("symlink"));
     create_file_with_modified(te.test_root().join("foo_0_now"), 0);
     create_file_with_modified(te.test_root().join("bar_1_min"), 60);
     create_file_with_modified(te.test_root().join("foo_10_min"), 600);
@@ -1692,8 +1705,9 @@ fn change_file_modified<P: AsRef<Path>>(path: P, iso_date: &str) {
 }
 
 #[test]
-fn test_modified_asolute() {
+fn test_modified_absolute() {
     let te = TestEnv::new(&[], &["15mar2018", "30dec2017"]);
+    remove_symlink(te.test_root().join("symlink"));
     change_file_modified(te.test_root().join("15mar2018"), "2018-03-15T12:00:00Z");
     change_file_modified(te.test_root().join("30dec2017"), "2017-12-30T23:59:00Z");
 


### PR DESCRIPTION
This is a reimplementation of https://github.com/sharkdp/fd/pull/402, using `once_cell::unsync::OnceCell` instead of a hand-rolled `Lazy` type.  It gives some performance benefits when multiple filters require metadata:

```
$ hyperfine ./fd-{before,after}" -j1 --search-path=../../linux --size=+1k --owner=tavianator >/dev/null"
Benchmark #1: ./fd-before -j1 --search-path=../../linux --size=+1k --owner=tavianator >/dev/null
  Time (mean ± σ):     449.3 ms ±   5.1 ms    [User: 246.9 ms, System: 354.8 ms]
  Range (min … max):   441.1 ms … 455.1 ms    10 runs
 
Benchmark #2: ./fd-after -j1 --search-path=../../linux --size=+1k --owner=tavianator >/dev/null
  Time (mean ± σ):     392.5 ms ±   3.8 ms    [User: 230.1 ms, System: 287.9 ms]
  Range (min … max):   388.0 ms … 399.3 ms    10 runs
 
Summary
  './fd-after -j1 --search-path=../../linux --size=+1k --owner=tavianator >/dev/null' ran
    1.14 ± 0.02 times faster than './fd-before -j1 --search-path=../../linux --size=+1k --owner=tavianator >/dev/null'
```

without much affect on perf in other cases:

```
$ hyperfine ./fd-{before,after}" -j1 --search-path=../../linux --size=+1k >/dev/null"
Benchmark #1: ./fd-before -j1 --search-path=../../linux --size=+1k >/dev/null
  Time (mean ± σ):     383.8 ms ±   5.6 ms    [User: 212.7 ms, System: 296.1 ms]
  Range (min … max):   377.5 ms … 393.3 ms    10 runs
 
Benchmark #2: ./fd-after -j1 --search-path=../../linux --size=+1k >/dev/null
  Time (mean ± σ):     385.2 ms ±   4.1 ms    [User: 228.4 ms, System: 280.5 ms]
  Range (min … max):   378.3 ms … 393.3 ms    10 runs
 
Summary
  './fd-before -j1 --search-path=../../linux --size=+1k >/dev/null' ran
    1.00 ± 0.02 times faster than './fd-after -j1 --search-path=../../linux --size=+1k >/dev/null'
```

`strace` confirms a reduction in `statx()` calls:

```
$ strace -fc ./fd-before -j1 --search-path=../../linux --size=+1k --owner=tavianator >/dev/null
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
...
 18.32    0.927790           3    254795     24015 statx
...
$ strace -fc ./fd-after -j1 --search-path=../../linux --size=+1k --owner=tavianator >/dev/null
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
...
 18.92    0.954145           5    181209     24015 statx
...
```

Together with #853 it would be possible to share the `Metadata` with the colorization which would be an additional benefit, but it's not done in this PR.