### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
     "filesystem",
     "tool",
 ]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 name = "fd-find"
 readme = "README.md"
 repository = "https://github.com/sharkdp/fd"


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields