### PR TITLE
walk: Encapsulate the buffering behavior in a struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +174,7 @@ dependencies = [
  "atty",
  "chrono",
  "clap",
+ "crossbeam-channel",
  "ctrlc",
  "diff",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ dirs-next = "2.0"
 normpath = "0.3"
 chrono = "0.4"
 once_cell = "1.8.0"
+crossbeam-channel = "0.5.1"
 
 [dependencies.clap]
 version = "2.31.3"

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
-use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
+
+use crossbeam_channel::Receiver;
 
 use crate::error::print_error;
 use crate::exit_codes::{merge_exitcodes, ExitCode};

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -4,13 +4,13 @@ use std::io;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 use std::{borrow::Cow, io::Write};
 
 use anyhow::{anyhow, Result};
+use crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender};
 use ignore::overrides::OverrideBuilder;
 use ignore::{self, WalkBuilder};
 use once_cell::unsync::OnceCell;
@@ -55,7 +55,7 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<Config>) -> R
     let first_path_buf = path_iter
         .next()
         .expect("Error: Path vector can not be empty");
-    let (tx, rx) = channel();
+    let (tx, rx) = unbounded();
 
     let mut override_builder = OverrideBuilder::new(first_path_buf.as_path());
 
@@ -219,11 +219,7 @@ impl<W: Write> ReceiverBuffer<W> {
         match self.mode {
             ReceiverMode::Buffering => {
                 // Wait at most until we should switch to streaming
-                let now = Instant::now();
-                self.deadline
-                    .checked_duration_since(now)
-                    .ok_or(RecvTimeoutError::Timeout)
-                    .and_then(|t| self.rx.recv_timeout(t))
+                self.rx.recv_deadline(self.deadline)
             }
             ReceiverMode::Streaming => {
                 // Wait however long it takes for a result


### PR DESCRIPTION
The new ReceiverBuffer struct allows us to factor out the receiver
implementation into a number of helper methods.  The new implementation
uses rx.{recv,recv_timeout} instead of a for loop, which enables us to
switch to streaming mode at the right time without waiting for more
results.

Fixes #868.
