### PR TITLE
Use tempfile instead of tempdir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fd-find"
 version = "8.5.3"
 dependencies = [
@@ -335,7 +344,7 @@ dependencies = [
  "once_cell",
  "regex",
  "regex-syntax",
- "tempdir",
+ "tempfile",
  "test-case",
  "users",
  "version_check",
@@ -364,12 +373,6 @@ name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "getrandom"
@@ -456,6 +459,15 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -661,43 +673,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,13 +765,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
+name = "tempfile"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "rand",
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
  "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ jemallocator = {version = "0.5.0", optional = true}
 
 [dev-dependencies]
 diff = "0.1"
-tempdir = "0.3"
+tempfile = "3.3"
 filetime = "0.2"
 test-case = "2.2"
 

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -8,7 +8,7 @@ use std::os::windows;
 use std::path::{Path, PathBuf};
 use std::process;
 
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 /// Environment for the integration tests.
 pub struct TestEnv {
@@ -27,7 +27,7 @@ fn create_working_directory(
     directories: &[&'static str],
     files: &[&'static str],
 ) -> Result<TempDir, io::Error> {
-    let temp_dir = TempDir::new("fd-tests")?;
+    let temp_dir = tempfile::Builder::new().prefix("fd-tests").tempdir()?;
 
     {
         let root = temp_dir.path();
@@ -169,7 +169,9 @@ impl TestEnv {
         let root = self.test_root();
         let broken_symlink_link = root.join(link_path);
         {
-            let temp_target_dir = TempDir::new("fd-tests-broken-symlink")?;
+            let temp_target_dir = tempfile::Builder::new()
+                .prefix("fd-tests-broken-symlink")
+                .tempdir()?;
             let broken_symlink_target = temp_target_dir.path().join("broken_symlink_target");
             fs::File::create(&broken_symlink_target)?;
             #[cfg(unix)]


### PR DESCRIPTION
Because tempdir is no longer maintained, because it has been combined with the tempfile crate.

Relates-To: #1188