### PR TITLE
fix: disable jemalloc on risc-v target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ libc = "0.2"
 # FIXME: Re-enable jemalloc on macOS
 # jemalloc is currently disabled on macOS due to a bug in jemalloc in combination with macOS
 # Catalina. See https://github.com/sharkdp/fd/issues/498 for details.
-[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_os = "freebsd"), not(target_env = "musl")))'.dependencies]
+[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_os = "freebsd"), not(target_env = "musl"), not(target_arch = "riscv64")))'.dependencies]
 jemallocator = {version = "0.3.0", optional = true}
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ use crate::regex_helper::{pattern_has_uppercase_char, pattern_matches_strings_wi
     not(target_os = "macos"),
     not(target_os = "freebsd"),
     not(target_env = "musl"),
+    not(target_arch = "riscv64"),
     feature = "use-jemalloc"
 ))]
 #[global_allocator]


### PR DESCRIPTION
`jemallocator` does not support risc-v and fails the compilation.
This fixes build for risc-v.

Ping @xctan as the original patch author