### PR TITLE
Add aarch64 Windows to CI.

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -91,6 +91,7 @@ jobs:
           - { target: aarch64-apple-darwin        , os: macos-14                      }
           - { target: x86_64-pc-windows-gnu       , os: windows-2022                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2022                  }
+          - { target: aarch64-pc-windows-msvc     , os: windows-11-arm                }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-22.04, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-22.04, use-cross: true }
     env:


### PR DESCRIPTION
Closes #1658.

I tested the CI run in my fork; you can see the results here https://github.com/jcotton42/fd/actions/runs/14741919681.

I do not have an ARM Windows device to test with at the moment, but CI was successful, and a check with `file` from Git Bash shows the binary is arm64.