### PR TITLE
Changes to support building/testing fd on Illumos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,9 @@ libc = "0.2"
 # FIXME: Re-enable jemalloc on macOS
 # jemalloc is currently disabled on macOS due to a bug in jemalloc in combination with macOS
 # Catalina. See https://github.com/sharkdp/fd/issues/498 for details.
-[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_os = "freebsd"), not(target_os = "openbsd"), not(all(target_env = "musl", target_pointer_width = "32")), not(target_arch = "riscv64")))'.dependencies]
+# This has to be kept in sync with src/main.rs where the allocator for
+# the program is set.
+[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_os = "freebsd"), not(target_os = "openbsd"), not(target_os = "illumos"), not(all(target_env = "musl", target_pointer_width = "32")), not(target_arch = "riscv64")))'.dependencies]
 tikv-jemallocator = {version = "0.6.0", optional = true}
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,12 +36,15 @@ use crate::regex_helper::{pattern_has_uppercase_char, pattern_matches_strings_wi
 
 // We use jemalloc for performance reasons, see https://github.com/sharkdp/fd/pull/481
 // FIXME: re-enable jemalloc on macOS, see comment in Cargo.toml file for more infos
+// This has to be kept in sync with the Cargo.toml file section that declares a
+// dependency on tikv-jemallocator.
 #[cfg(all(
     not(windows),
     not(target_os = "android"),
     not(target_os = "macos"),
     not(target_os = "freebsd"),
     not(target_os = "openbsd"),
+    not(target_os = "illumos"),
     not(all(target_env = "musl", target_pointer_width = "32")),
     not(target_arch = "riscv64"),
     feature = "use-jemalloc"

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2601,7 +2601,7 @@ fn test_strip_cwd_prefix() {
 /// When fd is ran from a non-existent working directory, but an existent
 /// directory is passed in the arguments, it should still run fine
 #[test]
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_os = "illumos")))]
 fn test_invalid_cwd() {
     let te = TestEnv::new(&[], &[]);
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1765,12 +1765,10 @@ fn test_exec() {
     }
 }
 
+// TODO test for windows
+#[cfg(not(windows))]
 #[test]
 fn test_exec_multi() {
-    // TODO test for windows
-    if cfg!(windows) {
-        return;
-    }
     let (te, abs_path) = get_test_env_with_abs_path(DEFAULT_DIRS, DEFAULT_FILES);
 
     te.assert_output(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1813,9 +1813,11 @@ fn test_exec_multi() {
         e1 e2",
     );
 
+    // We use printf here because we need to suppress a newline and
+    // echo -n is not POSIX-compliant.
     te.assert_output(
         &[
-            "foo", "--exec", "echo", "-n", "{/}: ", ";", "--exec", "echo", "{//}",
+            "foo", "--exec", "printf", "%s", "{/}: ", ";", "--exec", "printf", "%s\\n", "{//}",
         ],
         "a.foo: .
         b.foo: ./one


### PR DESCRIPTION
Fix for #1741: jemalloc doesn't build on Illumos, so add it to the list of excluded platforms.