### PR TITLE
Add support to find dead symlinks

### DIFF
--- a/doc/fd.1
+++ b/doc/fd.1
@@ -223,7 +223,8 @@ Searching for '--type file --type symlink' will show both regular files as well 
 symlinks. Note that the 'executable' and 'empty' filters work differently: '--type
 executable' implies '--type file' by default. And '--type empty' searches for
 empty files and directories, unless either '--type file' or '--type directory' is
-specified in addition.
+specified in addition to search for that type only, or '--type symlink' is
+specified in addition to search for dead symlinks.
 
 Examples:
   - Only search for files:
@@ -241,6 +242,9 @@ Examples:
   - Find empty directories:
       fd --type empty --type directory
       fd -te -td
+  - Find dead symlinks:
+      fd --type empty --type symlink
+      fd -te -tl
 .RE
 .TP
 .BI "\-e, \-\-extension " ext

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -328,7 +328,8 @@ pub struct Opts {
     /// well as symlinks. Note that the 'executable' and 'empty' filters work differently:
     /// '--type executable' implies '--type file' by default. And '--type empty' searches
     /// for empty files and directories, unless either '--type file' or '--type directory'
-    /// is specified in addition.
+    /// is specified in addition to search for that type only, or '--type symlink' is
+    /// specified in addition to search for dead symlinks.
     ///
     /// Examples:
     /// {n}  - Only search for files:
@@ -346,6 +347,9 @@ pub struct Opts {
     /// {n}  - Find empty directories:
     /// {n}      fd --type empty --type directory
     /// {n}      fd -te -td
+    /// {n}  - Find dead symlinks:
+    /// {n}      fd --type empty --type symlink
+    /// {n}      fd -te -tl
     #[arg(
         long = "type",
         short = 't',

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::io;
 #[cfg(any(unix, target_os = "redox"))]
 use std::os::unix::fs::FileTypeExt;
-use std::path::{Path, PathBuf};
+use std::path::{Path, PathBuf, MAIN_SEPARATOR_STR};
 
 use normpath::PathExt;
 
@@ -51,6 +51,17 @@ pub fn is_empty(entry: &dir_entry::DirEntry) -> bool {
             }
         } else if file_type.is_file() {
             entry.metadata().map(|m| m.len() == 0).unwrap_or(false)
+        } else if file_type.is_symlink() {
+            if let Ok(target) = entry.path().read_link() {
+                let full_target = entry
+                    .path()
+                    .parent()
+                    .unwrap_or(Path::new(MAIN_SEPARATOR_STR))
+                    .join(target);
+                !full_target.exists()
+            } else {
+                false
+            }
         } else {
             false
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,9 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
             }
 
             // If only 'empty' was specified, search for both files and directories:
-            if file_types.empty_only && !(file_types.files || file_types.directories) {
+            if file_types.empty_only
+                && !(file_types.files || file_types.directories || file_types.symlinks)
+            {
                 file_types.files = true;
                 file_types.directories = true;
             }


### PR DESCRIPTION
Find dead symbolic links by reusing the `--type empty` flag.