### PR TITLE
Use just the file name of the program name for generating completions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,10 +93,16 @@ fn run() -> Result<ExitCode> {
 #[cold]
 fn print_completions(shell: clap_complete::Shell) -> Result<ExitCode> {
     // The program name is the first argument.
-    let program_name = env::args().next().unwrap_or_else(|| "fd".to_string());
+    let first_arg = env::args().next();
+    let program_name = first_arg
+        .as_ref()
+        .map(Path::new)
+        .and_then(|path| path.file_name())
+        .and_then(|file| file.to_str())
+        .unwrap_or("fd");
     let mut cmd = Opts::command();
     cmd.build();
-    clap_complete::generate(shell, &mut cmd, &program_name, &mut std::io::stdout());
+    clap_complete::generate(shell, &mut cmd, program_name, &mut std::io::stdout());
     Ok(ExitCode::Success)
 }
 


### PR DESCRIPTION
If passed a full path to the executable (like done in the Makefile) that value is used in the generated completions. At least for fish this just doesn't work.

This fixes #1172