### PR TITLE
Use 'MAIN_SEPARATOR_STR' instead of '&MAIN_SEPARATOR.to_string()'

### DIFF
--- a/src/exec/input.rs
+++ b/src/exec/input.rs
@@ -34,10 +34,10 @@ pub fn dirname(path: &Path) -> OsString {
 #[cfg(test)]
 mod path_tests {
     use super::*;
-    use std::path::MAIN_SEPARATOR;
+    use std::path::MAIN_SEPARATOR_STR;
 
     fn correct(input: &str) -> String {
-        input.replace('/', &MAIN_SEPARATOR.to_string())
+        input.replace('/', MAIN_SEPARATOR_STR)
     }
 
     macro_rules! func_tests {

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -129,7 +129,7 @@ fn normalize_output(s: &str, trim_start: bool, normalize_line: bool) -> String {
         .lines()
         .map(|line| {
             let line = if trim_start { line.trim_start() } else { line };
-            let line = line.replace('/', &std::path::MAIN_SEPARATOR.to_string());
+            let line = line.replace('/', std::path::MAIN_SEPARATOR_STR);
             if normalize_line {
                 let mut words: Vec<_> = line.split_whitespace().collect();
                 words.sort_unstable();


### PR DESCRIPTION
Use 'MAIN_SEPARATOR_STR' instead of '&MAIN_SEPARATOR.to_string()'