### PR TITLE
fix: Remove duplicate nix from lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,18 +481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.9.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "normpath"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
To fix the broken build on master due to a bad merge