### PR TITLE
fix zsh completion

### DIFF
--- a/contrib/completion/_fd
+++ b/contrib/completion/_fd
@@ -138,7 +138,7 @@ _fd() {
     + '(exec-cmds)' # execute command
     '(long-listing max-results)'{-x+,--exec=}'[execute command for each search result]:command: _command_names -e:*\;::program arguments: _normal'
     '(long-listing max-results)'{-X+,--exec-batch=}'[execute command for all search results at once]:command: _command_names -e:*\;::program arguments: _normal'
-    '(long-listing max-results)'{--batch-size=}'[max number of args for each -X call]:size'
+    '(long-listing max-results)--batch-size=[max number of args for each -X call]:size'
 
     + other
     '!(--max-buffer-time)--max-buffer-time=[set amount of time to buffer before showing output]:time (ms)'


### PR DESCRIPTION
fix following error
```
$ fd name <TAB>
_arguments:comparguments:319: invalid argument: (long-listing max-results){--batch-size=}[max number of args for each -X call]:size
_arguments:comparguments:319: invalid argument: (long-listing max-results){--batch-size=}[max number of args for each -X call]:size
_arguments:comparguments:319: invalid argument: (long-listing max-results){--batch-size=}[max number of args for each -X call]:size
```