### PR TITLE
feat: add new option "--exclude-absolute-path" #1751

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -305,6 +305,20 @@ pub struct Opts {
     )]
     pub exclude: Vec<String>,
 
+    /// Exclude directories that match the given absolute paths.
+    /// Multiple absolute paths can be specified.
+    ///
+    /// Examles:
+    /// {n}  --exclude-absolute-path /Volumes/
+    /// {n}  --exclude-absolute-path /Library/Backups/
+    #[arg(
+        long,
+        value_name = "absolute-path",
+        help = "Exclude directories that match the given absolute paths",
+        long_help
+    )]
+    pub exclude_absolute_path: Vec<String>,
+
     /// Do not traverse into directories that match the search criteria. If
     /// you want to exclude specific directories, use the '--exclude=…' option.
     #[arg(long, hide_short_help = true, conflicts_with_all(&["size", "exact_depth"]),

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,9 @@ pub struct Config {
     /// A list of glob patterns that should be excluded from the search.
     pub exclude_patterns: Vec<String>,
 
+    /// A list of paths that should be excluded from the search.
+    pub exclude_absolute_paths: Vec<String>,
+
     /// A list of custom ignore files.
     pub ignore_files: Vec<PathBuf>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,6 +316,11 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         command: command.map(Arc::new),
         batch_size: opts.batch_size,
         exclude_patterns: opts.exclude.iter().map(|p| String::from("!") + p).collect(),
+        exclude_absolute_paths: opts
+            .exclude_absolute_path
+            .iter()
+            .map(|p| String::from("") + p)
+            .collect(),
         ignore_files: std::mem::take(&mut opts.ignore_file),
         size_constraints: size_limits,
         time_constraints,

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -364,6 +364,32 @@ impl WorkerState {
             .same_file_system(config.one_file_system)
             .max_depth(config.max_depth);
 
+        if !self.config.exclude_absolute_paths.is_empty() {
+            let exclude_abs_paths: Vec<PathBuf> = self
+                .config
+                .exclude_absolute_paths
+                .iter()
+                .map(|s| {
+                    let mut s = s.clone();
+                    if !s.ends_with('/') {
+                        s.push('/');
+                    }
+                    PathBuf::from(s)
+                })
+                .collect();
+            builder.filter_entry(move |entry| match entry.path().canonicalize() {
+                Ok(abs_path) => {
+                    for excluded in &exclude_abs_paths {
+                        if abs_path.starts_with(excluded) {
+                            return false;
+                        }
+                    }
+                    true
+                }
+                Err(_) => true,
+            });
+        }
+
         if config.read_fdignore {
             builder.add_custom_ignore_filename(".fdignore");
         }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -377,17 +377,19 @@ impl WorkerState {
                     PathBuf::from(s)
                 })
                 .collect();
-            builder.filter_entry(move |entry| match entry.path().canonicalize() {
-                Ok(abs_path) => {
-                    for excluded in &exclude_abs_paths {
-                        if abs_path.starts_with(excluded) {
-                            return false;
+            builder.filter_entry(
+                move |entry| match filesystem::path_absolute_form(entry.path()) {
+                    Ok(abs_path) => {
+                        for excluded in &exclude_abs_paths {
+                            if abs_path.starts_with(excluded) {
+                                return false;
+                            }
                         }
+                        true
                     }
-                    true
-                }
-                Err(_) => true,
-            });
+                    Err(_) => true,
+                },
+            );
         }
 
         if config.read_fdignore {

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -195,7 +195,7 @@ impl TestEnv {
         match fs::canonicalize(&joined) {
             Ok(canonical) => canonical.to_string_lossy().into_owned(),
             Err(_) => joined.to_string_lossy().into_owned(), // fallback
-        }    
+        }
     }
 
     /// Create a broken symlink at the given path in the temp_dir.

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -185,6 +185,19 @@ impl TestEnv {
         }
     }
 
+    /// Returns the canonical path for files or folders in the temporary directory.
+    /// Normally, `TestEnv` creates a temporary directory under `/var` for tests. However, this
+    /// doesn't work well with `--exclude-absolute-path`, as it filters entries using their
+    /// absolute paths, and the canonical path of `/var` is actually `/private/var` on macOS.
+    pub fn get_canonical_path_in_temp_dir(&self, path: &str) -> String {
+        let joined = self.temp_dir.path().join(path);
+
+        match fs::canonicalize(&joined) {
+            Ok(canonical) => canonical.to_string_lossy().into_owned(),
+            Err(_) => joined.to_string_lossy().into_owned(), // fallback
+        }    
+    }
+
     /// Create a broken symlink at the given path in the temp_dir.
     pub fn create_broken_symlink<P: AsRef<Path>>(
         &mut self,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1629,7 +1629,10 @@ fn test_exclude_absolute_paths() {
     let te = TestEnv::new(dirs, DEFAULT_FILES);
 
     te.assert_output(
-        &["--exclude-absolute-path", &te.get_canonical_path_in_temp_dir("one/two")],
+        &[
+            "--exclude-absolute-path",
+            &te.get_canonical_path_in_temp_dir("one/two"),
+        ],
         "a.foo
         e1 e2
         one/

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1622,6 +1622,39 @@ fn test_excludes() {
     );
 }
 
+/// Exclude absolute paths (--exclude-absolute-path)
+#[test]
+fn test_exclude_absolute_paths() {
+    let dirs: &[&str] = &["one/two/three", "one/four/dir"];
+    let te = TestEnv::new(dirs, DEFAULT_FILES);
+
+    te.assert_output(
+        &["--exclude-absolute-path", &te.get_canonical_path_in_temp_dir("one/two")],
+        "a.foo
+        e1 e2
+        one/
+        one/b.foo
+        one/four/
+        one/four/dir/
+        symlink",
+    );
+
+    te.assert_output(
+        &[
+            "--exclude-absolute-path",
+            &te.get_canonical_path_in_temp_dir("one/two/"),
+            "--exclude-absolute-path",
+            &te.get_canonical_path_in_temp_dir("one/four/dir"),
+        ],
+        "a.foo
+        e1 e2
+        one/
+        one/b.foo
+        one/four/
+        symlink",
+    );
+}
+
 #[test]
 fn format() {
     let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);


### PR DESCRIPTION
### Summary
This pull request adds support for excluding absolute paths from search results.

### Details
- Introduced a new option `--exclude-absolute-path` in the CLI arguments.
- Used `WalkBuilder::filter_entry` to filter out entries that match the specified absolute paths.

Related Issue
- [exclude and absolute path as argument #1577](https://github.com/sharkdp/fd/issues/1577)
- [--exclude doesn't work with absolute paths #851](https://github.com/sharkdp/fd/issues/851)
- [--exclude is not working #1337](https://github.com/sharkdp/fd/issues/1337)
- [Global absolute paths in ignore file? #1150](https://github.com/sharkdp/fd/issues/1150)