### PR TITLE
maint: Remove use of unmaintained users crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,6 @@ dependencies = [
  "regex-syntax 0.7.5",
  "tempfile",
  "test-case",
- "users",
  "version_check",
 ]
 
@@ -791,16 +790,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,7 @@ default-features = false
 features = ["nu-ansi-term"]
 
 [target.'cfg(unix)'.dependencies]
-users = "0.11.0"
-nix = { version = "0.26.2", default-features = false, features = ["signal"] }
+nix = { version = "0.26.2", default-features = false, features = ["signal", "user"] }
 
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
The users crate is no longer maintained. There is a maintained fork called uzers, but we already have a dependency on nix, and that has the functionality we need.