### PR TITLE
Fixing clashing naming of temp directories

### DIFF
--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -27,7 +27,7 @@ fn create_working_directory(
     directories: &[&'static str],
     files: &[&'static str],
 ) -> Result<TempDir, io::Error> {
-    let temp_dir = tempfile::Builder::new().prefix("fd-tests").tempdir()?;
+    let temp_dir = tempfile::Builder::new().prefix("fd-tests").rand_bytes(2).tempdir()?;
 
     {
         let root = temp_dir.path();


### PR DESCRIPTION
## Objective
* The random names of temporay directories used for test are clashing witht the actual test
* Fixes #1181 

## Solution
* using 2 bytes for naming the directories