### PR TITLE
Include valid symlinks with both --follow and --type symlink

### DIFF
--- a/src/filetypes.rs
+++ b/src/filetypes.rs
@@ -15,10 +15,11 @@ pub struct FileTypes {
 
 impl FileTypes {
     pub fn should_ignore(&self, entry: &walk::DirEntry) -> bool {
+        let is_symlink = entry.is_symlink();
         if let Some(ref entry_type) = entry.file_type() {
-            (!self.files && entry_type.is_file())
-                || (!self.directories && entry_type.is_dir())
-                || (!self.symlinks && entry_type.is_symlink())
+            (!self.files && entry_type.is_file() && !is_symlink)
+                || (!self.directories && entry_type.is_dir() && !is_symlink)
+                || (!self.symlinks && is_symlink)
                 || (!self.sockets && filesystem::is_socket(*entry_type))
                 || (!self.pipes && filesystem::is_pipe(*entry_type))
                 || (self.executables_only

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -447,6 +447,13 @@ impl DirEntry {
         }
     }
 
+    pub fn is_symlink(&self) -> bool {
+        match &self.inner {
+            DirEntryInner::Normal(e) => e.path_is_symlink(),
+            DirEntryInner::BrokenSymlink(_) => true,
+        }
+    }
+
     pub fn metadata(&self) -> Option<&Metadata> {
         self.metadata
             .get_or_init(|| match &self.inner {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -758,9 +758,16 @@ fn test_follow_broken_symlink() {
 
     te.assert_output(
         &["--follow", "--type", "symlink", "symlink"],
-        "./broken_symlink",
+        "./broken_symlink\n./symlink",
     );
     te.assert_output(&["--follow", "--type", "file", "symlink"], "");
+}
+
+#[test]
+fn test_follow_symlink() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(&["--type", "symlink", "--follow"], "./symlink");
 }
 
 /// Null separator (--print0)


### PR DESCRIPTION
This changes it so that if you specify `--type symlink` then it will
check if each entry is a symlink even if we would otherwise follow it.

Fixes: #939