### PR TITLE
anyhow is not only used for the completions feature

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-#[cfg(feature = "completions")]
 use anyhow::anyhow;
 use clap::{
     error::ErrorKind, value_parser, Arg, ArgAction, ArgGroup, ArgMatches, Command, Parser,


### PR DESCRIPTION
fixes: https://github.com/sharkdp/fd/issues/1166

currently building `fd` with `--no-default-features` fails:

```
error: cannot find macro `anyhow` in this scope
   --> src/cli.rs:845:13
    |
845 |         Err(anyhow!(
    |             ^^^^^^
    |
    = note: consider importing one of these items:
            anyhow::anyhow
            crate::anyhow
    = note: `anyhow` is in scope, but it is a crate, not a macro
```