### PR TITLE
docs: Add installation method with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,12 @@ Note that rust version *1.77.2* or later is required.
 
 The [release page](https://github.com/sharkdp/fd/releases) includes precompiled binaries for Linux, macOS and Windows. Statically-linked binaries are also available: look for archives with `musl` in the file name.
 
+On Linux and macOS installation from binaries can be automated with [gah](https://github.com/marverix/gah):
+
+```
+gah install fd
+```
+
 ## Development
 ```bash
 git clone https://github.com/sharkdp/fd


### PR DESCRIPTION
Hello!
This PR adds to the documentation installation method using [gah](https://github.com/marverix/gah):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.