### PR TITLE
chore: Update outdated LICENSE year

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 The fd developers
+Copyright (c) 2017-present The fd developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the outdated copyright year to the present. 
So there will not be a need for any further license year updates