### PR TITLE
walk: Use unbounded channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "regex-syntax",
  "tempfile",
  "test-case",
+ "thread_local",
  "version_check",
 ]
 
@@ -797,6 +798,16 @@ dependencies = [
  "quote",
  "syn 2.0.38",
  "test-case-core",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ normpath = "1.1.1"
 crossbeam-channel = "0.5.8"
 clap_complete = {version = "4.4.4", optional = true}
 faccess = "0.2.4"
+thread_local = "1.1.7"
 
 [patch.crates-io]
 ignore = { git = "https://github.com/tavianator/ripgrep", branch = "fd" }

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -13,7 +13,7 @@ use super::CommandSet;
 /// generate a command with the supplied command template. The generated command will then
 /// be executed, and this process will continue until the receiver's sender has closed.
 pub fn job(
-    rx: Receiver<WorkerMsg>,
+    rx: Receiver<WorkerMsg<'_>>,
     cmd: &CommandSet,
     out_perm: &Mutex<()>,
     config: &Config,
@@ -49,7 +49,7 @@ pub fn job(
     merge_exitcodes(results)
 }
 
-pub fn batch(rx: Receiver<WorkerMsg>, cmd: &CommandSet, config: &Config) -> ExitCode {
+pub fn batch(rx: Receiver<WorkerMsg<'_>>, cmd: &CommandSet, config: &Config) -> ExitCode {
     let paths =
         rx.into_iter()
             .map(WorkerMsg::take)


### PR DESCRIPTION
Includes #1413.  The relevant commit is 5200718420577a6a2b4b474735567bad33318482:

> We originally switched to bounded channels for backpressure to fix https://github.com/sharkdp/fd/issues/918.
> However, bounded channels have a significant initialization overhead as
> they pre-allocate a fixed-size buffer for the messages.
> 
> This implementation uses a different backpressure strategy: each thread
> gets a limited-size pool of WorkerResults.  When the size limit is hit,
> the sender thread has to wait for the receiver thread to handle a result
> from that pool and recycle it.
> 
> Inspired by [snmalloc], results are recycled by sending the boxed result
> over a channel back to the thread that allocated it.  By allocating and
> freeing each WorkerResult from the same thread, allocator contention is
> reduced dramatically.  And since we now pass results by pointer instead
> of by value, message passing overhead is reduced as well.
> 
> Fixes https://github.com/sharkdp/fd/issues/1408.
> 
> [snmalloc]: https://github.com/microsoft/snmalloc

I benchmarked this with [`bfs`'s benchmark suite](https://github.com/tavianator/bfs/tree/main/bench).  Both `fd`s were built against a version of `ignore` that included https://github.com/BurntSushi/ripgrep/commit/d938e955af7a39ac0245b1ce84924f7f4a2141ac, so we won't actually see performance quite this good until a new `ignore` release happens.  Still, the results are good enough IMO that this fixes #1408 and #1362.

<details>
<summary>Benchmark results (updated)</summary>

## Complete traversal

### linux v6.5 (86,380 files)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/linux -false` | 20.2 ± 0.6 | 19.0 | 21.5 | 1.14 ± 0.11 |
| `find bench/corpus/linux -false` | 98.5 ± 0.2 | 98.1 | 98.9 | 5.58 ± 0.49 |
| `fd -u '^$' bench/corpus/linux` | 190.4 ± 47.0 | 133.0 | 231.3 | 10.78 ± 2.83 |
| `fd-master -u '^$' bench/corpus/linux` | 60.6 ± 15.7 | 29.5 | 70.5 | 3.43 ± 0.94 |
| `fd-unbounded -u '^$' bench/corpus/linux` | 17.7 ± 1.5 | 15.3 | 20.0 | 1.00 |

### rust 1.72.1 (192,714 files)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/rust -false` | 52.2 ± 1.7 | 50.2 | 56.4 | 1.55 ± 0.08 |
| `find bench/corpus/rust -false` | 313.5 ± 1.2 | 311.6 | 315.6 | 9.29 ± 0.40 |
| `fd -u '^$' bench/corpus/rust` | 274.6 ± 37.6 | 256.6 | 352.3 | 8.14 ± 1.17 |
| `fd-master -u '^$' bench/corpus/rust` | 55.7 ± 16.7 | 45.2 | 86.0 | 1.65 ± 0.50 |
| `fd-unbounded -u '^$' bench/corpus/rust` | 33.8 ± 1.4 | 31.6 | 36.3 | 1.00 |

### chromium 119.0.6036.2 (2,119,292 files)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/chromium -false` | 513.5 ± 11.4 | 490.6 | 528.1 | 2.06 ± 0.05 |
| `find bench/corpus/chromium -false` | 3285.0 ± 6.8 | 3275.2 | 3295.2 | 13.15 ± 0.14 |
| `fd -u '^$' bench/corpus/chromium` | 2538.8 ± 46.8 | 2476.3 | 2582.0 | 10.16 ± 0.22 |
| `fd-master -u '^$' bench/corpus/chromium` | 295.3 ± 17.6 | 264.9 | 307.4 | 1.18 ± 0.07 |
| `fd-unbounded -u '^$' bench/corpus/chromium` | 249.9 ± 2.6 | 246.5 | 254.8 | 1.00 |

## Printing paths

### Without colors

#### linux v6.5

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/linux` | 32.3 ± 1.6 | 27.5 | 34.8 | 1.03 ± 0.09 |
| `find bench/corpus/linux` | 103.0 ± 0.4 | 102.4 | 103.7 | 3.27 ± 0.24 |
| `fd -u --search-path bench/corpus/linux` | 192.0 ± 47.9 | 133.2 | 230.4 | 6.09 ± 1.58 |
| `fd-master -u --search-path bench/corpus/linux` | 87.1 ± 12.8 | 48.3 | 95.2 | 2.76 ± 0.45 |
| `fd-unbounded -u --search-path bench/corpus/linux` | 31.5 ± 2.3 | 29.5 | 40.2 | 1.00 |

### With colors

#### linux v6.5

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/linux -color` | 208.7 ± 2.6 | 204.3 | 214.0 | 2.71 ± 0.09 |
| `fd -u --search-path bench/corpus/linux --color=always` | 185.3 ± 49.1 | 133.2 | 230.3 | 2.40 ± 0.64 |
| `fd-master -u --search-path bench/corpus/linux --color=always` | 95.9 ± 21.1 | 67.4 | 121.2 | 1.24 ± 0.28 |
| `fd-unbounded -u --search-path bench/corpus/linux --color=always` | 77.1 ± 2.4 | 74.0 | 81.6 | 1.00 |

## Parallelism

### rust 1.72.1

#### `-j1`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j1 bench/corpus/rust -false` | 213.6 ± 0.5 | 212.8 | 214.4 | 1.00 |
| `fd -j1 -u '^$' bench/corpus/rust` | 277.2 ± 0.5 | 276.5 | 278.3 | 1.30 ± 0.00 |
| `fd-master -j1 -u '^$' bench/corpus/rust` | 283.4 ± 0.6 | 282.3 | 284.2 | 1.33 ± 0.00 |
| `fd-unbounded -j1 -u '^$' bench/corpus/rust` | 281.3 ± 0.5 | 280.6 | 282.1 | 1.32 ± 0.00 |

#### `-j2`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j2 bench/corpus/rust -false` | 193.3 ± 1.0 | 191.5 | 195.2 | 1.24 ± 0.01 |
| `fd -j2 -u '^$' bench/corpus/rust` | 222.1 ± 5.3 | 216.5 | 231.8 | 1.42 ± 0.04 |
| `fd-master -j2 -u '^$' bench/corpus/rust` | 160.2 ± 1.5 | 158.3 | 162.7 | 1.03 ± 0.01 |
| `fd-unbounded -j2 -u '^$' bench/corpus/rust` | 155.9 ± 0.9 | 154.6 | 157.5 | 1.00 |

#### `-j3`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j3 bench/corpus/rust -false` | 117.2 ± 6.2 | 108.7 | 125.6 | 1.05 ± 0.06 |
| `fd -j3 -u '^$' bench/corpus/rust` | 221.2 ± 2.5 | 217.1 | 223.7 | 1.99 ± 0.03 |
| `fd-master -j3 -u '^$' bench/corpus/rust` | 118.1 ± 2.4 | 112.9 | 121.0 | 1.06 ± 0.02 |
| `fd-unbounded -j3 -u '^$' bench/corpus/rust` | 111.2 ± 0.8 | 109.7 | 112.6 | 1.00 |

#### `-j4`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j4 bench/corpus/rust -false` | 83.9 ± 4.1 | 77.1 | 89.6 | 1.00 |
| `fd -j4 -u '^$' bench/corpus/rust` | 231.4 ± 5.2 | 219.9 | 235.0 | 2.76 ± 0.15 |
| `fd-master -j4 -u '^$' bench/corpus/rust` | 95.4 ± 4.1 | 89.2 | 100.3 | 1.14 ± 0.07 |
| `fd-unbounded -j4 -u '^$' bench/corpus/rust` | 87.8 ± 1.1 | 85.7 | 89.5 | 1.05 ± 0.05 |

#### `-j6`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j6 bench/corpus/rust -false` | 61.1 ± 1.4 | 58.1 | 63.8 | 1.00 |
| `fd -j6 -u '^$' bench/corpus/rust` | 230.6 ± 15.9 | 200.4 | 252.7 | 3.77 ± 0.27 |
| `fd-master -j6 -u '^$' bench/corpus/rust` | 74.0 ± 5.7 | 66.7 | 80.6 | 1.21 ± 0.10 |
| `fd-unbounded -j6 -u '^$' bench/corpus/rust` | 63.5 ± 0.9 | 61.8 | 64.8 | 1.04 ± 0.03 |

#### `-j8`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j8 bench/corpus/rust -false` | 53.5 ± 2.2 | 50.1 | 57.4 | 1.04 ± 0.05 |
| `fd -j8 -u '^$' bench/corpus/rust` | 236.8 ± 13.2 | 222.3 | 259.0 | 4.61 ± 0.27 |
| `fd-master -j8 -u '^$' bench/corpus/rust` | 65.0 ± 7.5 | 57.0 | 73.2 | 1.27 ± 0.15 |
| `fd-unbounded -j8 -u '^$' bench/corpus/rust` | 51.4 ± 0.8 | 50.2 | 52.7 | 1.00 |

#### `-j12`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j12 bench/corpus/rust -false` | 52.4 ± 2.4 | 47.9 | 57.0 | 1.27 ± 0.07 |
| `fd -j12 -u '^$' bench/corpus/rust` | 247.3 ± 13.7 | 230.0 | 268.8 | 5.99 ± 0.38 |
| `fd-master -j12 -u '^$' bench/corpus/rust` | 59.0 ± 12.0 | 46.9 | 73.3 | 1.43 ± 0.29 |
| `fd-unbounded -j12 -u '^$' bench/corpus/rust` | 41.3 ± 1.3 | 38.8 | 43.2 | 1.00 |

#### `-j16`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j16 bench/corpus/rust -false` | 73.1 ± 5.5 | 65.9 | 83.5 | 2.06 ± 0.17 |
| `fd -j16 -u '^$' bench/corpus/rust` | 273.2 ± 10.3 | 246.7 | 280.3 | 7.69 ± 0.41 |
| `fd-master -j16 -u '^$' bench/corpus/rust` | 77.9 ± 0.9 | 76.3 | 80.0 | 2.19 ± 0.09 |
| `fd-unbounded -j16 -u '^$' bench/corpus/rust` | 35.5 ± 1.3 | 33.2 | 38.1 | 1.00 |

## Details

### Versions

```console
$ bfs --version | head -n1
bfs 3.0.4
$ find --version | head -n1
find (GNU findutils) 4.9.0
$ fd --version
fd 8.7.1
$ fd-master --version
fd 8.7.1
$ fd-unbounded --version
fd 8.7.1
```

</details>