### PR TITLE
remove description of --batch-size flag from EXAMPLES subsection

### DIFF
--- a/doc/fd.1
+++ b/doc/fd.1
@@ -454,11 +454,5 @@ $ fd -e py
 .TP
 .RI "Open all search results with vim:"
 $ fd pattern -X vim
-.TP
-.BI "\-\-batch\-size " size
-Pass at most
-.I size
-arguments to each call to the command given with -X.
-.TP
 .SH SEE ALSO
 .BR find (1)


### PR DESCRIPTION
--batch-size option is already described in OPTIONS subsection and it's description in EXAMPLES is totally irrelevant.
This also removes the indent before "SEE ALSO" to make it a new
subsection.

First image is a screenshot of current man page and the second one is the man page after this change.

![Screenshot from 2022-05-21 18-53-14](https://user-images.githubusercontent.com/48558638/169656228-33a3e559-34e3-4414-8752-72145982fe08.png)
![Screenshot from 2022-05-21 18-53-31](https://user-images.githubusercontent.com/48558638/169656239-676b7f9d-f410-45c1-9fd9-302bfbce8230.png)

