### PR TITLE
add support for matching multiple patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- New `--and <pattern>` option to add additional patterns that must also be matched. See #315
+  and #1139 (@Uthar)
 - Added `--changed-after` as alias for `--changed-within`, to have a name consistent with `--changed-before`.
 
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -144,6 +144,17 @@ pub struct Opts {
     )]
     pub fixed_strings: bool,
 
+    /// Additional search patterns that need to be matched
+    #[arg(
+        long = "and",
+        value_name = "pattern",
+        long_help = "Add additional required search patterns, all of which must be matched. Multiple \
+                     additional patterns can be specified. The patterns are regular expressions, \
+                     unless '--glob' or '--fixed-strings' is used.",
+        hide_short_help = true
+    )]
+    pub exprs: Option<Vec<String>>,
+
     /// Show absolute instead of relative paths
     #[arg(
         long,
@@ -499,17 +510,6 @@ pub struct Opts {
                  pass '--' first, or it will be considered as a flag (fd -- '-foo')."
     )]
     pub pattern: String,
-
-    /// Additional search patterns that need to be matched
-    #[arg(
-        long = "and",
-        value_name = "pattern",
-        long_help = "Add additional required search patterns, all of which must be matched. Multiple \
-                     additional patterns can be specified. The patterns are regular expressions, \
-                     unless '--glob' or '--fixed-strings' is used.",
-        hide_short_help = true
-    )]
-    pub exprs: Option<Vec<String>>,
 
     /// Set path separator when printing file paths
     #[arg(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -500,6 +500,17 @@ pub struct Opts {
     )]
     pub pattern: String,
 
+    /// Additional search patterns that need to be matched
+    #[arg(
+        long = "and",
+        value_name = "pattern",
+        long_help = "Add additional required search patterns, all of which must be fulfilled. Multiple \
+                     additional patterns can be specified. The patterns are regular expressions,
+                     unless '--glob' or '--fixed-strings' is used.",
+        hide_short_help = true
+    )]
+    pub exprs: Option<Vec<String>>,
+
     /// Set path separator when printing file paths
     #[arg(
         long,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -504,8 +504,8 @@ pub struct Opts {
     #[arg(
         long = "and",
         value_name = "pattern",
-        long_help = "Add additional required search patterns, all of which must be fulfilled. Multiple \
-                     additional patterns can be specified. The patterns are regular expressions,
+        long_help = "Add additional required search patterns, all of which must be matched. Multiple \
+                     additional patterns can be specified. The patterns are regular expressions, \
                      unless '--glob' or '--fixed-strings' is used.",
         hide_short_help = true
     )]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,7 +151,8 @@ pub struct Opts {
         long_help = "Add additional required search patterns, all of which must be matched. Multiple \
                      additional patterns can be specified. The patterns are regular expressions, \
                      unless '--glob' or '--fixed-strings' is used.",
-        hide_short_help = true
+        hide_short_help = true,
+        allow_hyphen_values = true
     )]
     pub exprs: Option<Vec<String>>,
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -76,6 +76,203 @@ fn test_simple() {
     );
 }
 
