### PR TITLE
Limit nix features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,15 +358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "nix"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +366,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ features = ["suggestions", "color", "wrap_help", "cargo", "unstable-grouped"]
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11.0"
-nix = "0.24.1"
+nix = { version = "0.24.1", default-features = false, features = ["signal"] }
 
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
This removes memoffset as an indirect dependency and reduces clean build times slightly.