### PR TITLE
Abort on panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ debug = true
 lto = true
 strip = true
 codegen-units = 1
+panic = "abort"
 
 [features]
 use-jemalloc = ["tikv-jemallocator"]


### PR DESCRIPTION
This should help both runtime performance and side of the executable.

 And I can't think of a reason why we would need unwinding on panic in
release builds.