### PR TITLE
Add a link back to Github to `--help` (but not `-h`)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -17,7 +17,7 @@ pub fn build_app() -> Command<'static> {
                  details.",
         )
         .after_long_help(
-            "Bugs can be reported on Github: https://github.com/sharkdp/fd"
+            "Bugs can be reported on GitHub: https://github.com/sharkdp/fd/issues"
         )
         .arg(
             Arg::new("hidden")

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,9 @@ pub fn build_app() -> Command<'static> {
             "Note: `fd -h` prints a short and concise overview while `fd --help` gives all \
                  details.",
         )
+        .after_long_help(
+            "Bugs can be reported on Github: https://github.com/sharkdp/fd"
+        )
         .arg(
             Arg::new("hidden")
                 .long("hidden")


### PR DESCRIPTION
This is a follow-up to #1086 