### PR TITLE
walk: Send WorkerResults in batches

### DIFF
--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -8,11 +8,13 @@ use lscolors::{Colorable, LsColors, Style};
 use crate::config::Config;
 use crate::filesystem::strip_current_dir;
 
+#[derive(Debug)]
 enum DirEntryInner {
     Normal(ignore::DirEntry),
     BrokenSymlink(PathBuf),
 }
 
+#[derive(Debug)]
 pub struct DirEntry {
     inner: DirEntryInner,
     metadata: OnceCell<Option<Metadata>>,

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -4,12 +4,12 @@ use std::io::{self, Write};
 use std::mem;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
-use crossbeam_channel::{bounded, Receiver, RecvTimeoutError, Sender};
+use crossbeam_channel::{bounded, Receiver, RecvTimeoutError, SendError, Sender};
 use etcetera::BaseStrategy;
 use ignore::overrides::{Override, OverrideBuilder};
 use ignore::{self, WalkBuilder, WalkParallel, WalkState};
@@ -36,11 +36,87 @@ enum ReceiverMode {
 
 /// The Worker threads can result in a valid entry having PathBuf or an error.
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
 pub enum WorkerResult {
     // Errors should be rare, so it's probably better to allow large_enum_variant than
     // to box the Entry variant
     Entry(DirEntry),
     Error(ignore::Error),
+}
+
+/// A batch of WorkerResults to send over a channel.
+#[derive(Clone)]
+struct Batch {
+    items: Arc<Mutex<Option<Vec<WorkerResult>>>>,
+}
+
+impl Batch {
+    fn new() -> Self {
+        Self {
+            items: Arc::new(Mutex::new(Some(vec![]))),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Option<Vec<WorkerResult>>> {
+        self.items.lock().unwrap()
+    }
+}
+
+impl IntoIterator for Batch {
+    type Item = WorkerResult;
+    type IntoIter = std::vec::IntoIter<WorkerResult>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.lock().take().unwrap().into_iter()
+    }
+}
+
+/// Wrapper that sends batches of items at once over a channel.
+struct BatchSender {
+    batch: Batch,
+    tx: Sender<Batch>,
+}
+
+impl BatchSender {
+    fn new(tx: Sender<Batch>) -> Self {
+        Self {
+            batch: Batch::new(),
+            tx,
+        }
+    }
+
+    /// Check if we need to flush a batch.
+    fn needs_flush(batch: Option<&Vec<WorkerResult>>) -> bool {
+        match batch {
+            // Limit the batch size to provide some backpressure
+            Some(vec) => vec.len() >= 0x400,
+            // Batch was already taken by the receiver, so make a new one
+            None => true,
+        }
+    }
+
+    /// Add an item to a batch.
+    fn send(&mut self, item: WorkerResult) -> Result<(), SendError<()>> {
+        let mut batch = self.batch.lock();
+
+        if Self::needs_flush(batch.as_ref()) {
+            drop(batch);
+            self.batch = Batch::new();
+            batch = self.batch.lock();
+        }
+
+        let items = batch.as_mut().unwrap();
+        items.push(item);
+
+        if items.len() == 1 {
+            // New batch, send it over the channel
+            self.tx
+                .send(self.batch.clone())
+                .map_err(|_| SendError(()))?;
+        }
+
+        Ok(())
+    }
 }
 
 /// Maximum size of the output buffer before flushing results to the console
@@ -57,7 +133,7 @@ struct ReceiverBuffer<'a, W> {
     /// The ^C notifier.
     interrupt_flag: &'a AtomicBool,
     /// Receiver for worker results.
-    rx: Receiver<WorkerResult>,
+    rx: Receiver<Batch>,
     /// Standard output.
     stdout: W,
     /// The current buffer mode.
@@ -72,7 +148,7 @@ struct ReceiverBuffer<'a, W> {
 
 impl<'a, W: Write> ReceiverBuffer<'a, W> {
     /// Create a new receiver buffer.
-    fn new(state: &'a WorkerState, rx: Receiver<WorkerResult>, stdout: W) -> Self {
+    fn new(state: &'a WorkerState, rx: Receiver<Batch>, stdout: W) -> Self {
         let config = &state.config;
         let quit_flag = state.quit_flag.as_ref();
         let interrupt_flag = state.interrupt_flag.as_ref();
@@ -103,7 +179,7 @@ impl<'a, W: Write> ReceiverBuffer<'a, W> {
     }
 
     /// Receive the next worker result.
-    fn recv(&self) -> Result<WorkerResult, RecvTimeoutError> {
+    fn recv(&self) -> Result<Batch, RecvTimeoutError> {
         match self.mode {
             ReceiverMode::Buffering => {
                 // Wait at most until we should switch to streaming
@@ -119,34 +195,40 @@ impl<'a, W: Write> ReceiverBuffer<'a, W> {
     /// Wait for a result or state change.
     fn poll(&mut self) -> Result<(), ExitCode> {
         match self.recv() {
-            Ok(WorkerResult::Entry(dir_entry)) => {
-                if self.config.quiet {
-                    return Err(ExitCode::HasResults(true));
-                }
+            Ok(batch) => {
+                for result in batch {
+                    match result {
+                        WorkerResult::Entry(dir_entry) => {
+                            if self.config.quiet {
+                                return Err(ExitCode::HasResults(true));
+                            }
 
-                match self.mode {
-                    ReceiverMode::Buffering => {
-                        self.buffer.push(dir_entry);
-                        if self.buffer.len() > MAX_BUFFER_LENGTH {
-                            self.stream()?;
+                            match self.mode {
+                                ReceiverMode::Buffering => {
+                                    self.buffer.push(dir_entry);
+                                    if self.buffer.len() > MAX_BUFFER_LENGTH {
+                                        self.stream()?;
+                                    }
+                                }
+                                ReceiverMode::Streaming => {
+                                    self.print(&dir_entry)?;
+                                    self.flush()?;
+                                }
+                            }
+
+                            self.num_results += 1;
+                            if let Some(max_results) = self.config.max_results {
+                                if self.num_results >= max_results {
+                                    return self.stop();
+                                }
+                            }
+                        }
+                        WorkerResult::Error(err) => {
+                            if self.config.show_filesystem_errors {
+                                print_error(err.to_string());
+                            }
                         }
                     }
-                    ReceiverMode::Streaming => {
-                        self.print(&dir_entry)?;
-                        self.flush()?;
-                    }
-                }
-
-                self.num_results += 1;
-                if let Some(max_results) = self.config.max_results {
-                    if self.num_results >= max_results {
-                        return self.stop();
-                    }
-                }
-            }
-            Ok(WorkerResult::Error(err)) => {
-                if self.config.show_filesystem_errors {
-                    print_error(err.to_string());
                 }
             }
             Err(RecvTimeoutError::Timeout) => {
@@ -319,13 +401,13 @@ impl WorkerState {
 
     /// Run the receiver work, either on this thread or a pool of background
     /// threads (for --exec).
-    fn receive(&self, rx: Receiver<WorkerResult>) -> ExitCode {
+    fn receive(&self, rx: Receiver<Batch>) -> ExitCode {
         let config = &self.config;
 
         // This will be set to `Some` if the `--exec` argument was supplied.
         if let Some(ref cmd) = config.command {
             if cmd.in_batch_mode() {
-                exec::batch(rx, cmd, &config)
+                exec::batch(rx.into_iter().flatten(), cmd, &config)
             } else {
                 let out_perm = Mutex::new(());
 
@@ -337,7 +419,8 @@ impl WorkerState {
                         let rx = rx.clone();
 
                         // Spawn a job thread that will listen for and execute inputs.
-                        let handle = scope.spawn(|| exec::job(rx, cmd, &out_perm, &config));
+                        let handle = scope
+                            .spawn(|| exec::job(rx.into_iter().flatten(), cmd, &out_perm, &config));
 
                         // Push the handle of the spawned thread into the vector for later joining.
                         handles.push(handle);
@@ -355,12 +438,12 @@ impl WorkerState {
     }
 
     /// Spawn the sender threads.
-    fn spawn_senders(&self, walker: WalkParallel, tx: Sender<WorkerResult>) {
+    fn spawn_senders(&self, walker: WalkParallel, tx: Sender<Batch>) {
         walker.run(|| {
             let patterns = &self.patterns;
             let config = &self.config;
             let quit_flag = self.quit_flag.as_ref();
-            let tx = tx.clone();
+            let mut tx = BatchSender::new(tx.clone());
 
             Box::new(move |entry| {
                 if quit_flag.load(Ordering::Relaxed) {
@@ -545,8 +628,7 @@ impl WorkerState {
             .unwrap();
         }
 
-        // Channel capacity was chosen empircally to perform similarly to an unbounded channel
-        let (tx, rx) = bounded(0x4000 * config.threads);
+        let (tx, rx) = bounded(config.threads);
 
         let exit_code = thread::scope(|scope| {
             // Spawn the receiver thread(s)


### PR DESCRIPTION
Fixes #1408, fixes #1362.

<details>
<summary>Benchmark results</summary>

## Complete traversal

### linux v6.5 (86,380 files)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/linux -false` | 19.3 ± 0.4 | 18.6 | 20.3 | 1.02 ± 0.08 |
| `find bench/corpus/linux -false` | 96.7 ± 0.4 | 96.0 | 97.2 | 5.14 ± 0.39 |
| `fd -u '^$' bench/corpus/linux` | 229.0 ± 29.4 | 135.6 | 239.2 | 12.16 ± 1.82 |
| `fd-master -u '^$' bench/corpus/linux` | 61.4 ± 18.2 | 29.7 | 74.4 | 3.26 ± 1.00 |
| `fd-batch -u '^$' bench/corpus/linux` | 18.8 ± 1.4 | 16.0 | 20.8 | 1.00 |

### rust 1.72.1 (192,714 files)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/rust -false` | 53.7 ± 1.9 | 51.2 | 58.4 | 1.57 ± 0.11 |
| `find bench/corpus/rust -false` | 304.5 ± 0.9 | 302.7 | 305.8 | 8.91 ± 0.51 |
| `fd -u '^$' bench/corpus/rust` | 360.0 ± 0.9 | 358.7 | 361.4 | 10.53 ± 0.61 |
| `fd-master -u '^$' bench/corpus/rust` | 70.9 ± 20.6 | 44.5 | 91.1 | 2.07 ± 0.62 |
| `fd-batch -u '^$' bench/corpus/rust` | 34.2 ± 2.0 | 30.9 | 37.3 | 1.00 |

### chromium 119.0.6036.2 (2,119,292 files)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/chromium -false` | 516.9 ± 9.1 | 504.1 | 532.8 | 2.10 ± 0.04 |
| `find bench/corpus/chromium -false` | 3218.6 ± 9.7 | 3205.6 | 3242.2 | 13.07 ± 0.12 |
| `fd -u '^$' bench/corpus/chromium` | 2522.9 ± 50.4 | 2484.3 | 2602.1 | 10.25 ± 0.22 |
| `fd-master -u '^$' bench/corpus/chromium` | 281.3 ± 21.3 | 259.5 | 306.2 | 1.14 ± 0.09 |
| `fd-batch -u '^$' bench/corpus/chromium` | 246.2 ± 2.1 | 243.5 | 250.1 | 1.00 |

## Printing paths

### Without colors

#### linux v6.5

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/linux` | 32.0 ± 1.5 | 29.4 | 34.8 | 1.47 ± 0.11 |
| `find bench/corpus/linux` | 102.4 ± 1.0 | 101.1 | 104.5 | 4.70 ± 0.27 |
| `fd -u --search-path bench/corpus/linux` | 152.3 ± 41.8 | 132.7 | 248.7 | 7.00 ± 1.96 |
| `fd-master -u --search-path bench/corpus/linux` | 72.4 ± 22.0 | 46.3 | 98.7 | 3.33 ± 1.03 |
| `fd-batch -u --search-path bench/corpus/linux` | 21.8 ± 1.2 | 19.4 | 23.7 | 1.00 |

#### chromium 119.0.6036.2

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/chromium` | 707.0 ± 28.2 | 668.0 | 768.4 | 2.32 ± 0.10 |
| `find bench/corpus/chromium` | 3378.1 ± 11.0 | 3368.4 | 3399.6 | 11.09 ± 0.12 |
| `fd -u --search-path bench/corpus/chromium` | 2495.7 ± 64.0 | 2440.6 | 2577.8 | 8.20 ± 0.23 |
| `fd-master -u --search-path bench/corpus/chromium` | 776.0 ± 19.8 | 742.4 | 820.3 | 2.55 ± 0.07 |
| `fd-batch -u --search-path bench/corpus/chromium` | 304.5 ± 3.1 | 297.2 | 307.3 | 1.00 |

### With colors

#### linux v6.5

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/linux -color` | 221.5 ± 2.8 | 215.2 | 226.3 | 4.43 ± 0.26 |
| `fd -u --search-path bench/corpus/linux --color=always` | 172.4 ± 51.1 | 133.9 | 251.0 | 3.45 ± 1.04 |
| `fd-master -u --search-path bench/corpus/linux --color=always` | 81.1 ± 18.3 | 69.0 | 120.2 | 1.62 ± 0.38 |
| `fd-batch -u --search-path bench/corpus/linux --color=always` | 50.0 ± 2.9 | 47.4 | 56.9 | 1.00 |

#### chromium 119.0.6036.2

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/chromium -color` | 5.644 ± 0.022 | 5.612 | 5.685 | 4.64 ± 0.07 |
| `fd -u --search-path bench/corpus/chromium --color=always` | 2.502 ± 0.072 | 2.448 | 2.614 | 2.06 ± 0.07 |
| `fd-master -u --search-path bench/corpus/chromium --color=always` | 4.738 ± 0.156 | 4.496 | 5.037 | 3.89 ± 0.14 |
| `fd-batch -u --search-path bench/corpus/chromium --color=always` | 1.218 ± 0.018 | 1.199 | 1.250 | 1.00 |

## Parallelism

### rust 1.72.1

#### `-j1`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j1 bench/corpus/rust -false` | 219.0 ± 1.7 | 216.7 | 221.5 | 1.00 |
| `fd -j1 -u '^$' bench/corpus/rust` | 271.1 ± 2.7 | 269.2 | 278.8 | 1.24 ± 0.02 |
| `fd-master -j1 -u '^$' bench/corpus/rust` | 275.5 ± 1.7 | 273.6 | 279.0 | 1.26 ± 0.01 |
| `fd-batch -j1 -u '^$' bench/corpus/rust` | 275.2 ± 2.3 | 271.8 | 278.8 | 1.26 ± 0.01 |

#### `-j2`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j2 bench/corpus/rust -false` | 199.7 ± 3.3 | 196.1 | 207.9 | 1.30 ± 0.03 |
| `fd -j2 -u '^$' bench/corpus/rust` | 219.3 ± 6.8 | 210.0 | 229.6 | 1.42 ± 0.05 |
| `fd-master -j2 -u '^$' bench/corpus/rust` | 158.4 ± 1.7 | 155.0 | 160.6 | 1.03 ± 0.02 |
| `fd-batch -j2 -u '^$' bench/corpus/rust` | 154.2 ± 2.0 | 152.0 | 159.8 | 1.00 |

#### `-j3`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j3 bench/corpus/rust -false` | 118.0 ± 7.0 | 110.3 | 129.7 | 1.08 ± 0.07 |
| `fd -j3 -u '^$' bench/corpus/rust` | 214.3 ± 7.4 | 198.6 | 224.2 | 1.95 ± 0.07 |
| `fd-master -j3 -u '^$' bench/corpus/rust` | 115.7 ± 3.5 | 111.0 | 120.3 | 1.06 ± 0.04 |
| `fd-batch -j3 -u '^$' bench/corpus/rust` | 109.6 ± 1.7 | 105.9 | 112.5 | 1.00 |

#### `-j4`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j4 bench/corpus/rust -false` | 85.7 ± 5.2 | 79.0 | 95.4 | 1.00 |
| `fd -j4 -u '^$' bench/corpus/rust` | 221.8 ± 6.8 | 204.5 | 234.2 | 2.59 ± 0.18 |
| `fd-master -j4 -u '^$' bench/corpus/rust` | 94.1 ± 4.3 | 88.4 | 100.0 | 1.10 ± 0.08 |
| `fd-batch -j4 -u '^$' bench/corpus/rust` | 86.5 ± 1.3 | 82.7 | 88.8 | 1.01 ± 0.06 |

#### `-j6`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j6 bench/corpus/rust -false` | 62.4 ± 1.8 | 59.8 | 65.5 | 1.00 |
| `fd -j6 -u '^$' bench/corpus/rust` | 231.9 ± 13.6 | 201.8 | 246.2 | 3.71 ± 0.24 |
| `fd-master -j6 -u '^$' bench/corpus/rust` | 76.2 ± 5.7 | 66.1 | 81.8 | 1.22 ± 0.10 |
| `fd-batch -j6 -u '^$' bench/corpus/rust` | 62.5 ± 1.3 | 60.6 | 66.7 | 1.00 ± 0.04 |

#### `-j8`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j8 bench/corpus/rust -false` | 53.0 ± 1.3 | 51.0 | 55.9 | 1.03 ± 0.04 |
| `fd -j8 -u '^$' bench/corpus/rust` | 230.0 ± 4.4 | 223.8 | 237.5 | 4.49 ± 0.14 |
| `fd-master -j8 -u '^$' bench/corpus/rust` | 59.4 ± 6.6 | 53.9 | 76.3 | 1.16 ± 0.13 |
| `fd-batch -j8 -u '^$' bench/corpus/rust` | 51.2 ± 1.2 | 49.3 | 53.4 | 1.00 |

#### `-j12`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j12 bench/corpus/rust -false` | 53.6 ± 2.8 | 48.2 | 62.7 | 1.32 ± 0.08 |
| `fd -j12 -u '^$' bench/corpus/rust` | 245.5 ± 14.9 | 224.8 | 268.6 | 6.03 ± 0.40 |
| `fd-master -j12 -u '^$' bench/corpus/rust` | 56.5 ± 11.8 | 48.2 | 75.8 | 1.39 ± 0.29 |
| `fd-batch -j12 -u '^$' bench/corpus/rust` | 40.7 ± 1.1 | 39.0 | 43.8 | 1.00 |

#### `-j16`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs -j16 bench/corpus/rust -false` | 68.8 ± 7.0 | 54.7 | 79.2 | 1.88 ± 0.21 |
| `fd -j16 -u '^$' bench/corpus/rust` | 246.9 ± 10.5 | 238.5 | 276.0 | 6.76 ± 0.42 |
| `fd-master -j16 -u '^$' bench/corpus/rust` | 54.6 ± 14.9 | 45.2 | 81.1 | 1.50 ± 0.41 |
| `fd-batch -j16 -u '^$' bench/corpus/rust` | 36.5 ± 1.7 | 33.7 | 39.7 | 1.00 |

## Process spawning

### linux v6.5

#### One file per process

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/linux -maxdepth 2 -exec true -- {} \;` | 1.391 ± 0.066 | 1.309 | 1.469 | 9.65 ± 0.75 |
| `find bench/corpus/linux -maxdepth 2 -exec true -- {} \;` | 1.351 ± 0.028 | 1.312 | 1.396 | 9.37 ± 0.61 |
| `fd -u --search-path bench/corpus/linux --max-depth=2 -x true --` | 0.274 ± 0.059 | 0.182 | 0.349 | 1.90 ± 0.42 |
| `fd -j1 -u --search-path bench/corpus/linux --max-depth=2 -x true --` | 1.015 ± 0.028 | 0.970 | 1.050 | 7.04 ± 0.48 |
| `fd-master -u --search-path bench/corpus/linux --max-depth=2 -x true --` | 0.157 ± 0.021 | 0.136 | 0.191 | 1.09 ± 0.16 |
| `fd-master -j1 -u --search-path bench/corpus/linux --max-depth=2 -x true --` | 1.013 ± 0.015 | 0.998 | 1.047 | 7.03 ± 0.44 |
| `fd-batch -u --search-path bench/corpus/linux --max-depth=2 -x true --` | 0.144 ± 0.009 | 0.127 | 0.158 | 1.00 |
| `fd-batch -j1 -u --search-path bench/corpus/linux --max-depth=2 -x true --` | 1.013 ± 0.028 | 0.973 | 1.064 | 7.03 ± 0.47 |

#### Many files per process

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/linux -exec true -- {} +` | 73.0 ± 1.8 | 69.8 | 76.3 | 1.00 |
| `find bench/corpus/linux -exec true -- {} +` | 256.1 ± 0.7 | 255.2 | 257.3 | 3.51 ± 0.08 |
| `fd -u --search-path bench/corpus/linux -X true --` | 311.0 ± 33.1 | 217.1 | 328.5 | 4.26 ± 0.47 |
| `fd-master -u --search-path bench/corpus/linux -X true --` | 198.9 ± 20.4 | 170.4 | 215.6 | 2.72 ± 0.29 |
| `fd-batch -u --search-path bench/corpus/linux -X true --` | 146.5 ± 1.8 | 144.3 | 152.0 | 2.01 ± 0.05 |

#### Spawn in parent directory

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs bench/corpus/linux -maxdepth 3 -execdir true -- {} +` | 972.9 ± 15.2 | 943.3 | 995.2 | 1.00 |
| `find bench/corpus/linux -maxdepth 3 -execdir true -- {} +` | 1030.5 ± 25.0 | 991.8 | 1062.4 | 1.06 ± 0.03 |

## Details

### Versions

```console
$ bfs --version | head -n1
bfs 3.0.4
$ find --version | head -n1
find (GNU findutils) 4.9.0
$ fd --version
fd 8.7.1
$ fd-master --version
fd 8.7.1
$ fd-batch --version
fd 8.7.1
```

</details>