### PR TITLE
Fix logic for --no-ignore-parent

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -260,10 +260,7 @@ fn construct_config(matches: clap::ArgMatches, pattern_regex: &str) -> Result<Co
         read_vcsignore: !(matches.is_present("no-ignore")
             || matches.is_present("rg-alias-hidden-ignore")
             || matches.is_present("no-ignore-vcs")),
-        read_parent_ignore: !(matches.is_present("no-ignore")
-            || matches.is_present("rg-alias-hidden-ignore")
-            || matches.is_present("no-ignore-vcs")
-            || matches.is_present("no-ignore-parent")),
+        read_parent_ignore: !matches.is_present("no-ignore-parent"),
         read_global_ignore: !(matches.is_present("no-ignore")
             || matches.is_present("rg-alias-hidden-ignore")
             || matches.is_present("no-global-ignore-file")),

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -72,7 +72,7 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<Config>) -> R
     walker
         .hidden(config.ignore_hidden)
         .ignore(config.read_fdignore)
-        .parents(config.read_parent_ignore)
+        .parents(config.read_parent_ignore && (config.read_fdignore || config.read_vcsignore))
         .git_ignore(config.read_vcsignore)
         .git_global(config.read_vcsignore)
         .git_exclude(config.read_vcsignore)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -614,6 +614,22 @@ fn test_no_ignore_vcs() {
     );
 }
 
+/// Test that --no-ignore-vcs still respects .fdignored in parent directory
+#[test]
+fn test_no_ignore_vcs_child_dir() {
+    let te = TestEnv::new(
+        &["inner"],
+        &["inner/fdignored.foo", "inner/foo", "inner/gitignored.foo"],
+    );
+
+    te.assert_output_subdirectory(
+        "inner",
+        &["--no-ignore-vcs", "foo"],
+        "./foo
+        ./gitignored.foo",
+    );
+}
+
 /// Custom ignore files (--ignore-file)
 #[test]
 fn test_custom_ignore_files() {


### PR DESCRIPTION
Make sure that using `--no-ignore-vcs` or `--no-ignore` don't also
enable `--no-ignore-parent`. So that if `--no-ignore-vcs` is enabled, it
continues to respect .fdignore and .ignore in the parent directories.

Fixes: #907
Fixes: #901