### PR TITLE
Add target aarch64-unknown-linux-musl

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -71,6 +71,7 @@ jobs:
       matrix:
         job:
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04, use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-20.04, use-cross: true }
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04, use-cross: true }
           - { target: arm-unknown-linux-musleabihf, os: ubuntu-20.04, use-cross: true }
           - { target: i686-pc-windows-msvc        , os: windows-2019                  }


### PR DESCRIPTION
Add target aarch64-unknown-linux-musl, to support ASUS routers that use the third-party [Asuswrt-Merlin](https://www.asuswrt-merlin.net/) firmware (#1477).