### PR TITLE
chore: Use macos-13 instead of 12

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -87,7 +87,7 @@ jobs:
           - { target: i686-pc-windows-msvc        , os: windows-2022                  }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-22.04, use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-22.04, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-12                      }
+          - { target: x86_64-apple-darwin         , os: macos-13                      }
           - { target: aarch64-apple-darwin        , os: macos-14                      }
           - { target: x86_64-pc-windows-gnu       , os: windows-2022                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2022                  }


### PR DESCRIPTION
Github actions doesn't suport macos-12 anymore