### PR TITLE
set default path separator to '/' in UCRT64 of MSYS

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -128,13 +128,11 @@ pub fn strip_current_dir(path: &Path) -> &Path {
 pub fn default_path_separator() -> Option<String> {
     if cfg!(windows) {
         let msystem = env::var("MSYSTEM").ok()?;
-        match msystem.as_str() {
-            "MINGW64" | "MINGW32" | "MSYS" => Some("/".to_owned()),
-            _ => None,
+        if !msystem.as_str().is_empty() {
+            return Some("/".to_owned());
         }
-    } else {
-        None
     }
+    None
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Use path separator "/" also in UCRT64 of MSYS.

The environments of MSYS: [[https://www.msys2.org/docs/environments/]]