### PR TITLE
Update etcetera from 0.9 to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d14b66eac142247efb8561051ff0fb3d3f58a09801a541b89f46dcc4cc67b84"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
 dependencies = [
  "cfg-if",
  "home",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ regex-syntax = "0.8"
 ctrlc = "3.2"
 globset = "0.4"
 anyhow = "1.0"
-etcetera = "0.9"
+etcetera = "0.10"
 normpath = "1.1.1"
 crossbeam-channel = "0.5.14"
 clap_complete = {version = "4.5.47", optional = true}


### PR DESCRIPTION
Pin `home` to `<0.5.11` to avoid MSRV problems. As described in https://github.com/lunacookies/etcetera/releases/tag/v0.10.0. This keeps the MSRV at 1.70.0 (less than `fd`’s 1.77.2), rather than increasing it to 1.81.0 for `etcetera` 0.10.