### PR TITLE
fix: disable jemalloc on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ libc = "0.2"
 # FIXME: Re-enable jemalloc on macOS
 # jemalloc is currently disabled on macOS due to a bug in jemalloc in combination with macOS
 # Catalina. See https://github.com/sharkdp/fd/issues/498 for details.
-[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_env = "musl")))'.dependencies]
+[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_os = "freebsd"), not(target_env = "musl")))'.dependencies]
 jemallocator = "0.3.0"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ use crate::regex_helper::{pattern_has_uppercase_char, pattern_matches_strings_wi
     not(windows),
     not(target_os = "android"),
     not(target_os = "macos"),
+    not(target_os = "freebsd"),
     not(target_env = "musl")
 ))]
 #[global_allocator]


### PR DESCRIPTION
As jemalloc is the default system allocator on FreeBSD and the
jemalloc-sys crate failes to compile on FreeBSD, this fixes the build on
FreeBSD.