### PR TITLE
Bump clap_complete to 4.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.4.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "586a385f7ef2f8b4d86bddaa0c094794e7ccbfe5ffef1f434fe928143fc783a5"
+checksum = "4110a1e6af615a9e6d0a36f805d5c99099f8bab9b8042f5bc1fa220a4a89e36f"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ anyhow = "1.0"
 etcetera = "0.8"
 normpath = "1.1.1"
 crossbeam-channel = "0.5.8"
-clap_complete = {version = "4.4.0", optional = true}
+clap_complete = {version = "4.4.1", optional = true}
 faccess = "0.2.4"
 
 [dependencies.clap]


### PR DESCRIPTION
This fixes an issue with fish shell completions that was causing problems for fd.

I wasn't sure if this warranted an entry in the CHANGELOG so I didn't bother.

Fixes #1367

See https://github.com/clap-rs/clap/issues/5101 and https://github.com/clap-rs/clap/pull/5114 for details.