### PR TITLE
Rust 1.70 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,6 @@ dependencies = [
  "normpath",
  "nu-ansi-term",
  "num_cpus",
- "once_cell",
  "regex",
  "regex-syntax",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,17 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,7 +316,6 @@ version = "8.7.0"
 dependencies = [
  "anyhow",
  "argmax",
- "atty",
  "chrono",
  "clap",
  "clap_complete",
@@ -402,15 +390,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 repository = "https://github.com/sharkdp/fd"
 version = "8.7.0"
 edition= "2021"
-rust-version = "1.67.0"
+rust-version = "1.70.0"
 
 [badges.appveyor]
 repository = "sharkdp/fd"
@@ -47,7 +47,6 @@ globset = "0.4"
 anyhow = "1.0"
 dirs-next = "2.0"
 normpath = "1.1.1"
-once_cell = "1.17.2"
 crossbeam-channel = "0.5.8"
 clap_complete = {version = "4.3.0", optional = true}
 faccess = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ version_check = "0.9"
 [dependencies]
 nu-ansi-term = "0.47"
 argmax = "0.3.1"
-atty = "0.2"
 ignore = "0.4.20"
 num_cpus = "1.15"
 regex = "1.7.3"

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -1,10 +1,9 @@
+use std::cell::OnceCell;
 use std::ffi::OsString;
 use std::fs::{FileType, Metadata};
 use std::path::{Path, PathBuf};
 
 use lscolors::{Colorable, LsColors, Style};
-
-use once_cell::unsync::OnceCell;
 
 use crate::config::Config;
 use crate::filesystem::strip_current_dir;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,12 @@ mod regex_helper;
 mod walk;
 
 use std::env;
+use std::io::IsTerminal;
 use std::path::Path;
 use std::sync::Arc;
 use std::time;
 
 use anyhow::{anyhow, bail, Context, Result};
-use atty::Stream;
 use clap::{CommandFactory, Parser};
 use globset::GlobBuilder;
 use lscolors::LsColors;
@@ -217,7 +217,7 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
     #[cfg(not(windows))]
     let ansi_colors_support = true;
 
-    let interactive_terminal = atty::is(Stream::Stdout);
+    let interactive_terminal = std::io::stdout().is_terminal();
     let colored_output = match opts.color {
         ColorWhen::Always => true,
         ColorWhen::Never => false,


### PR DESCRIPTION
Rust 1.70 allows us to remove a couple of dependencies. But maybe we should wait a little bit before increasing the MSRV