### PR TITLE
Add empty `rustfmt.toml` to enforce default formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# Defaults are used


### PR DESCRIPTION
See https://github.com/sharkdp/bat/pull/2068