### PR TITLE
CI: replace macos-latest with macos-12

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -68,7 +68,7 @@ jobs:
           - { os: ubuntu-20.04, target: i686-unknown-linux-musl     , use-cross: true }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu    , use-cross: true }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-musl   , use-cross: true }
-          - { os: macos-latest , target: x86_64-apple-darwin         }
+          - { os: macos-12    , target: x86_64-apple-darwin         }
           # - { os: windows-2019, target: i686-pc-windows-gnu         }  ## disabled; error: linker `i686-w64-mingw32-gcc` not found
           - { os: windows-2019, target: i686-pc-windows-msvc        }
           - { os: windows-2019, target: x86_64-pc-windows-gnu       }


### PR DESCRIPTION
Closes #1156.

Fix the last CI warning.

```
macOS-latest pipelines will use macOS-12 soon. For more details, see https://github.com/actions/runner-images/issues/6384
```

Check latest CI tests here. (https://github.com/miles170/fd/actions/runs/3459652451)