### PR TITLE
Add --filter argument that filters results based on command exit-code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   was often useful, it also broke some existing workflows, and there wasn't a good way to opt out of it. And there isn't really a good way for us to add
   a way to opt out of it. And you can easily get similar behavior by adding `.git/` to your global fdignore file.
     See #1457.
+- Add `-f` \ `--filter <command>` argument that allows you to filter results based on the output of a command, as requested in #400.
 
 ## Bugfixes
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -776,6 +776,11 @@ impl clap::FromArgMatches for Exec {
                     .get_occurrences::<String>("exec_batch")
                     .map(CommandSet::new_batch)
             })
+            .or_else(|| {
+                matches
+                    .get_occurrences::<String>("filter")
+                    .map(CommandSet::new_filter)
+            })
             .transpose()
             .map_err(|e| clap::Error::raw(ErrorKind::InvalidValue, e))?;
         Ok(Exec { command })
@@ -797,7 +802,7 @@ impl clap::Args for Exec {
                 .allow_hyphen_values(true)
                 .value_terminator(";")
                 .value_name("cmd")
-                .conflicts_with("list_details")
+                .conflicts_with_all(["list_details", "exec_batch"])
                 .help("Execute a command for each search result")
                 .long_help(
                     "Execute a command for each search result in parallel (use --threads=1 for sequential command execution). \
@@ -851,7 +856,35 @@ impl clap::Args for Exec {
                            fd -g 'test_*.py' -X vim\n\n  \
                        - Find all *.rs files and count the lines with \"wc -l ...\":\n\n      \
                            fd -e rs -X wc -l\
-                     "
+                    "
+                ),
+        )
+        .arg(
+            Arg::new("filter")
+                .action(ArgAction::Append)
+                .long("filter")
+                .short('f')
+                .num_args(1..)
+                .allow_hyphen_values(true)
+                .value_terminator(";")
+                .value_name("cmd")
+                .conflicts_with_all(["exec", "exec_batch", "list_details"])
+                .help("Execute a command to determine whether each result should be filtered")
+                .long_help(
+                    "Execute a command in parallel for each search result, filtering out results where the exit code is non-zero. \
+                     There is no guarantee of the order commands are executed in, and the order should not be depended upon. \
+                     All positional arguments following --filter are considered to be arguments to the command - not to fd. \
+                     It is therefore recommended to place the '-f'/'--filter' option last.\n\
+                     The following placeholders are substituted before the command is executed:\n  \
+                       '{}':   path (of the current search result)\n  \
+                       '{/}':  basename\n  \
+                       '{//}': parent directory\n  \
+                       '{.}':  path without file extension\n  \
+                       '{/.}': basename without file extension\n  \
+                       '{{':   literal '{' (for escaping)\n  \
+                       '}}':   literal '}' (for escaping)\n\n\
+                     If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
+                    "
                 ),
         )
     }
@@ -874,3 +907,4 @@ fn ensure_current_directory_exists(current_directory: &Path) -> anyhow::Result<(
         ))
     }
 }
+

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -35,21 +35,13 @@ pub fn job(
         };
 
         // Generate a command, execute it and store its exit code.
