### PR TITLE
Making `-1` conflict with `--exec` and making `max-results` override `-1`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ use crate::filter::SizeFilter;
     max_term_width = 98,
     args_override_self = true,
     group(ArgGroup::new("execs").args(&["exec", "exec_batch", "list_details"]).conflicts_with_all(&[
-            "max_results", "has_results", "count"])),
+            "max_results", "has_results", "count", "max_one_result"])),
 )]
 pub struct Opts {
     /// Include hidden directories and files in the search results (default:
@@ -505,6 +505,7 @@ pub struct Opts {
         long,
         value_name = "count",
         hide_short_help = true,
+        overrides_with("max_one_result"),
         help = "Limit the number of search results",
         long_help
     )]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2384,6 +2384,11 @@ fn test_max_results() {
     };
     assert_just_one_result_with_option("--max-results=1");
     assert_just_one_result_with_option("-1");
+
+    // check that --max-results & -1 conflic with --exec
+    te.assert_failure(&["thing", "--max-results=0", "--exec=cat"]);
+    te.assert_failure(&["thing", "-1", "--exec=cat"]);
+    te.assert_failure(&["thing", "--max-results=1", "-1", "--exec=cat"]);
 }
 
 /// Filenames with non-utf8 paths are passed to the executed program unchanged


### PR DESCRIPTION
resolves #1393 