### PR TITLE
feat: ignore `.git/` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Features
 
+- Breaking: `.git/` is now ignored by default when using `--hidden` / `-H`, use `--no-ignore` / `-I` or 
+  `--no-ignore-vcs` to override, see #1387 and #1396 (@skoriop)
+
 ## Bugfixes
 
 ## Changes

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -66,6 +66,13 @@ pub fn scan(paths: &[PathBuf], patterns: Arc<Vec<Regex>>, config: Arc<Config>) -
             .add(pattern)
             .map_err(|e| anyhow!("Malformed exclude pattern: {}", e))?;
     }
+
+    if config.read_vcsignore {
+        override_builder
+            .add("!.git")
+            .map_err(|e| anyhow!("Malformed default exclude pattern: {}", e))?;
+    }
+
     let overrides = override_builder
         .build()
         .map_err(|_| anyhow!("Mismatch in exclude patterns"))?;

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -70,7 +70,7 @@ pub fn scan(paths: &[PathBuf], patterns: Arc<Vec<Regex>>, config: Arc<Config>) -
     if config.read_vcsignore {
         override_builder
             .add("!.git")
-            .map_err(|e| anyhow!("Malformed default exclude pattern: {}", e))?;
+            .expect("Invalid exclude pattern");
     }
 
     let overrides = override_builder


### PR DESCRIPTION
Closes #1387 (**breaking change!**)

`.git/` is now ignored by default even with `--hidden` / `-H`.

Use `--no-ignore` / `-I` or `--no-ignore-vcs` to override.

