### PR TITLE
A couple of minor recommendations from the Code Quality action

### DIFF
--- a/src/filetypes.rs
+++ b/src/filetypes.rs
@@ -2,6 +2,7 @@ use crate::filesystem;
 use crate::walk;
 
 /// Whether or not to show
+#[derive(Default)]
 pub struct FileTypes {
     pub files: bool,
     pub directories: bool,
@@ -10,20 +11,6 @@ pub struct FileTypes {
     pub pipes: bool,
     pub executables_only: bool,
     pub empty_only: bool,
-}
-
-impl Default for FileTypes {
-    fn default() -> FileTypes {
-        FileTypes {
-            files: false,
-            directories: false,
-            symlinks: false,
-            sockets: false,
-            pipes: false,
-            executables_only: false,
-            empty_only: false,
-        }
-    }
 }
 
 impl FileTypes {
@@ -37,7 +24,7 @@ impl FileTypes {
                 || (self.executables_only
                     && !entry
                         .metadata()
-                        .map(|m| filesystem::is_executable(m))
+                        .map(filesystem::is_executable)
                         .unwrap_or(false))
                 || (self.empty_only && !filesystem::is_empty(entry))
                 || !(entry_type.is_file()


### PR DESCRIPTION
use derive for a Default impl, and use a function directly instead of
needlessly wrapping it in a closure