### PR TITLE
Fix docs typos

### DIFF
--- a/doc/fd.1
+++ b/doc/fd.1
@@ -379,7 +379,7 @@ This option can be specified multiple times, in which case all commands are run 
 file found, in the order they are provided. In that case, you must supply a ';' argument for
 all but the last commands.
 
-If parallelism is enabled, the order commands will be exectued in is non-deterministic. And even with
+If parallelism is enabled, the order commands will be executed in is non-deterministic. And even with
 --threads=1, the order is determined by the operating system and may not be what you expect. Thus, it is
 recommended that you don't rely on any ordering of the results.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,7 +49,7 @@ pub struct Opts {
 
     /// Show search results from files and directories that would otherwise be
     /// ignored by '.gitignore', '.ignore', '.fdignore', the global ignore file,
-    /// or the default rule tthat excludes .git/.
+    /// or the default rule that excludes .git/.
     /// The flag can be overridden with --ignore.
     #[arg(
         long,
@@ -226,7 +226,7 @@ pub struct Opts {
         alias = "dereference",
         long_help = "By default, fd does not descend into symlinked directories. Using this \
                      flag, symbolic links are also traversed. \
-                     Flag can be overriden with --no-follow."
+                     Flag can be overridden with --no-follow."
     )]
     pub follow: bool,
 

--- a/src/exec/token.rs
+++ b/src/exec/token.rs
@@ -48,7 +48,7 @@ pub(super) fn tokenize(input: &str) -> ArgumentTemplate {
             0 | 1 => {
                 // we found an escaped {{ or }}, so add
                 // everything up to the first char to the buffer
-                // then skipp the second one.
+                // then skip the second one.
                 buf += &remaining[..m.start() + BRACE_LEN];
                 remaining = &remaining[m.end()..];
             }


### PR DESCRIPTION
Some of the fixes are for the man page and --help message.