### PR TITLE
Allow use to disable jemalloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ libc = "0.2"
 # jemalloc is currently disabled on macOS due to a bug in jemalloc in combination with macOS
 # Catalina. See https://github.com/sharkdp/fd/issues/498 for details.
 [target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_os = "freebsd"), not(target_env = "musl")))'.dependencies]
-jemallocator = "0.3.0"
+jemallocator = {version = "0.3.0", optional = true}
 
 [dev-dependencies]
 diff = "0.1"
@@ -77,3 +77,7 @@ test-case = "1.2"
 [profile.release]
 lto = true
 codegen-units = 1
+
+[features]
+use-jemalloc = ["jemallocator"]
+default = ["use-jemalloc"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,8 @@ use crate::regex_helper::{pattern_has_uppercase_char, pattern_matches_strings_wi
     not(target_os = "android"),
     not(target_os = "macos"),
     not(target_os = "freebsd"),
-    not(target_env = "musl")
+    not(target_env = "musl"),
+    feature = "use-jemalloc"
 ))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;


### PR DESCRIPTION
jemalloc will require special flags on devices where page size is not 4K. With default options fd will not work on a Mac Mini M1 where hardware only allow 16K paging size. This commit will allow the user to turn off jemalloc (using --no-default-features) under special circumstances where jemalloc is not usable.