### PR TITLE
doc: Disambiguate modification time vs timestamp

### DIFF
--- a/doc/fd.1
+++ b/doc/fd.1
@@ -336,7 +336,7 @@ tebibytes
 .TP
 .BI "\-\-changed-within " date|duration
 Filter results based on the file modification time.
-Files with modification times greater than the argument will be returned.
+Files with modification timestamps greater than the argument will be returned.
 The argument can be provided as a duration (\fI10h, 1d, 35min\fR) or as a specific point
 in time as full RFC3339 format with time zone, as a date or datetime in the
 local time zone (\fIYYYY-MM-DD\fR or \fIYYYY-MM-DD HH:MM:SS\fR), or as the prefix '@'
@@ -355,7 +355,7 @@ Examples:
 .TP
 .BI "\-\-changed-before " date|duration
 Filter results based on the file modification time.
-Files with modification times less than the argument will be returned.
+Files with modification timestamps less than the argument will be returned.
 The argument can be provided as a duration (\fI10h, 1d, 35min\fR) or as a specific point
 in time as full RFC3339 format with time zone, as a date or datetime in the
 local time zone (\fIYYYY-MM-DD\fR or \fIYYYY-MM-DD HH:MM:SS\fR), or as the prefix '@'


### PR DESCRIPTION
Description of `--changed-within` has the following statement.

> Files with modification times greater than the argument will be returned.

At least for me the natural interpretation of "modification time" is relative, e.g. 2 weeks ago, 24 hours ago, etc. Using this interpretation the statement above is opposite of the actual behaviour: modification time greater than (i.e. more than) 24 hour would match files _older_ than the argument, not newer.

I think the statement intended to say "modification **timestamps** greater than", which would make it unambiguous, i.e. prevent the incorrect interpretation. Fixed descriptions of both `--changed-within` and `--changed-before` accordingly.
