### PR TITLE
docs: Explicitly warn against relying on result order for exec

### DIFF
--- a/doc/fd.1
+++ b/doc/fd.1
@@ -368,6 +368,10 @@ This option can be specified multiple times, in which case all commands are run 
 file found, in the order they are provided. In that case, you must supply a ';' argument for
 all but the last commands.
 
+If parallelism is enabled, the order commands will be exectued in is non-deterministic. And even with
+--threads=1, the order is determined by the operating system and may not be what you expect. Thus, it is
+recommended that you don't rely on any ordering of the results.
+
 The following placeholders are substituted before the command is executed:
 .RS
 .IP {}
@@ -411,6 +415,9 @@ Examples:
 Execute
 .I command
 once, with all search results as arguments.
+
+The order of the arguments is non-deterministic and should not be relied upon.
+
 One of the following placeholders is substituted before the command is executed:
 .RS
 .IP {}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -800,6 +800,7 @@ impl clap::Args for Exec {
                 .help("Execute a command for each search result")
                 .long_help(
                     "Execute a command for each search result in parallel (use --threads=1 for sequential command execution). \
+                     There is no guarantee of the order commands are executed in, and the order should not be depended upon. \
                      All positional arguments following --exec are considered to be arguments to the command - not to fd. \
                      It is therefore recommended to place the '-x'/'--exec' option last.\n\
                      The following placeholders are substituted before the command is executed:\n  \
@@ -834,6 +835,7 @@ impl clap::Args for Exec {
                 .help("Execute a command with all search results at once")
                 .long_help(
                     "Execute the given command once, with all search results as arguments.\n\
+                     The order of the arguments is non-deterministic, and should not be relied upon.\n\
                      One of the following placeholders is substituted before the command is executed:\n  \
                        '{}':   path (of all search results)\n  \
                        '{/}':  basename\n  \


### PR DESCRIPTION
Supersedes: #1230