### PR TITLE
chore: Bind milestone to merged PR and closed issues automatically

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,0 +1,32 @@
+# Description:
+#   - Add milestone to a merged PR automatically
+#   - Add milestone to a closed issue that has a merged PR fix (if any)
+
+name: Milestone Action
+on:
+  issues:
+    types: [closed]
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  update-milestone:
+    runs-on: ubuntu-latest
+    name: Milestone Update
+    steps:
+      - name: Set Milestone for PR
+        uses: hustcer/milestone-action@v2
+        if: github.event.pull_request.merged == true
+        with:
+          action: bind-pr # `bind-pr` is the default action
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Bind milestone to closed issue that has a merged PR fix
+      - name: Set Milestone for Issue
+        uses: hustcer/milestone-action@v2
+        if: github.event.issue.state == 'closed'
+        with:
+          action: bind-issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description:

This workflow will do the following things:

   - Add milestone to a merged PR automatically, example [action running logs](https://github.com/nushell/nushell/actions/runs/12530004607/job/34946134565)
   - Add milestone to a closed issue that has a merged PR fix (if any), example [action running logs](https://github.com/nushell/nushell/actions/runs/12515661380/job/34913564683)

If there is no opened milestone the action will stop. If there are multiple opened milestones, the action will bind to the one whose due date is closest to the PR merged date and fall back to the first one sorted by the milestone created date.

We have use it in Nushell for a while, such as [v0.101.0](https://github.com/nushell/nushell/issues?q=is%3Aclosed+milestone%3Av0.101.0)

Don't merge it if it's not a good fit 