### PR TITLE
RFC: --exec with placeholder corresponding to regex groups/ocurrences

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -402,8 +402,11 @@ pub fn build_app() -> Command<'static> {
                        '{//}': parent directory\n  \
                        '{.}':  path without file extension\n  \
                        '{/.}': basename without file extension\n \
-                       '{<num>}': <num> is the regex group substitution index for the pattern matched \n\n\
-                     If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
+                       '{N}':  text matched by the N-th group in the first pattern ocurrence. Text outside groups are discarted.\n\
+                       '{M.N}':text matched in the M-th pattern ocurrence by the N-th group over the the path or filename.\n\n\
+                     Obs:\n
+                       - Using 0 for M/N substitutes by the text from all groups or all ocurrences respectively.\n\
+                       - If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
                      Examples:\n\n  \
                        - find all *.zip files and unzip them:\n\n      \
                            fd -e zip -x unzip\n\n  \
@@ -435,7 +438,6 @@ pub fn build_app() -> Command<'static> {
                        '{//}': parent directory\n  \
                        '{.}':  path without file extension\n  \
                        '{/.}': basename without file extension\n \
-                       '{<num>}': <num> is the regex group substitution index for the pattern matched \n\n\
                      If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
                      Examples:\n\n  \
                        - Find all test_*.py files and open them in your favorite editor:\n\n      \

--- a/src/app.rs
+++ b/src/app.rs
@@ -401,7 +401,8 @@ pub fn build_app() -> Command<'static> {
                        '{/}':  basename\n  \
                        '{//}': parent directory\n  \
                        '{.}':  path without file extension\n  \
-                       '{/.}': basename without file extension\n\n\
+                       '{/.}': basename without file extension\n \
+                       '{<num>}': <num> is the regex group substitution index for the pattern matched \n\n\
                      If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
                      Examples:\n\n  \
                        - find all *.zip files and unzip them:\n\n      \
@@ -410,6 +411,8 @@ pub fn build_app() -> Command<'static> {
                            fd -e h -e cpp -x clang-format -i\n\n  \
                        - Convert all *.jpg files to *.png files:\n\n      \
                            fd -e jpg -x convert {} {.}.png\
+                       - Rename all *.jpeg files with extension *.jpg:\n\n      \
+                           fd '(.+)\\.(jpg)$' -x mv {} {1}.{2}\
                     ",
                 ),
         )
@@ -431,7 +434,8 @@ pub fn build_app() -> Command<'static> {
                        '{/}':  basename\n  \
                        '{//}': parent directory\n  \
                        '{.}':  path without file extension\n  \
-                       '{/.}': basename without file extension\n\n\
+                       '{/.}': basename without file extension\n \
+                       '{<num>}': <num> is the regex group substitution index for the pattern matched \n\n\
                      If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
                      Examples:\n\n  \
                        - Find all test_*.py files and open them in your favorite editor:\n\n      \

--- a/src/app.rs
+++ b/src/app.rs
@@ -404,6 +404,7 @@ pub fn build_app() -> Command<'static> {
                        '{/.}': basename without file extension\n \
                        '{N}':  text matched by the N-th group in the first pattern ocurrence. Text outside groups are discarted.\n\
                        '{M.N}':text matched in the M-th pattern ocurrence by the N-th group over the the path or filename.\n\n\
+                       '{N:-D}': text matched by the optional ocurrence/group or defaults to 'D' when not matched.\n\
                      Obs:\n
                        - Using 0 for M/N substitutes by the text from all groups or all ocurrences respectively.\n\
                        - If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -1,9 +1,14 @@
+use std::ffi::OsStr;
 use std::{
     fs::{FileType, Metadata},
     path::{Path, PathBuf},
 };
+use std::borrow::Cow;
 
 use once_cell::unsync::OnceCell;
