### PR TITLE
add filters for creation and access time

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -594,6 +594,80 @@ pub fn build_app() -> App<'static, 'static> {
                 ),
         )
         .arg(
+            Arg::with_name("accessed-within")
+                .long("accessed-within")
+                .alias("accessed-after")
+                .alias("access-newer-than")
+                .takes_value(true)
+                .value_name("date|dur")
+                .number_of_values(1)
+                .help("Filter by file access time (newer than)")
+                .long_help(
+                    "Filter results based on the file access time. The argument can be provided \
+                     as a specific point in time (YYYY-MM-DD HH:MM:SS) or as a duration (10h, 1d, 35min). \
+                     If the time is not specified, it defaults to 00:00:00. \
+                     '--accessed-newer-than' or '--accessed-after' can be used as an alias.\n\
+                     Examples:\n    \
+                         --accessed-within 2weeks\n    \
+                         --access-newer-than '2018-10-27 10:00:00'",
+                ),
+        )
+        .arg(
+            Arg::with_name("accessed-before")
+                .long("accessed-before")
+                .alias("access-older-than")
+                .takes_value(true)
+                .value_name("date|dur")
+                .number_of_values(1)
+                .help("Filter by file access time (older than)")
+                .long_help(
+                    "Filter results based on the file access time. The argument can be provided \
+                     as a specific point in time (YYYY-MM-DD HH:MM:SS) or as a duration (10h, 1d, 35min). \
+                     If the time is not specified, it defaults to 00:00:00. \
+                     '--access-older-than' can be used as an alias.\n\
+                     Examples:\n    \
+                         --accessed-before 2weeks\n    \
+                         --access-older-than '2018-10-27 10:00:00'",
+                ),
+        )
+        .arg(
+            Arg::with_name("created-within")
+                .long("created-within")
+                .alias("created-after")
+                .alias("creation-newer-than")
+                .takes_value(true)
+                .value_name("date|dur")
+                .number_of_values(1)
+                .help("Filter by file creation time (newer than)")
+                .long_help(
+                    "Filter results based on the file creation time. The argument can be provided \
+                     as a specific point in time (YYYY-MM-DD HH:MM:SS) or as a duration (10h, 1d, 35min). \
+                     If the time is not specified, it defaults to 00:00:00. \
+                     '--creation-newer-than' or '--created-after' can be used as an alias.\n\
+                     Examples:\n    \
+                         --created-within 2weeks\n    \
+                         --creation-newer-than '2018-10-27 10:00:00'",
+                ),
+        )
+        .arg(
+            Arg::with_name("created-before")
+                .long("created-before")
+                .alias("creation-older-than")
+                .takes_value(true)
+                .value_name("date|dur")
+                .number_of_values(1)
+                .help("Filter by file creation time (older than)")
+                .long_help(
+                    "Filter results based on the file creation time. The argument can be provided \
+                     as a specific point in time (YYYY-MM-DD HH:MM:SS) or as a duration (10h, 1d, 35min). \
+                     If the time is not specified, it defaults to 00:00:00. \
+                     '--creation-older-than' can be used as an alias.\n\
+                     Examples:\n    \
+                         --created-before 2weeks\n    \
+                         --creation-older-than '2018-10-27 10:00:00'",
+                ),
+        )
+        .arg(
             Arg::with_name("max-results")
                 .long("max-results")
                 .takes_value(true)

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,5 +1,5 @@
 pub use self::size::SizeFilter;
-pub use self::time::TimeFilter;
+pub use self::time::{TimeFilter, TimeFilterKind, TimeRange};
 
 #[cfg(unix)]
 pub use self::owner::OwnerFilter;

--- a/src/filter/time.rs
+++ b/src/filter/time.rs
@@ -2,16 +2,19 @@ use chrono::{offset::TimeZone, DateTime, Local, NaiveDate};
 
 use std::time::SystemTime;
 
-/// Filter based on time ranges.
 #[derive(Debug, PartialEq)]
-pub enum TimeFilter {
+pub enum TimeRange {
     Before(SystemTime),
     After(SystemTime),
 }
 
-impl TimeFilter {
-    fn from_str(ref_time: &SystemTime, s: &str) -> Option<SystemTime> {
-        humantime::parse_duration(s)
+impl TimeRange {
+    pub fn from_str(
+        ref_time: &SystemTime,
+        s: &str,
+        variant: fn(SystemTime) -> TimeRange,
+    ) -> Option<Self> {
+        let time = humantime::parse_duration(s)
             .map(|duration| *ref_time - duration)
             .ok()
             .or_else(|| {
@@ -26,21 +29,66 @@ impl TimeFilter {
                     })
                     .or_else(|| Local.datetime_from_str(s, "%F %T").ok())
                     .map(|dt| dt.into())
-            })
+            })?;
+        Some(variant(time))
     }
 
-    pub fn before(ref_time: &SystemTime, s: &str) -> Option<TimeFilter> {
-        TimeFilter::from_str(ref_time, s).map(TimeFilter::Before)
+    #[cfg(test)]
+    fn after(ref_time: &SystemTime, s: &str) -> Option<Self> {
+        Self::from_str(ref_time, s, Self::After)
     }
 
-    pub fn after(ref_time: &SystemTime, s: &str) -> Option<TimeFilter> {
-        TimeFilter::from_str(ref_time, s).map(TimeFilter::After)
+    #[cfg(test)]
+    fn before(ref_time: &SystemTime, s: &str) -> Option<Self> {
+        Self::from_str(ref_time, s, Self::Before)
     }
 
     pub fn applies_to(&self, t: &SystemTime) -> bool {
         match self {
-            TimeFilter::Before(limit) => t < limit,
-            TimeFilter::After(limit) => t > limit,
+            TimeRange::Before(limit) => t < limit,
+            TimeRange::After(limit) => t > limit,
+        }
+    }
+}
+
+/// Which file time to filter on.
+#[derive(Debug, PartialEq)]
+pub enum TimeFilterKind {
+    Modified,
+    Accessed,
+    Created,
+}
+
+/// Filter based on time ranges.
+#[derive(Debug, PartialEq)]
+pub struct TimeFilter {
+    kind: TimeFilterKind,
+    range: TimeRange,
+}
+
+impl TimeFilter {
+    pub fn new(
+        kind: TimeFilterKind,
+        variant: fn(SystemTime) -> TimeRange,
+        text: &str,
+        ref_time: &SystemTime,
+    ) -> Option<Self> {
+        Some(Self {
+            kind,
+            range: TimeRange::from_str(ref_time, text, variant)?,
+        })
+    }
+
+    pub fn applies_to(&self, m: &std::fs::Metadata) -> bool {
+        let res = match self.kind {
+            TimeFilterKind::Modified => m.modified(),
+            TimeFilterKind::Accessed => m.accessed(),
+            TimeFilterKind::Created => m.created(),
+        };
+        if let Ok(time) = res {
+            self.range.applies_to(&time)
+        } else {
+            false
         }
     }
 }
@@ -57,55 +105,55 @@ mod tests {
             .unwrap()
             .into();
 
-        assert!(TimeFilter::after(&ref_time, "1min")
+        assert!(TimeRange::after(&ref_time, "1min")
             .unwrap()
             .applies_to(&ref_time));
-        assert!(!TimeFilter::before(&ref_time, "1min")
+        assert!(!TimeRange::before(&ref_time, "1min")
             .unwrap()
             .applies_to(&ref_time));
 
         let t1m_ago = ref_time - Duration::from_secs(60);
-        assert!(!TimeFilter::after(&ref_time, "30sec")
+        assert!(!TimeRange::after(&ref_time, "30sec")
             .unwrap()
             .applies_to(&t1m_ago));
-        assert!(TimeFilter::after(&ref_time, "2min")
+        assert!(TimeRange::after(&ref_time, "2min")
             .unwrap()
             .applies_to(&t1m_ago));
 
-        assert!(TimeFilter::before(&ref_time, "30sec")
+        assert!(TimeRange::before(&ref_time, "30sec")
             .unwrap()
             .applies_to(&t1m_ago));
-        assert!(!TimeFilter::before(&ref_time, "2min")
+        assert!(!TimeRange::before(&ref_time, "2min")
             .unwrap()
             .applies_to(&t1m_ago));
 
         let t10s_before = "2010-10-10 10:10:00";
-        assert!(!TimeFilter::before(&ref_time, t10s_before)
+        assert!(!TimeRange::before(&ref_time, t10s_before)
             .unwrap()
             .applies_to(&ref_time));
-        assert!(TimeFilter::before(&ref_time, t10s_before)
+        assert!(TimeRange::before(&ref_time, t10s_before)
             .unwrap()
             .applies_to(&t1m_ago));
 
-        assert!(TimeFilter::after(&ref_time, t10s_before)
+        assert!(TimeRange::after(&ref_time, t10s_before)
             .unwrap()
             .applies_to(&ref_time));
-        assert!(!TimeFilter::after(&ref_time, t10s_before)
+        assert!(!TimeRange::after(&ref_time, t10s_before)
             .unwrap()
             .applies_to(&t1m_ago));
 
         let same_day = "2010-10-10";
-        assert!(!TimeFilter::before(&ref_time, same_day)
+        assert!(!TimeRange::before(&ref_time, same_day)
             .unwrap()
             .applies_to(&ref_time));
-        assert!(!TimeFilter::before(&ref_time, same_day)
+        assert!(!TimeRange::before(&ref_time, same_day)
             .unwrap()
             .applies_to(&t1m_ago));
 
-        assert!(TimeFilter::after(&ref_time, same_day)
+        assert!(TimeRange::after(&ref_time, same_day)
             .unwrap()
             .applies_to(&ref_time));
-        assert!(TimeFilter::after(&ref_time, same_day)
+        assert!(TimeRange::after(&ref_time, same_day)
             .unwrap()
             .applies_to(&t1m_ago));
 
@@ -114,17 +162,17 @@ mod tests {
             .into();
         let t1m_ago = ref_time - Duration::from_secs(60);
         let t10s_before = "2010-10-10T10:10:00+00:00";
-        assert!(!TimeFilter::before(&ref_time, t10s_before)
+        assert!(!TimeRange::before(&ref_time, t10s_before)
             .unwrap()
             .applies_to(&ref_time));
-        assert!(TimeFilter::before(&ref_time, t10s_before)
+        assert!(TimeRange::before(&ref_time, t10s_before)
             .unwrap()
             .applies_to(&t1m_ago));
 
-        assert!(TimeFilter::after(&ref_time, t10s_before)
+        assert!(TimeRange::after(&ref_time, t10s_before)
             .unwrap()
             .applies_to(&ref_time));
-        assert!(!TimeFilter::after(&ref_time, t10s_before)
+        assert!(!TimeRange::after(&ref_time, t10s_before)
             .unwrap()
             .applies_to(&t1m_ago));
     }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -598,12 +598,10 @@ fn spawn_senders(
             if !config.time_constraints.is_empty() {
                 let mut matched = false;
                 if let Some(metadata) = entry.metadata() {
-                    if let Ok(modified) = metadata.modified() {
-                        matched = config
-                            .time_constraints
-                            .iter()
-                            .all(|tf| tf.applies_to(&modified));
-                    }
+                    matched = config
+                        .time_constraints
+                        .iter()
+                        .all(|tf| tf.applies_to(metadata));
                 }
                 if !matched {
                     return ignore::WalkState::Continue;


### PR DESCRIPTION
This generalizes the `TimeFilter` type to operate on different time attributes, and adds support for creation and access times, in addition to the modification time already supported.

Creation time is especially nice because it's not supported by GNU Find on Linux -- the option is there, but only works on BSD systems. This implementation does, and will work on whatever systems and filesystems the [`std::fs::Metadata::created()`](https://doc.rust-lang.org/std/fs/struct.Metadata.html#method.created) function supports. :)