### PR TITLE
Split integration tests into separate files

### DIFF
--- a/tests/integration/and.rs
+++ b/tests/integration/and.rs
@@ -1,5 +1,3 @@
-mod testenv;
-
 use crate::testenv::{TestEnv, DEFAULT_DIRS, EXTRA_FILES};
 
 /// AND test

--- a/tests/integration/exec.rs
+++ b/tests/integration/exec.rs
@@ -1,5 +1,3 @@
-mod testenv;
-
 use crate::testenv::{get_test_env_with_abs_path, TestEnv, DEFAULT_DIRS, DEFAULT_FILES};
 
 /// Shell script execution (--exec)

--- a/tests/integration/general.rs
+++ b/tests/integration/general.rs
@@ -1,5 +1,3 @@
-mod testenv;
-
 #[cfg(unix)]
 use nix::unistd::Uid;
 use std::fs;

--- a/tests/integration/glob.rs
+++ b/tests/integration/glob.rs
@@ -1,5 +1,3 @@
-mod testenv;
-
 use crate::testenv::{TestEnv, DEFAULT_DIRS, DEFAULT_FILES};
 
 /// Glob-based searches (--glob)

--- a/tests/integration/ignore.rs
+++ b/tests/integration/ignore.rs
@@ -1,5 +1,3 @@
-mod testenv;
-
 use std::fs;
 use std::io::Write;
 use test_case::test_case;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,0 +1,9 @@
+mod and;
+mod exec;
+mod general;
+mod glob;
+mod ignore;
+mod owner;
+mod symlink;
+
+mod testenv;

--- a/tests/integration/owner.rs
+++ b/tests/integration/owner.rs
@@ -1,5 +1,3 @@
-mod testenv;
-
 #[cfg(unix)]
 use nix::unistd::{Gid, Group, Uid, User};
 

--- a/tests/integration/symlink.rs
+++ b/tests/integration/symlink.rs
@@ -1,5 +1,3 @@
-mod testenv;
-
 use regex::escape;
 
 use crate::testenv::{get_test_env_with_abs_path, TestEnv, DEFAULT_DIRS, DEFAULT_FILES};

--- a/tests/integration/testenv/mod.rs
+++ b/tests/integration/testenv/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use normpath::PathExt;
 use std::env;
 use std::fs;


### PR DESCRIPTION
PR for https://github.com/sharkdp/fd/issues/1744.

Total test runtime appears very slightly slower (by ~100ms for me locally), presumably a constant due to the overhead of creating separate binaries for each test file. However, I think the improved organization is probably worth it as it makes it a little clearer how the tests are distributed and to know where to put new tests.

As each test file is created as a separate binary now clippy warns when parts of `testenv` are not used by every test file, so I added `#![allow(dead_code)]` at the top of `testenv/mod.rs` to suppress that. Not sure if there's a better way to handle that.

I'm open to any suggestions for different file layouts too. For example, if there any gaps in current test types a file could be created to highlight that with the goal of filling it out.