### PR TITLE
Fix up some lints on Windows

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,7 @@ pub struct Config {
     pub ls_colors: Option<LsColors>,
 
     /// Whether or not we are writing to an interactive terminal
+    #[cfg_attr(not(unix), allow(unused))]
     pub interactive_terminal: bool,
 
     /// The type of file to search for. If set to `None`, all file types are displayed. If

--- a/src/hyperlink.rs
+++ b/src/hyperlink.rs
@@ -1,12 +1,8 @@
 use crate::filesystem::absolute_path;
 use std::fmt::{self, Formatter, Write};
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 
 pub(crate) struct PathUrl(PathBuf);
-
-#[cfg(unix)]
-static HOSTNAME: OnceLock<String> = OnceLock::new();
 
 impl PathUrl {
     pub(crate) fn new(path: &Path) -> Option<PathUrl> {
@@ -46,6 +42,10 @@ fn encode(f: &mut Formatter, byte: u8) -> fmt::Result {
 
 #[cfg(unix)]
 fn host() -> &'static str {
+    use std::sync::OnceLock;
+
+    static HOSTNAME: OnceLock<String> = OnceLock::new();
+
     HOSTNAME
         .get_or_init(|| {
             nix::unistd::gethostname()


### PR DESCRIPTION
Lints are not run for Windows in CI so they are missed. There are a couple that have been showing for a few months now so here are some fixes.

The reasoning behind the unused field is because of here:
https://github.com/sharkdp/fd/blob/9f0fea6e21f5dfb192f456dd6fb1ff10cd1c1aa0/src/output.rs#L159-L167

Currently in CI you are only running Clippy for Linux. `cargo clippy --all-targets` does not lint for all target triples, but rather all compilation targets (binaries, libraries, tests, examples). So for each target you have cfg'd code, to lint that code you need to run Clippy on that target. Usually in the CI matrix in another step. Cross Clippy is theoretically possible but I've never gotten it to work reliably.