### PR TITLE
Fix panic when using --owner

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ fn construct_config(mut opts: Opts, pattern_regex: &str) -> Result<Config> {
     let size_limits = std::mem::take(&mut opts.size);
     let time_constraints = extract_time_constraints(&opts)?;
     #[cfg(unix)]
-    let owner_constraint: Option<OwnerFilter> = opts.owner;
+    let owner_constraint: Option<OwnerFilter> = opts.owner.and_then(OwnerFilter::filter_ignore);
 
     #[cfg(windows)]
     let ansi_colors_support =

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1949,7 +1949,7 @@ fn test_owner_current_group() {
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn test_owner_root() {
     // This test assumes the current user isn't root


### PR DESCRIPTION
Unfortunately, clap_derive can't combine a value_parser of Option<T> with an optional argument to get a merged Option<T> so we need to do the check for the nop outside of the value parser.

Also adds some tests for --owner

Fixes: #1163