-        let code = if filter {
-            cmd.execute_filter(
-                dir_entry.stripped_path(config),
-                config.path_separator.as_deref(),
-                out_perm,
-                buffer_output,
-            )
-        } else { 
-            cmd.execute(
-                dir_entry.stripped_path(config),
-                config.path_separator.as_deref(),
-                out_perm,
-                buffer_output,
-            )
-        };
+        let code = cmd.execute(
+            dir_entry.stripped_path(config),
+            config.path_separator.as_deref(),
+            out_perm,
+            buffer_output,
+            filter,
+        );
 
         ret = merge_exitcodes([ret, code]);
     }

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -40,6 +40,7 @@ pub fn job(
                 dir_entry.stripped_path(config),
                 config.path_separator.as_deref(),
                 out_perm,
+                buffer_output,
             )
         } else { 
             cmd.execute(

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -15,6 +15,7 @@ pub fn job(
     cmd: &CommandSet,
     out_perm: &Mutex<()>,
     config: &Config,
+    filter: bool,
 ) -> ExitCode {
     // Output should be buffered when only running a single thread
     let buffer_output: bool = config.threads > 1;
@@ -34,12 +35,21 @@ pub fn job(
         };
 
         // Generate a command, execute it and store its exit code.
-        let code = cmd.execute(
-            dir_entry.stripped_path(config),
-            config.path_separator.as_deref(),
-            out_perm,
-            buffer_output,
-        );
+        let code = if filter {
+            cmd.execute_filter(
+                dir_entry.stripped_path(config),
+                config.path_separator.as_deref(),
+                out_perm,
+            )
+        } else { 
+            cmd.execute(
+                dir_entry.stripped_path(config),
+                config.path_separator.as_deref(),
+                out_perm,
+                buffer_output,
+            )
+        };
+
         ret = merge_exitcodes([ret, code]);
     }
     // Returns error in case of any error.

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -120,12 +120,13 @@ impl CommandSet {
         input: &Path,
         path_separator: Option<&str>,
         out_perm: &Mutex<()>,
+        buffer_output: bool,
     ) -> ExitCode {
         let commands = self
             .commands
             .iter()
             .map(|c| c.generate(input, path_separator));
-        execute_commands_filtering(input, commands, out_perm)
+        execute_commands_filtering(input, commands, out_perm, buffer_output)
     }
 
     pub fn execute_batch<I>(&self, paths: I, limit: usize, path_separator: Option<&str>) -> ExitCode

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -107,26 +107,18 @@ impl CommandSet {
         path_separator: Option<&str>,
         out_perm: &Mutex<()>,
         buffer_output: bool,
+        filter: bool,
     ) -> ExitCode {
         let commands = self
             .commands
             .iter()
             .map(|c| c.generate(input, path_separator));
-        execute_commands(commands, out_perm, buffer_output)
-    }
 
-    pub fn execute_filter(
-        &self,
-        input: &Path,
-        path_separator: Option<&str>,
-        out_perm: &Mutex<()>,
-        buffer_output: bool,
-    ) -> ExitCode {
-        let commands = self
-            .commands
-            .iter()
-            .map(|c| c.generate(input, path_separator));
-        execute_commands_filtering(input, commands, out_perm, buffer_output)
+        if filter {
+            execute_commands_filtering(input, commands, out_perm, buffer_output)
+        } else {
+            execute_commands(commands, out_perm, buffer_output)
+        }
     }
 
     pub fn execute_batch<I>(&self, paths: I, limit: usize, path_separator: Option<&str>) -> ExitCode

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -16,7 +16,7 @@ use argmax::Command;
 
 use crate::exit_codes::{merge_exitcodes, ExitCode};
 
-use self::command::{execute_commands, handle_cmd_error};
+use self::command::{execute_commands, execute_commands_filtering, handle_cmd_error};
 use self::input::{basename, dirname, remove_extension};
 pub use self::job::{batch, job};
 use self::token::{tokenize, Token};
@@ -28,6 +28,8 @@ pub enum ExecutionMode {
     OneByOne,
     /// Command is run for a batch of results at once
     Batch,
+    /// Command is executed for each search result to determine if it should be filtered
+    FilterResults,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -76,6 +78,25 @@ impl CommandSet {
         })
     }
 
+    pub fn new_filter<I, T, S>(input: I) -> Result<CommandSet>
+    where
+        I: IntoIterator<Item = T>,
+        T: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Ok(CommandSet {
+            mode: ExecutionMode::FilterResults,
+            commands: input
+                .into_iter()
+                .map(CommandTemplate::new)
+                .collect::<Result<_>>()?,
+        })
+    }
+
+    pub fn get_mode(&self) -> ExecutionMode {
+        self.mode
+    }
+
     pub fn in_batch_mode(&self) -> bool {
         self.mode == ExecutionMode::Batch
     }
