### PR TITLE
CI: update macos runner version

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -79,7 +79,7 @@ jobs:
           - { os: ubuntu-20.04, target: i686-unknown-linux-musl     , use-cross: true }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu    , use-cross: true }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-musl   , use-cross: true }
-          - { os: macos-10.15 , target: x86_64-apple-darwin         }
+          - { os: macos-latest , target: x86_64-apple-darwin         }
           # - { os: windows-2019, target: i686-pc-windows-gnu         }  ## disabled; error: linker `i686-w64-mingw32-gcc` not found
           - { os: windows-2019, target: i686-pc-windows-msvc        }
           - { os: windows-2019, target: x86_64-pc-windows-gnu       }


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30.

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

The PR bumps the `runs-on` from `macos-10.15` to `macos-latest`.