### PR TITLE
docs: documentation link of regular expressions to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ X11/xinit/xinitrc
 X11/xinit/xserverrc
 ```
 
-The regular expression syntax used by `fd` is [documented here](https://docs.rs/regex/1.0.0/regex/#syntax).
+The regular expression syntax used by `fd` is [documented here](https://docs.rs/regex/latest/regex/#syntax).
 
 ### Specifying the root directory
 


### PR DESCRIPTION
Right now the README link redirects to the regex documentation for version 1.0.0, to improve this I have changed it to redirect to latest