### PR TITLE
Revert "Switch from std::sync::mpsc to crossbeam-channel"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,16 +100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,7 +155,6 @@ dependencies = [
  "atty",
  "chrono",
  "clap",
- "crossbeam-channel",
  "ctrlc",
  "diff",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ dirs-next = "2.0"
 normpath = "0.3"
 chrono = "0.4"
 once_cell = "1.8.0"
-crossbeam-channel = "0.5.1"
 
 [dependencies.clap]
 version = "2.34.0"

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
+use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
-
-use crossbeam_channel::Receiver;
 
 use crate::error::print_error;
 use crate::exit_codes::{merge_exitcodes, ExitCode};

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -4,13 +4,13 @@ use std::io;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 use std::{borrow::Cow, io::Write};
 
 use anyhow::{anyhow, Result};
-use crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender};
 use ignore::overrides::OverrideBuilder;
 use ignore::{self, WalkBuilder};
 use once_cell::unsync::OnceCell;
@@ -55,7 +55,7 @@ pub fn scan(path_vec: &[PathBuf], pattern: Arc<Regex>, config: Arc<Config>) -> R
     let first_path_buf = path_iter
         .next()
         .expect("Error: Path vector can not be empty");
-    let (tx, rx) = unbounded();
+    let (tx, rx) = channel();
 
     let mut override_builder = OverrideBuilder::new(first_path_buf.as_path());
 
@@ -232,7 +232,11 @@ impl<W: Write> ReceiverBuffer<W> {
         match self.mode {
             ReceiverMode::Buffering => {
                 // Wait at most until we should switch to streaming
-                self.rx.recv_deadline(self.deadline)
+                let now = Instant::now();
+                self.deadline
+                    .checked_duration_since(now)
+                    .ok_or(RecvTimeoutError::Timeout)
+                    .and_then(|t| self.rx.recv_timeout(t))
             }
             ReceiverMode::Streaming => {
                 // Wait however long it takes for a result


### PR DESCRIPTION
@sharkdp [noticed][1] a quite severe performance degredation due to this
change.  Switch back to std::sync::mpsc until we can fix the performance
regression.

This reverts commit a4bb734482c7bf3fd4d30081e7d3ce7786a3775e.

[1]: https://github.com/sharkdp/fd/pull/895#issuecomment-1002099369
