### PR TITLE
Propagate failed status code from subprocess with exec-batch

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1496,6 +1496,8 @@ fn test_exec_batch() {
             &["foo", "--exec-batch", "echo {}"],
             "[fd error]: First argument of exec-batch is expected to be a fixed executable",
         );
+
+        te.assert_failure_with_error(&["a.foo", "--exec-batch", "false"], "");
     }
 }
 
@@ -1551,6 +1553,8 @@ fn test_exec_batch_multi() {
             ],
         ]
     );
+
+    te.assert_failure_with_error(&["a.foo", "--exec-batch", "echo", ";", "false"], "");
 }
 
 #[test]


### PR DESCRIPTION
If a child process returns a failure status code for --exec-batch, then have fd also return a failed status code.

Closes: #1136