### PR TITLE
Make `--full-path` switch on automatically

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,9 @@ fn construct_config(matches: clap::ArgMatches, pattern_regex: &str) -> Result<Co
     // Search full path if the pattern contains a path separator, even if the flag was not set.
     // But only do so for hand-written patterns.
     let search_full_path = matches.is_present("full-path")
-        || (!matches.is_present("glob") && pattern_regex.contains(std::path::MAIN_SEPARATOR));
+        || (cfg!(unix)
+            && !matches.is_present("glob")
+            && pattern_regex.contains(std::path::MAIN_SEPARATOR));
 
     let size_limits = extract_size_limits(&matches)?;
     let time_constraints = extract_time_constraints(&matches)?;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -374,6 +374,7 @@ fn test_regex_overrides_glob() {
 }
 
 /// Make sure `--full-path` switches on on its own
+#[cfg(not(windows))] // TODO: make this work on Windows
 #[test]
 fn test_full_path_switches_on_by_input_with_separators() {
     let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -373,6 +373,26 @@ fn test_regex_overrides_glob() {
     te.assert_output(&["--glob", "--regex", "Foo2$"], "./one/two/C.Foo2");
 }
 
+/// Make sure `--full-path` switches on on its own
+#[test]
+fn test_full_path_switches_on_by_input_with_separators() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(
+        &[
+            // No `--full-path` flag given,
+            // but the search pattern contains a path separator.
+            "e/t",
+        ],
+        "./one/two
+        ./one/two/C.Foo2
+        ./one/two/c.foo
+        ./one/two/three
+        ./one/two/three/d.foo
+        ./one/two/three/directory_foo",
+    );
+}
+
 /// Full path search (--full-path)
 #[test]
 fn test_full_path() {


### PR DESCRIPTION
This PR suggests that `-p/--full-path` shall get enabled whenever there is a slash in the search pattern. The same way case sensitivity switches on when there is different casing in the input pattern.

That is, before these changes, `fd src/main` would silently give nothing; and now it just works.
This behavior might be useful for completion setups like fzf's `^T` or suchlike.

Also dropped is the error message when one types a trailing slash in the pattern: `fd src/`. I'm a bit sorry about that — this message was helpful, but since `fd src/` is now a legitimate way to invoke fd, it may be the right thing to do. But suggestions are always welcome.

There are points I thought about, but did not address within this contribution. Namely, since the flag now sets on automatically, we probably need and explicit `--no-full-path`, but I did not want to bloat the command-line interface. This behavior is also easy to trip up with `fd '[^/]'` or similar — this is why it does not get applied to glob patterns. But I believe if one explicitly writes out a `[^/]` in their pattern, they probably mean something by it.

----

Anyway, thank you so much for this brilliant program, and apologies if I have done anything stupid in my PR ✨ 
