### PR TITLE
Don't use jemalloc on OpenBSD (jemalloc fails to compile)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ libc = "0.2"
 # FIXME: Re-enable jemalloc on macOS
 # jemalloc is currently disabled on macOS due to a bug in jemalloc in combination with macOS
 # Catalina. See https://github.com/sharkdp/fd/issues/498 for details.
-[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_os = "freebsd"), not(all(target_env = "musl", target_pointer_width = "32")), not(target_arch = "riscv64")))'.dependencies]
+[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_os = "freebsd"), not(target_os = "openbsd"), not(all(target_env = "musl", target_pointer_width = "32")), not(target_arch = "riscv64")))'.dependencies]
 jemallocator = {version = "0.5.0", optional = true}
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ use crate::regex_helper::{pattern_has_uppercase_char, pattern_matches_strings_wi
     not(target_os = "android"),
     not(target_os = "macos"),
     not(target_os = "freebsd"),
+    not(target_os = "openbsd"),
     not(all(target_env = "musl", target_pointer_width = "32")),
     not(target_arch = "riscv64"),
     feature = "use-jemalloc"


### PR DESCRIPTION
jemalloc fails to compile on OpenBSD, so disable it there by default.

The current OpenBSD ports script [already does this](https://github.com/openbsd/ports/blob/55cab6ed35e0902edf2014de1941c7a4bf210061/sysutils/fd/Makefile#L18), but committing this here makes it easier to build from source or to install fd via cargo if desired.