### PR TITLE
Use nu-ansi-term instead of ansi-term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,15 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,7 +301,6 @@ dependencies = [
 name = "fd-find"
 version = "8.5.3"
 dependencies = [
- "ansi_term",
  "anyhow",
  "argmax",
  "atty",
@@ -331,6 +321,7 @@ dependencies = [
  "lscolors",
  "nix 0.24.2",
  "normpath",
+ "nu-ansi-term",
  "num_cpus",
  "once_cell",
  "regex",
@@ -532,11 +523,11 @@ dependencies = [
 
 [[package]]
 name = "lscolors"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074bff749d092e2e818fe954952102f88e21f67fc69f4d350621aab15a1810f1"
+checksum = "c2dedc85d67baf5327114fad78ab9418f8893b1121c17d5538dd11005ad1ddf2"
 dependencies = [
- "ansi_term",
+ "nu-ansi-term",
 ]
 
 [[package]]
@@ -574,6 +565,16 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04aaf5e9cb0fbf883cc0423159eacdf96a9878022084b35c462c428cab73bcaf"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
  "winapi",
 ]
 
@@ -617,6 +618,12 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "proc-macro-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/main.rs"
 version_check = "0.9"
 
 [dependencies]
-ansi_term = "0.12"
+nu-ansi-term = "0.46"
 argmax = "0.3.1"
 atty = "0.2"
 ignore = "0.4.3"
@@ -42,7 +42,6 @@ regex = "1.6.0"
 regex-syntax = "0.6"
 ctrlc = "3.2"
 humantime = "2.1"
-lscolors = "0.12"
 globset = "0.4"
 anyhow = "1.0"
 dirs-next = "2.0"
@@ -56,6 +55,11 @@ faccess = "0.2.4"
 [dependencies.clap]
 version = "4.0.22"
 features = ["suggestions", "color", "wrap_help", "cargo", "unstable-grouped", "derive"]
+
+[dependencies.lscolors]
+version = "0.13"
+default-features = false
+features = ["nu-ansi-term"]
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,7 +212,7 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
 
     #[cfg(windows)]
     let ansi_colors_support =
-        ansi_term::enable_ansi_support().is_ok() || std::env::var_os("TERM").is_some();
+        nu_ansi_term::enable_ansi_support().is_ok() || std::env::var_os("TERM").is_some();
     #[cfg(not(windows))]
     let ansi_colors_support = true;
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -46,7 +46,7 @@ fn print_trailing_slash<W: Write>(
             stdout,
             "{}",
             style
-                .map(Style::to_ansi_term_style)
+                .map(Style::to_nu_ansi_term_style)
                 .unwrap_or_default()
                 .paint(&config.actual_path_separator)
         )?;
@@ -85,14 +85,14 @@ fn print_entry_colorized<W: Write>(
 
         let style = ls_colors
             .style_for_indicator(Indicator::Directory)
-            .map(Style::to_ansi_term_style)
+            .map(Style::to_nu_ansi_term_style)
             .unwrap_or_default();
         write!(stdout, "{}", style.paint(parent_str))?;
     }
 
     let style = entry
         .style(ls_colors)
-        .map(Style::to_ansi_term_style)
+        .map(Style::to_nu_ansi_term_style)
         .unwrap_or_default();
     write!(stdout, "{}", style.paint(&path_str[offset..]))?;
 


### PR DESCRIPTION
Because ansi-term is no longer maintained.

Relates-To: #1188