@@ -92,6 +113,19 @@ impl CommandSet {
             .iter()
             .map(|c| c.generate(input, path_separator));
         execute_commands(commands, out_perm, buffer_output)
+    }
+
+    pub fn execute_filter(
+        &self,
+        input: &Path,
+        path_separator: Option<&str>,
+        out_perm: &Mutex<()>,
+    ) -> ExitCode {
+        let commands = self
+            .commands
+            .iter()
+            .map(|c| c.generate(input, path_separator));
+        execute_commands_filtering(input, commands, out_perm)
     }
 
     pub fn execute_batch<I>(&self, paths: I, limit: usize, path_separator: Option<&str>) -> ExitCode

--- a/src/exit_codes.rs
+++ b/src/exit_codes.rs
@@ -43,6 +43,7 @@ impl ExitCode {
     }
 }
 
+/// If any of the exit codes was an error, this returns a GeneralError
 pub fn merge_exitcodes(results: impl IntoIterator<Item = ExitCode>) -> ExitCode {
     if results.into_iter().any(ExitCode::is_error) {
         return ExitCode::GeneralError;

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -408,28 +408,32 @@ impl WorkerState {
 
         // This will be set to `Some` if the `--exec` argument was supplied.
         if let Some(ref cmd) = config.command {
-            if cmd.in_batch_mode() {
-                exec::batch(rx.into_iter().flatten(), cmd, config)
-            } else {
-                let out_perm = Mutex::new(());
+            match cmd.get_mode() {
+                exec::ExecutionMode::Batch => {
+                    exec::batch(rx.into_iter().flatten(), cmd, config)
+                },
+                exec::ExecutionMode::OneByOne | exec::ExecutionMode::FilterResults => {
+                    let out_perm = Mutex::new(());
+                    let filter = cmd.get_mode() == exec::ExecutionMode::FilterResults;
 
-                thread::scope(|scope| {
-                    // Each spawned job will store its thread handle in here.
-                    let threads = config.threads;
-                    let mut handles = Vec::with_capacity(threads);
-                    for _ in 0..threads {
-                        let rx = rx.clone();
+                    thread::scope(|scope| {
+                        // Each spawned job will store its thread handle in here.
+                        let threads = config.threads;
+                        let mut handles = Vec::with_capacity(threads);
+                        for _ in 0..threads {
+                            let rx = rx.clone();
 
-                        // Spawn a job thread that will listen for and execute inputs.
-                        let handle = scope
-                            .spawn(|| exec::job(rx.into_iter().flatten(), cmd, &out_perm, config));
+                            // Spawn a job thread that will listen for and execute inputs.
+                            let handle = scope
+                                .spawn(|| exec::job(rx.into_iter().flatten(), cmd, &out_perm, config, filter));
 
-                        // Push the handle of the spawned thread into the vector for later joining.
-                        handles.push(handle);
-                    }
-                    let exit_codes = handles.into_iter().map(|handle| handle.join().unwrap());
-                    merge_exitcodes(exit_codes)
-                })
+                            // Push the handle of the spawned thread into the vector for later joining.
+                            handles.push(handle);
+                        }
+                        let exit_codes = handles.into_iter().map(|handle| handle.join().unwrap());
+                        merge_exitcodes(exit_codes)
+                    })
+                },
             }
         } else {
             let stdout = io::stdout().lock();


### PR DESCRIPTION
Based on the RFC at #400.

This PR adds in a new argument, `-f` / `--filter <command>` which will filter all the results based on the result of the command. If it returns a non-zero exit code, the result will be filtered out.

This is my first Rust PR, please let me know if there is anything I can do to improve this!