### PR TITLE
Add option to filter files by inode number

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Options:
   -t, --type <filetype>            Filter by type: file (f), directory (d), symlink (l),
                                    executable (x), empty (e), socket (s), pipe (p)
   -e, --extension <ext>            Filter by file extension
+      --inum <num>                 Filter by inode number
   -S, --size <size>                Limit results based on the size of files
       --changed-within <date|dur>  Filter by file modification time (newer than)
       --changed-before <date|dur>  Filter by file modification time (older than)

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -243,6 +243,9 @@ Always colorize output.
 .BI "\-j, \-\-threads " num
 Set number of threads to use for searching & executing (default: number of available CPU cores).
 .TP
+.BI "\-\-inum " num
+Filter files by their inode number.
+.TP
 .BI "\-S, \-\-size " size
 Limit results based on the size of files using the format
 .I <+-><NUM><UNIT>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -365,6 +365,20 @@ pub struct Opts {
     )]
     pub extensions: Option<Vec<String>>,
 
+    /// Filter files by their inode number.
+    /// Format: [inum].
+    ///
+    /// Examples:
+    /// {n}    --inum 4242
+    #[cfg(unix)]
+    #[arg(
+        long,
+        value_name = "inode-number",
+        help = "Filter by inode number",
+        long_help
+    )]
+    pub inum: Option<u64>,
+
     /// Limit results based on the size of files using the format <+-><NUM><UNIT>.
     ///    '+': file size must be greater than or equal to this
     ///    '-': file size must be less than or equal to this

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,10 @@ pub struct Config {
     /// Whether elements of output should be separated by a null character
     pub null_separator: bool,
 
+    #[cfg(unix)]
+    /// The inode number to search for.
+    pub inode_number: Option<u64>,
+
     /// The maximum search depth, or `None` if no maximum search depth should be set.
     ///
     /// A depth of `1` includes all files under the current directory, a depth of `2` also includes

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,6 +205,8 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         .unwrap_or_else(|| std::path::MAIN_SEPARATOR.to_string());
     check_path_separator_length(path_separator.as_deref())?;
 
+    #[cfg(unix)]
+    let inode_number = std::mem::take(&mut opts.inum);
     let size_limits = std::mem::take(&mut opts.size);
     let time_constraints = extract_time_constraints(&opts)?;
     #[cfg(unix)]
@@ -298,6 +300,8 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         batch_size: opts.batch_size,
         exclude_patterns: opts.exclude.iter().map(|p| String::from("!") + p).collect(),
         ignore_files: std::mem::take(&mut opts.ignore_file),
+        #[cfg(unix)]
+        inode_number,
         size_constraints: size_limits,
         time_constraints,
         #[cfg(unix)]


### PR DESCRIPTION
Add the option on Unix systems to filter files by their inode number.

The Windows equivalent FileIndex is not yet stabilized, see https://github.com/rust-lang/rust/issues/63010.

This is especially useful to debug audit records, e.g.:

    Jan 30 17:48:55 laptop audit: PATH item=0 name="pulse" inode=7340042 dev=fe:03 mode=040700 ouid=1001 ogid=1001 rdev=00:00 obj=system_u:object_r:unlabeled_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

Closes: https://github.com/sharkdp/fd/issues/880

Maybe this option should enable `--hidden` by default?