### PR TITLE
Add flox install

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,13 @@ You can use the [Nix package manager](https://nixos.org/nix/) to install `fd`:
 nix-env -i fd
 ```
 
+### Via Flox
+
+You can use [Flox](https://flox.dev) to install `fd` into a Flox environment:
+```
+flox install fd
+```
+
 ### On FreeBSD
 
 You can install [the fd-find package](https://www.freshports.org/sysutils/fd) from the official repo:


### PR DESCRIPTION
`fd` is available in Flox, and seems to be working today!
Since Flox and Nix are related, I added the Flox install section below that of Nix.
If you have any questions about Flox, please let me know. 😊