### PR TITLE
CI: update actions to run on Node 16

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install rust toolchain (v${{ env.MIN_SUPPORTED_RUST_VERSION }})
       uses: actions-rs/toolchain@v1
@@ -86,7 +86,7 @@ jobs:
           - { os: windows-2019, target: x86_64-pc-windows-msvc      }
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install prerequisites
       shell: bash

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -28,17 +28,11 @@ jobs:
         profile: minimal # minimal component installation (ie, no documentation)
         components: clippy, rustfmt
     - name: Ensure `cargo fmt` has been run
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check
+      run: cargo fmt --check
     - name: Ensure MSRV is set in `clippy.toml`
       run: grep "^msrv = \"${{ env.MIN_SUPPORTED_RUST_VERSION }}\"\$" clippy.toml
     - name: Run clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --locked --all-targets --all-features
+      run: cargo clippy --locked --all-targets --all-features
 
   min_version:
     name: Minimum supported rust version
@@ -55,15 +49,9 @@ jobs:
         components: clippy
         profile: minimal
     - name: Run clippy (on minimum supported rust version to prevent warnings we can't fix)
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --locked --all-targets --all-features
+      run: cargo clippy --locked --all-targets --all-features
     - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --locked
+      run: cargo test --locked
 
   build:
     name: ${{ matrix.job.os }} (${{ matrix.job.target }})
@@ -122,12 +110,20 @@ jobs:
         cargo -V
         rustc -V
 
+    - name: Set cargo cmd
+      run: |
+        echo "CARGO_CMD=cargo" >> $GITHUB_ENV
+        echo "CARGO_CMD=cargo" >> $Env:GITHUB_ENV
+
+    - name: Install cross
+      if: ${{ matrix.job.use-cross == true }}
+      run: |
+        cargo install cross
+        echo "CARGO_CMD=cross" >> $GITHUB_ENV
+        echo "CARGO_CMD=cross" >> $Env:GITHUB_ENV
+
     - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: build
-        args: --locked --release --target=${{ matrix.job.target }}
+      run: ${{ env.CARGO_CMD }} build --locked --release --target=${{ matrix.job.target }}
 
     - name: Strip debug information from executable
       id: strip
@@ -175,11 +171,7 @@ jobs:
         echo "CARGO_TEST_OPTIONS=${CARGO_TEST_OPTIONS}" >> $GITHUB_OUTPUT
 
     - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: test
-        args: --locked --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
+      run: ${{ env.CARGO_CMD }} test --locked --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
 
     - name: Generate completions
       id: completions

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -111,15 +111,13 @@ jobs:
         rustc -V
 
     - name: Set cargo cmd
-      run: |
-        echo "CARGO_CMD=cargo" >> $GITHUB_ENV
-        echo "CARGO_CMD=cargo" >> $Env:GITHUB_ENV
+      shell: bash
+      run: echo "CARGO_CMD=cargo" >> $GITHUB_ENV
 
     - name: Set cargo cmd to cross
+      shell: bash
       if: ${{ matrix.job.use-cross == true }}
-      run: |
-        echo "CARGO_CMD=cross" >> $GITHUB_ENV
-        echo "CARGO_CMD=cross" >> $Env:GITHUB_ENV
+      run: echo "CARGO_CMD=cross" >> $GITHUB_ENV
 
     - name: Rust cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -21,12 +21,11 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v3
     - name: Install rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
-        components: clippy, rustfmt
+      run: |
+        rm -f "${HOME}/.cargo/bin/"{rustfmt,cargo-fmt}
+        rustup set profile minimal
+        rustup toolchain install stable -c "clippy,rustfmt"
+        rustup default stable
     - name: Ensure `cargo fmt` has been run
       run: cargo fmt --check
     - name: Ensure MSRV is set in `clippy.toml`
@@ -42,12 +41,10 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install rust toolchain (v${{ env.MIN_SUPPORTED_RUST_VERSION }})
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.MIN_SUPPORTED_RUST_VERSION }}
-        default: true
-        components: clippy
-        profile: minimal
+      run: |
+        rustup set profile minimal
+        rustup toolchain install ${{ env.MIN_SUPPORTED_RUST_VERSION }} -c clippy
+        rustup default ${{ env.MIN_SUPPORTED_RUST_VERSION }}
     - name: Run clippy (on minimum supported rust version to prevent warnings we can't fix)
       run: cargo clippy --locked --all-targets --all-features
     - name: Run tests
@@ -93,12 +90,11 @@ jobs:
         echo "PROJECT_HOMEPAGE=$(sed -n 's/^homepage = "\(.*\)"/\1/p' Cargo.toml)" >> $GITHUB_ENV
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: ${{ matrix.job.target }}
-        override: true
-        profile: minimal # minimal component installation (ie, no documentation)
+      run: |
+        rustup set profile minimal
+        rustup toolchain install stable
+        rustup override set stable
+        rustup target add ${{ matrix.job.target }}
 
     - name: Show version information (Rust, cargo, GCC)
       shell: bash

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -26,6 +26,8 @@ jobs:
         rustup set profile minimal
         rustup toolchain install stable -c "clippy,rustfmt"
         rustup default stable
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
     - name: Ensure `cargo fmt` has been run
       run: cargo fmt --check
     - name: Ensure MSRV is set in `clippy.toml`
@@ -45,6 +47,8 @@ jobs:
         rustup set profile minimal
         rustup toolchain install ${{ env.MIN_SUPPORTED_RUST_VERSION }} -c clippy
         rustup default ${{ env.MIN_SUPPORTED_RUST_VERSION }}
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
     - name: Run clippy (on minimum supported rust version to prevent warnings we can't fix)
       run: cargo clippy --locked --all-targets --all-features
     - name: Run tests
@@ -111,12 +115,20 @@ jobs:
         echo "CARGO_CMD=cargo" >> $GITHUB_ENV
         echo "CARGO_CMD=cargo" >> $Env:GITHUB_ENV
 
-    - name: Install cross
+    - name: Set cargo cmd to cross
       if: ${{ matrix.job.use-cross == true }}
       run: |
-        cargo install cross
         echo "CARGO_CMD=cross" >> $GITHUB_ENV
         echo "CARGO_CMD=cross" >> $Env:GITHUB_ENV
+
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.job.os }}-${{ matrix.job.target }}
+
+    - name: Install cross
+      if: ${{ matrix.job.use-cross == true }}
+      run: cargo install cross
 
     - name: Build
       run: ${{ env.CARGO_CMD }} build --locked --release --target=${{ matrix.job.target }}


### PR DESCRIPTION
Partial fix for #1156.

1. update actions/checkout to v3
2. remove use of actions-rs/cargo
    > actions-rs is currently inactive and has an issue like https://github.com/actions-rs/cargo/issues/216
3. remove use of actions-rs/toolchain
    > actions-rs is currently inactive and has an issue like https://github.com/actions-rs/toolchain/issues/219
4. add use of [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)

All tests are passed, as you can see here. (https://github.com/miles170/fd/actions/runs/3457767586)