+static AND_EXTRA_FILES: &[&str] = &[
+    "a.foo",
+    "one/b.foo",
+    "one/two/c.foo",
+    "one/two/C.Foo2",
+    "one/two/three/baz-quux",
+    "one/two/three/Baz-Quux2",
+    "one/two/three/d.foo",
+    "fdignored.foo",
+    "gitignored.foo",
+    ".hidden.foo",
+    "A-B.jpg",
+    "A-C.png",
+    "B-A.png",
+    "B-C.png",
+    "C-A.jpg",
+    "C-B.png",
+    "e1 e2",
+];
+
+/// AND test
+#[test]
+fn test_and_basic() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+
+    te.assert_output(
+        &["foo", "--and", "c"],
+        "one/two/C.Foo2
+        one/two/c.foo
+        one/two/three/directory_foo/",
+    );
+
+    te.assert_output(
+        &["f", "--and", "[ad]", "--and", "[_]"],
+        "one/two/three/directory_foo/",
+    );
+
+    te.assert_output(
+        &["f", "--and", "[ad]", "--and", "[.]"],
+        "a.foo
+        one/two/three/d.foo",
+    );
+
+    te.assert_output(&["Foo", "--and", "C"], "one/two/C.Foo2");
+
+    te.assert_output(&["foo", "--and", "asdasdasdsadasd"], "");
+}
+
+#[test]
+fn test_and_empty_pattern() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+    te.assert_output(&["Foo", "--and", "2", "--and", ""], "one/two/C.Foo2");
+}
+
+#[test]
+fn test_and_bad_pattern() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+
+    te.assert_failure(&["Foo", "--and", "2", "--and", "[", "--and", "C"]);
+    te.assert_failure(&["Foo", "--and", "[", "--and", "2", "--and", "C"]);
+    te.assert_failure(&["Foo", "--and", "2", "--and", "C", "--and", "["]);
+    te.assert_failure(&["[", "--and", "2", "--and", "C", "--and", "Foo"]);
+}
+
+#[test]
+fn test_and_pattern_starts_with_dash() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+
+    te.assert_output(
+        &["baz", "--and", "quux"],
+        "one/two/three/Baz-Quux2
+        one/two/three/baz-quux",
+    );
+    te.assert_output(
+        &["baz", "--and", "-"],
+        "one/two/three/Baz-Quux2
+        one/two/three/baz-quux",
+    );
+    te.assert_output(
+        &["Quu", "--and", "x", "--and", "-"],
+        "one/two/three/Baz-Quux2",
+    );
+}
+
+#[test]
+fn test_and_plus_extension() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+
+    te.assert_output(
+        &[
+            "A",
+            "--and",
+            "B",
+            "--extension",
+            "jpg",
+            "--extension",
+            "png",
+        ],
+        "A-B.jpg
+        B-A.png",
+    );
+
+    te.assert_output(
+        &[
+            "A",
+            "--extension",
+            "jpg",
+            "--and",
+            "B",
+            "--extension",
+            "png",
+        ],
+        "A-B.jpg
+        B-A.png",
+    );
+}
+
+#[test]
+fn test_and_plus_type() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+
+    te.assert_output(
+        &["c", "--type", "d", "--and", "foo"],
+        "one/two/three/directory_foo/",
+    );
+
+    te.assert_output(
+        &["c", "--type", "f", "--and", "foo"],
+        "one/two/C.Foo2
+        one/two/c.foo",
+    );
+}
+
+#[test]
+fn test_and_plus_glob() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+
+    te.assert_output(&["*foo", "--glob", "--and", "c*"], "one/two/c.foo");
+}
+
+#[test]
+fn test_and_plus_fixed_strings() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+
+    te.assert_output(
+        &["foo", "--fixed-strings", "--and", "c", "--and", "."],
+        "one/two/c.foo
+        one/two/C.Foo2",
+    );
+
+    te.assert_output(
+        &["foo", "--fixed-strings", "--and", "[c]", "--and", "."],
+        "",
+    );
+
+    te.assert_output(
+        &["Foo", "--fixed-strings", "--and", "C", "--and", "."],
+        "one/two/C.Foo2",
+    );
+}
+
+#[test]
+fn test_and_plus_ignore_case() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+
+    te.assert_output(
+        &["Foo", "--ignore-case", "--and", "C", "--and", "[.]"],
+        "one/two/C.Foo2
+        one/two/c.foo",
+    );
+}
+
+#[test]
+fn test_and_plus_case_sensitive() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+
+    te.assert_output(
+        &["foo", "--case-sensitive", "--and", "c", "--and", "[.]"],
+        "one/two/c.foo",
+    );
+}
+
+#[test]
+fn test_and_plus_full_path() {
+    let te = TestEnv::new(DEFAULT_DIRS, AND_EXTRA_FILES);
+
+    te.assert_output(
+        &["three", "--full-path", "--and", "foo", "--and", "dir"],
+        "one/two/three/directory_foo/",
+    );
+
+    te.assert_output(
+        &["three", "--full-path", "--and", "two", "--and", "dir"],
+        "one/two/three/directory_foo/",
+    );
+}
+
 /// Test each pattern type with an empty pattern.
 #[test]
 fn test_empty_pattern() {


### PR DESCRIPTION
Added the ~`--and`~ ~`--expr`~ `--and` flags that search for matches containing all the patterns, similar to the `-and` flag of GNU find.

https://github.com/minad/consult/issues/6
#315 