### PR TITLE
add --dry-run option to cli and implement it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Features
 
+- Add "--dry-run" option to print commands instead of executing when used with "--exec" to make tesing a bit easier (@savente93)
 
 ## Bugfixes
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -411,6 +411,11 @@ pub fn build_app() -> App<'static> {
                            fd -e jpg -x convert {} {.}.png\
                     ",
                 ),
+        ).arg(
+            Arg::new("dry-run")
+                .long("--dry-run")
+                .requires("exec")
+                .help("Print the commands to be executed without executing them"),
         )
         .arg(
             Arg::new("exec-batch")

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,9 @@ pub struct Config {
     /// If a value is supplied, each item found will be used to generate and execute commands.
     pub command: Option<Arc<CommandTemplate>>,
 
+    /// Whether to print commands instead of executing them for testing
+    pub dry_run: bool,
+
     /// Maximum number of search results to pass to each `command`. If zero, the number is
     /// unlimited.
     pub batch_size: usize,

--- a/src/exec/command.rs
+++ b/src/exec/command.rs
@@ -11,26 +11,7 @@ pub fn execute_command(
     mut cmd: Command,
     out_perm: &Mutex<()>,
     enable_output_buffering: bool,
-    dry_run: bool,
 ) -> ExitCode {
-    if dry_run {
-        let _lock = out_perm.lock().unwrap();
-        let stdout = io::stdout();
-
-        let out = format!(
-            "{} {}\n",
-            cmd.get_program().to_str().unwrap_or_default(),
-            cmd.get_args()
-                .map(|arg| arg.to_str().unwrap_or_default())
-                .collect::<Vec<_>>()
-                .join(" ")
-        );
-
-        let _ = stdout.lock().write_all(out.as_bytes());
-
-        return ExitCode::Success;
-    }
-
     // Spawn the supplied command.
     let output = if enable_output_buffering {
         cmd.output()

--- a/src/exec/command.rs
+++ b/src/exec/command.rs
@@ -11,7 +11,26 @@ pub fn execute_command(
     mut cmd: Command,
     out_perm: &Mutex<()>,
     enable_output_buffering: bool,
+    dry_run: bool,
 ) -> ExitCode {
+    if dry_run {
+        let _lock = out_perm.lock().unwrap();
+        let stdout = io::stdout();
+
+        let out = format!(
+            "{} {}\n",
+            cmd.get_program().to_str().unwrap_or_default(),
+            cmd.get_args()
+                .map(|arg| arg.to_str().unwrap_or_default())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+
+        let _ = stdout.lock().write_all(out.as_bytes());
+
+        return ExitCode::Success;
+    }
+
     // Spawn the supplied command.
     let output = if enable_output_buffering {
         cmd.output()

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -142,20 +142,26 @@ impl CommandTemplate {
         input: &Path,
         out_perm: Arc<Mutex<()>>,
         buffer_output: bool,
+        dry_run: bool,
     ) -> ExitCode {
         let mut cmd = Command::new(self.args[0].generate(&input, self.path_separator.as_deref()));
         for arg in &self.args[1..] {
             cmd.arg(arg.generate(&input, self.path_separator.as_deref()));
         }
 
-        execute_command(cmd, &out_perm, buffer_output)
+        execute_command(cmd, &out_perm, buffer_output, dry_run)
     }
 
     pub fn in_batch_mode(&self) -> bool {
         self.mode == ExecutionMode::Batch
     }
 
-    pub fn generate_and_execute_batch<I>(&self, paths: I, buffer_output: bool) -> ExitCode
+    pub fn generate_and_execute_batch<I>(
+        &self,
+        paths: I,
+        buffer_output: bool,
+        dry_run: bool,
+    ) -> ExitCode
     where
         I: Iterator<Item = PathBuf>,
     {
@@ -183,7 +189,7 @@ impl CommandTemplate {
         }
 
         if has_path {
-            execute_command(cmd, &Mutex::new(()), buffer_output)
+            execute_command(cmd, &Mutex::new(()), buffer_output, dry_run)
         } else {
             ExitCode::Success
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,6 +270,7 @@ fn construct_config(matches: clap::ArgMatches, pattern_regex: &str) -> Result<Co
         one_file_system: matches.is_present("one-file-system"),
         null_separator: matches.is_present("null_separator"),
         quiet: matches.is_present("quiet"),
+        dry_run: matches.is_present("dry-run"),
         max_depth: matches
             .value_of("max-depth")
             .or_else(|| matches.value_of("rg-depth"))

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -350,6 +350,7 @@ fn spawn_receiver(
 
     let show_filesystem_errors = config.show_filesystem_errors;
     let threads = config.threads;
+    let dry_run = config.dry_run;
     // This will be used to check if output should be buffered when only running a single thread
     let enable_output_buffering: bool = threads > 1;
     thread::spawn(move || {
@@ -362,6 +363,7 @@ fn spawn_receiver(
                     show_filesystem_errors,
                     enable_output_buffering,
                     config.batch_size,
+                    dry_run,
                 )
             } else {
                 let shared_rx = Arc::new(Mutex::new(rx));
@@ -383,6 +385,7 @@ fn spawn_receiver(
                             out_perm,
                             show_filesystem_errors,
                             enable_output_buffering,
+                            dry_run,
                         )
                     });
 


### PR DESCRIPTION
I've implemented a `--dry-run` since it is a need that I've found myself having when using `fd`. I'm aware that I should have created an issue first for discussion, which I only realised after implementing the feature. However, because it is somewhat related to #943 as well as being a relatively minor/simple change I decided to open a PR anyway. If there are things that will need discussion I'm happy to close this and open another PR once all the discussions are resolved. 

Otherwise, there is not that much to say about this change. All it does is take the `dry_run` option from the CLI and pass it down to the commands being executed so they can be printed instead of executed. For this I've mostly just repurposed existing code and tests with slight adjustments for the use case. Hoping this will be an easy merge :) 