### PR TITLE
Implement new flag for printing the executed commands

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -442,6 +442,15 @@ pub fn build_app() -> Command<'static> {
                 ),
         )
         .arg(
+            Arg::new("print-exec")
+                .long("print-exec")
+                .short('P')
+                .help("Print each command ran with -x or -X.")
+                .long_help(
+                    "Print each command to be ran. If -x or -X is not used, this argument has no effect."
+                ),
+        )
+        .arg(
             Arg::new("batch-size")
             .long("batch-size")
             .takes_value(true)

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -5,11 +5,13 @@ use std::{
 
 use once_cell::unsync::OnceCell;
 
+#[derive(Clone)]
 enum DirEntryInner {
     Normal(ignore::DirEntry),
     BrokenSymlink(PathBuf),
 }
 
+#[derive(Clone)]
 pub struct DirEntry {
     inner: DirEntryInner,
     metadata: OnceCell<Option<Metadata>>,

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -1,39 +1,37 @@
 use std::io::{Write, stdout};
-use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, channel};
 use std::sync::{Arc, Mutex};
 
+use crate::config::Config;
 use crate::dir_entry::DirEntry;
 use crate::error::print_error;
 use crate::exit_codes::{merge_exitcodes, ExitCode};
+use crate::output;
 use crate::walk::WorkerResult;
 
-use super::{CommandSet, CommandSetDisplay};
+use super::CommandSet;
 
-pub fn print_command<W: Write>(stdout: &mut W, path: &PathBuf, cmd: &CommandSet) {
-    if let Err(e) = write!(stdout,"{}\n", CommandSetDisplay::new(cmd, path.to_path_buf())) {
-        print_error(format!("Could not write to output: {}", e));
-        ExitCode::GeneralError.exit();
-    }
-    return
+fn print_command<W: Write>(stdout: &mut W, entry: &DirEntry, cmd: &CommandSet, config: &Config) {
+    output::print_command_with_entry(stdout, entry, cmd, config);
 }
 
-/// Print commands in the reciever without running them.
-/// Returns a new channel with the same results to allow passing the
-/// return value to the `job`-function to run the commands concurrently.
+/// Print commands from the `rx` receiver without running them.
+/// Returns a new channel with the same results to allow passing the return value to the
+/// `job`-function to then execute the printed commands in multiple threads.
 pub fn peek_job_commands(
     rx: &Receiver<WorkerResult>,
     cmd: &CommandSet,
+    config: &Config,
     show_filesystem_errors: bool,
 ) -> Receiver<WorkerResult> {
     let (send, rx_new) = channel::<WorkerResult>();
-    let res: Vec<PathBuf> = rx
+    let res: Vec<DirEntry> = rx
         .into_iter()
         .filter_map(|worker_result| {
             send.send(worker_result.to_owned()).unwrap();
             match worker_result {
             WorkerResult::Entry(dir_entry) => {
-                Some(dir_entry.into_path())
+                    Some(dir_entry)
             },
             WorkerResult::Error(err) => {
                 if show_filesystem_errors {
@@ -44,7 +42,7 @@ pub fn peek_job_commands(
         })
         .collect();
     for p in res.iter() {
-        print_command(&mut stdout(), p, cmd);
+        print_command(&mut stdout(), p, cmd,config);
     }
     return rx_new
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -399,12 +399,12 @@ fn extract_command(
     None.or_else(|| {
         matches
             .grouped_values_of("exec")
-            .map(|args| CommandSet::new(args, path_separator.map(str::to_string)))
+            .map(|args| CommandSet::new(args, path_separator.map(str::to_string), matches.is_present("print-exec")))
     })
     .or_else(|| {
         matches
             .grouped_values_of("exec-batch")
-            .map(|args| CommandSet::new_batch(args, path_separator.map(str::to_string)))
+            .map(|args| CommandSet::new_batch(args, path_separator.map(str::to_string), matches.is_present("print-exec")))
     })
     .or_else(|| {
         if !matches.is_present("list-details") {
@@ -415,7 +415,7 @@ fn extract_command(
         let color_arg = format!("--color={}", color);
 
         let res = determine_ls_command(&color_arg, colored_output)
-            .map(|cmd| CommandSet::new_batch([cmd], path_separator.map(str::to_string)).unwrap());
+            .map(|cmd| CommandSet::new_batch([cmd], path_separator.map(str::to_string),false).unwrap());
 
         Some(res)
     })

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -353,8 +353,10 @@ fn spawn_receiver(
                 exec::batch(rx, cmd, show_filesystem_errors, config.batch_size)
             } else {
 
+                // If printing commands, wait for results from the receiver to print them before
+                // running commands.
                 let shared_rx = if cmd.should_print() {
-                    Arc::new(Mutex::new( exec::peek_job_commands(&rx, cmd, show_filesystem_errors) ))
+                    Arc::new(Mutex::new(exec::peek_job_commands(&rx, cmd, &config, show_filesystem_errors)))
                 } else {
                     Arc::new(Mutex::new(rx))
                 };


### PR DESCRIPTION
Implementation for #1042, flag `--print-exec` / `-P`
The flag causes the commands that are going to be executed to first be printed with colored highlighting. Highlighting uses the same logic as when running fd and just listing results. The highlighting is also applied to templates.