### PR TITLE
Update README.md to RHEL 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ You can install [the fd package](https://github.com/getsolus/packages/tree/main/
 eopkg install fd
 ```
 
-### On RedHat Enterprise Linux 8/9 (RHEL8/9), Almalinux 8/9, EuroLinux 8/9 or Rocky Linux 8/9
+### On RedHat Enterprise Linux (RHEL) 8/9/10, Almalinux 8/9/10, EuroLinux 8/9 or Rocky Linux 8/9/10
 
 You can install [the `fd` package](https://copr.fedorainfracloud.org/coprs/tkbcopr/fd/) from Fedora Copr.
 


### PR DESCRIPTION
RHEL 10 has been released. We’ve tested the Copr package on it.

There doesn’t appear to be plans for a EuroLinux 10. The slower, malloc-based fd-find isn’t available for EPEL 10.0 yet and is being tracked [here](https://bugzilla.redhat.com/show_bug.cgi?id=2370031). So I’ve left these two unchanged.