### PR TITLE
feat: Add a way to escape { and }in exec templates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 name = "fd-find"
 version = "8.7.1"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick",
  "anyhow",
  "argmax",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 name = "fd-find"
 version = "8.7.1"
 dependencies = [
+ "aho-corasick 1.0.1",
  "anyhow",
  "argmax",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ path = "src/main.rs"
 version_check = "0.9"
 
 [dependencies]
+aho-corasick = "1.0"
 nu-ansi-term = "0.49"
 argmax = "0.3.1"
 ignore = "0.4.20"

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -380,9 +380,14 @@ parent directory
 path without file extension
 .IP {/.}
 basename without file extension
+.IP {{}
+literal '{'
 .RE
 
 If no placeholder is present, an implicit "{}" at the end is assumed.
+
+If you need to include the literal text of one of the placeholders, you can use "{{}" to
+escape the first "{". For example "{{}}" expands to "{}", and "{{}{{}}}" expands to "{{}".
 
 Examples:
 

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -380,14 +380,16 @@ parent directory
 path without file extension
 .IP {/.}
 basename without file extension
-.IP {{}
-literal '{'
+.IP {{
+literal '{' (an escape sequence)
+.IP }}
+literal '}' (an escape sequence)
 .RE
 
 If no placeholder is present, an implicit "{}" at the end is assumed.
 
-If you need to include the literal text of one of the placeholders, you can use "{{}" to
-escape the first "{". For example "{{}}" expands to "{}", and "{{}{{}}}" expands to "{{}".
+Notice that you can use "{{" and "}}" to escape "{" and "}" respectively, which is especially
+useful if you need to include the literal text of one of the above placeholders.
 
 Examples:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -808,7 +808,8 @@ impl clap::Args for Exec {
                        '{//}': parent directory\n  \
                        '{.}':  path without file extension\n  \
                        '{/.}': basename without file extension\n  \
-                       '{{}':  literal '{' (for escaping)\n\n\
+                       '{{':   literal '{' (for escaping)\n  \
+                       '}}':   literal '}' (for escaping)\n\n\
                      If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
                      Examples:\n\n  \
                        - find all *.zip files and unzip them:\n\n      \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -840,7 +840,8 @@ impl clap::Args for Exec {
                        '{//}': parent directory\n  \
                        '{.}':  path without file extension\n  \
                        '{/.}': basename without file extension\n  \
-                       '{{}':  literal '{' (for escaping)\n\n\
+                       '{{':   literal '{' (for escaping)\n  \
+                       '}}':   literal '}' (for escaping)\n\n\
                      If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
                      Examples:\n\n  \
                        - Find all test_*.py files and open them in your favorite editor:\n\n      \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -807,7 +807,8 @@ impl clap::Args for Exec {
                        '{/}':  basename\n  \
                        '{//}': parent directory\n  \
                        '{.}':  path without file extension\n  \
-                       '{/.}': basename without file extension\n\n\
+                       '{/.}': basename without file extension\n  \
+                       '{{}':  literal '{' (for escaping)\n\n\
                      If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
                      Examples:\n\n  \
                        - find all *.zip files and unzip them:\n\n      \
@@ -837,7 +838,8 @@ impl clap::Args for Exec {
                        '{/}':  basename\n  \
                        '{//}': parent directory\n  \
                        '{.}':  path without file extension\n  \
-                       '{/.}': basename without file extension\n\n\
+                       '{/.}': basename without file extension\n  \
+                       '{{}':  literal '{' (for escaping)\n\n\
                      If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
                      Examples:\n\n  \
                        - Find all test_*.py files and open them in your favorite editor:\n\n      \

--- a/src/exec/token.rs
+++ b/src/exec/token.rs
@@ -1,4 +1,8 @@
+use aho_corasick::AhoCorasick;
 use std::fmt::{self, Display, Formatter};
+use std::sync::OnceLock;
+
+use super::ArgumentTemplate;
 
 /// Designates what should be written to a buffer
 ///
@@ -25,5 +29,70 @@ impl Display for Token {
             Token::Text(ref string) => f.write_str(string)?,
         }
         Ok(())
+    }
+}
+
+static PLACEHOLDERS: OnceLock<AhoCorasick> = OnceLock::new();
+
+pub(super) fn tokenize(input: &str) -> ArgumentTemplate {
+    // NOTE: we assume that { and } have the same length
+    const BRACE_LEN: usize = '{'.len_utf8();
+    let mut tokens = Vec::new();
+    let mut remaining = input;
+    let mut buf = String::new();
+    let placeholders = PLACEHOLDERS.get_or_init(|| {
+        AhoCorasick::new(&["{{", "}}", "{}", "{/}", "{//}", "{.}", "{/.}"]).unwrap()
+    });
+    while let Some(m) = placeholders.find(remaining) {
+        match m.pattern().as_u32() {
+            0 | 1 => {
+                // we found an escaped {{ or }}, so add
+                // everything up to the first char to the buffer
+                // then skipp the second one.
+                buf += &remaining[..m.start() + BRACE_LEN];
+                remaining = &remaining[m.end()..];
+            }
+            id if !remaining[m.end()..].starts_with('}') => {
+                buf += &remaining[..m.start()];
+                if !buf.is_empty() {
+                    tokens.push(Token::Text(std::mem::take(&mut buf)));
+                }
+                tokens.push(token_from_pattern_id(id));
+                remaining = &remaining[m.end()..];
+            }
+            _ => {
+                // We got a normal pattern, but the final "}"
+                // is escaped, so add up to that to the buffer, then
+                // skip the final }
+                buf += &remaining[..m.end()];
+                remaining = &remaining[m.end() + BRACE_LEN..];
+            }
+        }
+    }
+    // Add the rest of the string to the buffer, and add the final buffer to the tokens
+    if !remaining.is_empty() {
+        buf += remaining;
+    }
+    if tokens.is_empty() {
+        // No placeholders were found, so just return the text
+        return ArgumentTemplate::Text(buf);
+    }
+    // Add final text segment
+    if !buf.is_empty() {
+        tokens.push(Token::Text(buf));
+    }
+    debug_assert!(!tokens.is_empty());
+    ArgumentTemplate::Tokens(tokens)
+}
+
+fn token_from_pattern_id(id: u32) -> Token {
+    use Token::*;
+    match id {
+        2 => Placeholder,
+        3 => Basename,
+        4 => Parent,
+        5 => NoExt,
+        6 => BasenameNoExt,
+        _ => unreachable!(),
     }
 }


### PR DESCRIPTION
fixes #1303 

Alternative to #1314 