### PR TITLE
docs(install): add x-cmd method to install fd

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,15 @@ You can use [Flox](https://flox.dev) to install `fd` into a Flox environment:
 flox install fd
 ```
 
+### Via x-cmd
+
+You can use the [x-cmd](https://www.x-cmd.com) to install `fd`:
+```
+x env use fd
+# of
+x fd
+```
+
 ### On FreeBSD
 
 You can install [the fd-find package](https://www.freshports.org/sysutils/fd) from the official repo:


### PR DESCRIPTION
- Hi, [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.. It helps you download fd release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the fd installation.md?**[The installation method for the x command](https://www.x-cmd.com/start/).
  ```sh
  x env use fd
  # or
  x fd
  ```

- We wrote a [fd introduction article](https://www.x-cmd.com/pkg/fd) and a [demo](https://www.x-cmd.com/1min/fd)