### PR TITLE
Bump proc_macro2 to support building on nightly rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
Nightly rust seems to need a bump of [proc_macro2](https://docs.rs/proc-macro2/latest/proc_macro2/).

Without this, the following error occurs:

```rust
   Compiling proc-macro2 v1.0.52
   Compiling fd-find v8.7.0 (/home/josh/dev/fd)
error[E0635]: unknown feature `proc_macro_span_shrink`
  --> /home/josh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.52/src/lib.rs:92:30
   |
92 |     feature(proc_macro_span, proc_macro_span_shrink)
   |                              ^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0635`.
error: could not compile `proc-macro2` (lib) due to previous error
```

I just ran `cargo update proc-macro2`, which fixes the issue.