### PR TITLE
Fix `--min-depth` for broken symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fd returns an error when current working directory does not exist while a search path is
   specified, see #1072 (@vijfhoek)
 - Improved "command not found" error message, see #1083 and #1109 (@themkat)
+- Fixed `--min-depth` for broken symlinks, see #1017 (@theirix)
 
 ## Changes
 

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -82,10 +82,12 @@ impl DirEntry {
             .as_ref()
     }
 
-    pub fn depth(&self) -> Option<usize> {
+    /// Returns true if the entry has the depth greater or equal compared to `depth`
+    pub fn deeper(&self, depth: usize) -> bool {
         match &self.inner {
-            DirEntryInner::Normal(e) => Some(e.depth()),
-            DirEntryInner::BrokenSymlink(_) => None,
+            DirEntryInner::Normal(e) => e.depth() >= depth,
+            // broken symlink passes match if it is just longer thatn the `depth`
+            DirEntryInner::BrokenSymlink(p) => p.components().count() - 1 >= depth,
         }
     }
 }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -441,7 +441,7 @@ fn spawn_senders(
             };
 
             if let Some(min_depth) = config.min_depth {
-                if entry.depth().map_or(true, |d| d < min_depth) {
+                if !entry.deeper(min_depth) {
                     return ignore::WalkState::Continue;
                 }
             }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -825,6 +825,30 @@ fn test_min_depth() {
     );
 }
 
+/// Minimum depth (--min-depth) with broken link
+#[test]
+fn test_min_depth_broken_link() {
+    let mut te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+    te.create_broken_symlink("one/two/broken_symlink")
+        .expect("Failed to create broken symlink.");
+
+    te.assert_output(
+        &["--min-depth", "3"],
+        "one/two/broken_symlink
+        one/two/c.foo
+        one/two/C.Foo2
+        one/two/three/
+        one/two/three/d.foo
+        one/two/three/directory_foo/",
+    );
+
+    te.assert_output(
+        &["--min-depth", "4"],
+        "one/two/three/d.foo
+        one/two/three/directory_foo/",
+    );
+}
+
 /// Exact depth (--exact-depth)
 #[test]
 fn test_exact_depth() {


### PR DESCRIPTION
Fixes #1017 .
Instead of computing depth for broken symlink we can just ensure the directory entry passes the minimal depth check. The `DirEntry::depth` function is not needed anymore so it has been removed.