### PR TITLE
Add an example for where to put pattern/path when using -x

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -395,6 +395,7 @@ pub fn build_app() -> Command<'static> {
                 .long_help(
                     "Execute a command for each search result in parallel (use --threads=1 for sequential command execution). \
                      All positional arguments following --exec are considered to be arguments to the command - not to fd. \
+                     --exec will eat everything that comes after it until ';', even if it is meant to be the path or pattern. \
                      It is therefore recommended to place the '-x'/'--exec' option last.\n\
                      The following placeholders are substituted before the command is executed:\n  \
                        '{}':   path (of the current search result)\n  \

--- a/src/app.rs
+++ b/src/app.rs
@@ -404,12 +404,14 @@ pub fn build_app() -> Command<'static> {
                        '{/.}': basename without file extension\n\n\
                      If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
                      Examples:\n\n  \
-                       - find all *.zip files and unzip them:\n\n      \
+                       - Find all *.zip files and unzip them:\n\n      \
                            fd -e zip -x unzip\n\n  \
-                       - find *.h and *.cpp files and run \"clang-format -i ..\" for each of them:\n\n      \
+                       - Find *.h and *.cpp files and run \"clang-format -i ..\" for each of them:\n\n      \
                            fd -e h -e cpp -x clang-format -i\n\n  \
                        - Convert all *.jpg files to *.png files:\n\n      \
-                           fd -e jpg -x convert {} {.}.png\
+                           fd -e jpg -x convert {} {.}.png\n\n  \
+                       - Echo all files that start with 'pat' and end in 'tern' in the directory some_path:\n\n      \
+                           fd '^pat.*tern$' ./some_path -x echo\
                     ",
                 ),
         )


### PR DESCRIPTION
As per #1018, `fd --help` for `-x` is not very helpful at demonstrating that -x should be at the end of `fd`, after paths and patterns. This PR adds an example to make it more obvious.