### PR TITLE
Add --ignore-file-name option (#1713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Features
 
 - Add a hidden `--mindepth` alias for `--min-depth`. (#1617)
+- Add `--ignore-file-name` option to specify a custom name for ignore files, providing more
+  flexible ignore rule management. See #1713 
 
 
 ## Bugfixes

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -498,6 +498,19 @@ pub struct Opts {
     )]
     pub ignore_file: Vec<PathBuf>,
 
+    /// Use a custom file name for ignore files. When this is set, fd will not
+    /// look for '.ignore' or '.fdignore' files, but for a file with the given
+    /// name in each directory. If the custom ignore file is empty, all entries
+    /// in its directory are ignored.
+    #[arg(
+        long,
+        value_name = "name",
+        hide_short_help = true,
+        help = "Use a custom name for ignore files instead of .ignore/.fdignore",
+        long_help
+    )]
+    pub ignore_file_name: Option<String>,
+
     /// Declare when to use color for the pattern match output
     #[arg(
         long,

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,10 @@ pub struct Config {
     /// A list of custom ignore files.
     pub ignore_files: Vec<PathBuf>,
 
+    /// The name of the custom ignore file to look for in each directory.
+    /// If set, .ignore and .fdignore are not used.
+    pub custom_ignore_file_name: Option<String>,
+
     /// The given constraints on the size of returned files
     pub size_constraints: Vec<SizeFilter>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,6 +314,7 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         batch_size: opts.batch_size,
         exclude_patterns: opts.exclude.iter().map(|p| String::from("!") + p).collect(),
         ignore_files: std::mem::take(&mut opts.ignore_file),
+        custom_ignore_file_name: opts.ignore_file_name.take(),
         size_constraints: size_limits,
         time_constraints,
         #[cfg(unix)]


### PR DESCRIPTION
This PR adds support for a new flag `--ignore-file-name=FOO`. #1713

- It overrides the default `.ignore` / `~/.fdignore` files.
- Instead, it looks for the specified file (`FOO`) in each directory.
- Patterns in the file are parsed the same as `.gitignore`.

Additional behavior:
- If the file exists but contains only empty lines, it causes the entire directory to be ignored.