+use regex::bytes::Regex;
+
+use crate::filesystem;
 
 enum DirEntryInner {
     Normal(ignore::DirEntry),
@@ -13,6 +18,7 @@ enum DirEntryInner {
 pub struct DirEntry {
     inner: DirEntryInner,
     metadata: OnceCell<Option<Metadata>>,
+    matches: Vec<String>,
 }
 
 impl DirEntry {
@@ -21,6 +27,7 @@ impl DirEntry {
         Self {
             inner: DirEntryInner::Normal(e),
             metadata: OnceCell::new(),
+            matches: Vec::new(),
         }
     }
 
@@ -28,6 +35,7 @@ impl DirEntry {
         Self {
             inner: DirEntryInner::BrokenSymlink(path),
             metadata: OnceCell::new(),
+            matches: Vec::new(),
         }
     }
 
@@ -36,6 +44,10 @@ impl DirEntry {
             DirEntryInner::Normal(e) => e.path(),
             DirEntryInner::BrokenSymlink(pathbuf) => pathbuf.as_path(),
         }
+    }
+
+    pub fn matches(&self) -> &Vec<String> {
+        &&self.matches
     }
 
     pub fn into_path(self) -> PathBuf {
@@ -66,6 +78,47 @@ impl DirEntry {
             DirEntryInner::Normal(e) => Some(e.depth()),
             DirEntryInner::BrokenSymlink(_) => None,
         }
+    }
+
+    pub fn is_match(&mut self, pattern: &Regex, search_full_path: bool) -> bool {
+        let search_str = self.get_search_str(search_full_path);
+        let search_res = filesystem::osstr_to_bytes(search_str.as_ref());
+
+        let mut parts:Vec<String> = Vec::new();
+        for matched in pattern.captures_iter(&search_res) {
+            for (j, group) in matched.iter().enumerate() {
+                if j > 0 {
+                    if let Some(value) = group {
+                        let cap = value.as_bytes();
+                        let text = std::str::from_utf8(cap).unwrap();
+                        let part = text.to_string();
+                        parts.push(part);
+                    }
+                }
+            }
+        }
+        self.matches = parts;
+        self.matches.len() > 0
+    }
+
+    fn get_search_str(&self, search_full_path: bool) -> Cow<OsStr> {
+        let entry_path = self.path();
+
+        let search_str: Cow<OsStr> = if search_full_path {
+            let path_abs_buf = filesystem::path_absolute_form(entry_path)
+                .expect("Retrieving absolute path succeeds");
+            Cow::Owned(path_abs_buf.as_os_str().to_os_string())
+        } else {
+            match entry_path.file_name() {
+                Some(filename) => Cow::Borrowed(filename),
+                None => unreachable!(
+                    "Encountered file system entry without a file name. This should only \
+                        happen for paths like 'foo/bar/..' or '/' which are not supposed to \
+                        appear in a file system traversal."
+                ),
+            }
+        };
+        search_str
     }
 }
 

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -39,7 +39,7 @@ pub fn job(
         // Drop the lock so that other threads can read from the receiver.
         drop(lock);
         // Generate a command, execute it and store its exit code.
-        results.push(cmd.execute(dir_entry.path(), Arc::clone(&out_perm), buffer_output))
+        results.push(cmd.execute(dir_entry.path(), dir_entry.matches(), Arc::clone(&out_perm), buffer_output))
     }
     // Returns error in case of any error.
     merge_exitcodes(results)

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -222,7 +222,7 @@ impl CommandTemplate {
         S: AsRef<str>,
     {
         static PLACEHOLDER_PATTERN: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r"\{(/?\.?|//)\}").unwrap());
+            Lazy::new(|| Regex::new(r"\{(/?\.?|//|[0-9]+)\}").unwrap());
 
         let mut args = Vec::new();
         let mut has_placeholder = false;
@@ -247,7 +247,12 @@ impl CommandTemplate {
                     "{/}" => tokens.push(Token::Basename),
                     "{//}" => tokens.push(Token::Parent),
                     "{/.}" => tokens.push(Token::BasenameNoExt),
-                    _ => unreachable!("Unhandled placeholder"),
+                    number => {
+                        let len_1 = number.len()-1;
+                        let num = &number[1..len_1];
+                        let pos = num.parse::<usize>().unwrap();
+                        tokens.push(Token::Positional(pos))
+                    }
                 }
 
                 has_placeholder = true;

--- a/src/exec/token.rs
+++ b/src/exec/token.rs
@@ -12,7 +12,7 @@ pub enum Token {
     NoExt,
     BasenameNoExt,
     Text(String),
-    Positional(usize),
+    Positional(usize, usize),
 }
 
 impl Display for Token {
@@ -24,7 +24,7 @@ impl Display for Token {
             Token::NoExt => f.write_str("{.}")?,
             Token::BasenameNoExt => f.write_str("{/.}")?,
             Token::Text(ref string) => f.write_str(string)?,
-            Token::Positional(ref pos) => f.write_str(&pos.to_string())?,
+            Token::Positional(ocurrence, group) => f.write_str(format!("{{{}.{}}}", ocurrence, group).as_str())?,
         }
         Ok(())
     }

--- a/src/exec/token.rs
+++ b/src/exec/token.rs
@@ -12,6 +12,7 @@ pub enum Token {
     NoExt,
     BasenameNoExt,
     Text(String),
+    Positional(usize),
 }
 
 impl Display for Token {
@@ -23,6 +24,7 @@ impl Display for Token {
             Token::NoExt => f.write_str("{.}")?,
             Token::BasenameNoExt => f.write_str("{/.}")?,
             Token::Text(ref string) => f.write_str(string)?,
+            Token::Positional(ref pos) => f.write_str(&pos.to_string())?,
         }
         Ok(())
     }

--- a/src/exec/token.rs
+++ b/src/exec/token.rs
@@ -12,7 +12,7 @@ pub enum Token {
     NoExt,
     BasenameNoExt,
     Text(String),
-    Positional(usize, usize),
+    Positional(usize, usize, String),
 }
 
 impl Display for Token {
@@ -24,7 +24,7 @@ impl Display for Token {
             Token::NoExt => f.write_str("{.}")?,
             Token::BasenameNoExt => f.write_str("{/.}")?,
             Token::Text(ref string) => f.write_str(string)?,
-            Token::Positional(ocurrence, group) => f.write_str(format!("{{{}.{}}}", ocurrence, group).as_str())?,
+            Token::Positional(ocurrence, group, ref default) => f.write_str(format!("{{{}.{}:-{}}}", ocurrence, group, default).as_str())?,
         }
         Ok(())
     }


### PR DESCRIPTION
### What

Allow the groups/occurrences matched by the regex pattern over the filename/path to be used as placeholders for commands executed with the flag `--exec`.

Note however that it's just a proof-of-concept yet. I just have written for checking if such a feature would become accepted. The code is far from done but at least it's possible to run and play with any supported regex and the placeholder support.

So, please share your opinion.

### Features

- Allow the use of regex group constructs for extracting specific pieces from the files/directories name.
- Allow capturing as many occurrences as matched by the regex pattern and use them as placeholders.
- Allow specifying a default text when the group/occurrence is not matched.

#### Uses cases:

##### Renaming or moving files and folders:

``` bash
fd '(.+)( copy.*)(\.\w+)$' -x mv "{}" "{1}.{3}"
```

##### Adding prefixes, text, and extensions to file names:
  
``` bash
fd '([\w-]+)(\.[\w-]+)?$' -t f -x echo "|| {} |groups| {//}/{1}{2:-.ext}"
```

### Syntax

From the help:

```
-x, --exec <cmd>...
    Execute a command for each search result in parallel (use --threads=1 for sequential command execution). All positional
    arguments following --exec are considered to be arguments to the command - not to fd. It is therefore recommended to
    place the '-x'/'--exec' option last.
    The following placeholders are substituted before the command is executed:
      '{}':   path (of the current search result)
      '{/}':  basename
      '{//}': parent directory
      '{.}':  path without file extension
      '{/.}': basename without file extension
+     '{N}':  text matched by the N-th group in the first pattern occurrence. Text outside groups is discarded.
+     '{M.N}': text matched in the M-th pattern occurrence by the N-th group over the path or filename.
+     '{N:-D}': text matched by the optional occurrence/group or defaults to 'D' when not matched.
+   Obs:
+   - Using 0 for M/N substitutes by the text from all groups or all occurrences respectively.
    - If no placeholder is present, an implicit "{}" at the end is assumed.
 ```

#### Examples

``` bash
cargo run -- '(\w+)\.(\w+)$' -x echo "|| {} |groups| {//}/{2}.{1}" | column -t

cargo run -- '([a-zA-Z0-9]+)([\._-]\w+)\.(\w+)$' -x echo "|| {} |groups| {//}/{1}.{3}" | column -t

cargo run -- '([\w-]+)(\.[\w-]+)?$' -t f -x echo "|| {} |groups| {//}/{1}{2:-.ext}" | column -t

cargo run -- '([\./])([\w\.]+)' -p  -x echo "|| {} |matches| {1.0} {2.0} {3.0} {4.0} {5.0} {6.0} {7.0} {8.0} {9.0} {10.0}" | column -t

cargo run -- '(\w+)([_-]+\w+)(\.\w+)?' -x echo "|/| {/} |0| {0} {0.1} {0.2} {0.3} |1| {1.0} {1.1} {1.2} {1.3}" | column -t

cargo run -- '([-_\.]+)?([a-zA-Z0-9])([a-zA-Z0-9]+)' -x echo "|/| {/} |0| {0} {0.1} {0.2} {0.3} |1| {1.0} {1.1} {1.2} {1.3} |2| {2.0} {2.1} {2.2} {2.3}" | column -t

cargo run -- '(/)(\w+)(\.\w+)?' -p -a -x echo "|| {} |groups| {0.1} {0.2} {0.3}" | column -t
```