### PR TITLE
Make -u idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 
 ## Changes
-
+- Changed `-u` flag to be equivalent to `-HI`. Multiple `-u` flags still allowed but do nothing, see #840 (@jacksontheel)
 
 ## Other
 

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -58,7 +58,7 @@ The global fd ignore file (usually
 The flag can be overridden with '--ignore'.
 .TP
 .B \-u, \-\-unrestricted
-Alias for '--no-ignore'. Can be repeated; '-uu' is an alias for '--no-ignore --hidden'.
+Perform an unrestricted search, including ignored and hidden files. This is an alias for '--hidden --no-ignore'.
 .TP
 .B \-\-no\-ignore\-vcs
 Show search results from files and directories that would otherwise be ignored by gitignore files

--- a/src/app.rs
+++ b/src/app.rs
@@ -104,10 +104,10 @@ pub fn build_app() -> Command<'static> {
                 .overrides_with_all(&["ignore", "no-hidden"])
                 .multiple_occurrences(true) // Allowed for historical reasons
                 .hide_short_help(true)
-                .help("Alias for '--no-ignore', and '--hidden'")
+                .help("Unrestricted search, alias for '--no-ignore --hidden'")
                 .long_help(
-                    "Perform a search with no filters applied. Unfilters ignored \
-                         files and hidden files.",
+                    "Perform an unrestricted search, including ignored and hidden files. This is \
+                    an alias for '--no-ignore --hidden'."
                 ),
         )
         .arg(

--- a/src/app.rs
+++ b/src/app.rs
@@ -102,12 +102,12 @@ pub fn build_app() -> Command<'static> {
                 .short('u')
                 .long("unrestricted")
                 .overrides_with_all(&["ignore", "no-hidden"])
-                .multiple_occurrences(true)
+                .multiple_occurrences(true) // Allowed for historical reasons
                 .hide_short_help(true)
-                .help("Alias for '--no-ignore', and '--hidden' when given twice")
+                .help("Alias for '--no-ignore', and '--hidden'")
                 .long_help(
-                    "Alias for '--no-ignore'. Can be repeated. '-uu' is an alias for \
-                         '--no-ignore --hidden'.",
+                    "Perform a search with no filters applied. Unfilters ignored \
+                         files and hidden files.",
                 ),
         )
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ fn construct_config(matches: clap::ArgMatches, pattern_regex: &str) -> Result<Co
         case_sensitive,
         search_full_path: matches.is_present("full-path"),
         ignore_hidden: !(matches.is_present("hidden")
-            || matches.occurrences_of("rg-alias-hidden-ignore") >= 2),
+            || matches.is_present("rg-alias-hidden-ignore")),
         read_fdignore: !(matches.is_present("no-ignore")
             || matches.is_present("rg-alias-hidden-ignore")),
         read_vcsignore: !(matches.is_present("no-ignore")

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -656,18 +656,6 @@ fn test_no_ignore_aliases() {
 
     te.assert_output(
         &["-u", "foo"],
-        "./a.foo
-        ./fdignored.foo
-        ./gitignored.foo
-        ./one/b.foo
-        ./one/two/c.foo
-        ./one/two/C.Foo2
-        ./one/two/three/d.foo
-        ./one/two/three/directory_foo",
-    );
-
-    te.assert_output(
-        &["-uu", "foo"],
         "./.hidden.foo
         ./a.foo
         ./fdignored.foo
@@ -2039,7 +2027,7 @@ fn test_number_parsing_errors() {
 #[test_case("--no-ignore-vcs", &["--ignore-vcs"] ; "no-ignore-vcs")]
 #[test_case("--follow", &["--no-follow"] ; "follow")]
 #[test_case("--absolute-path", &["--relative-path"] ; "absolute-path")]
-#[test_case("-u", &["--ignore"] ; "u")]
+#[test_case("-u", &["--ignore", "--no-hidden"] ; "u")]
 #[test_case("-uu", &["--ignore", "--no-hidden"] ; "uu")]
 fn test_opposing(flag: &str, opposing_flags: &[&str]) {
     let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);


### PR DESCRIPTION
Closes #840 

Made some small changes to remove the need to repeat the `-u` flag multiple times to unfilter everything. As suggested, the unrestricted flag may still be used multiple times (to make the change as non-breaking as possible), but any unrestricted flag after the first is ignored.

Modified help strings and tests to cover the change.
