### PR TITLE
Os update

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -80,20 +80,19 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-22.04, use-cross: true }
-          - { target: aarch64-unknown-linux-musl  , os: ubuntu-22.04, use-cross: true }
-          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-22.04, use-cross: true }
-          - { target: arm-unknown-linux-musleabihf, os: ubuntu-22.04, use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-24.04, use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-24.04, use-cross: true }
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-24.04, use-cross: true }
+          - { target: arm-unknown-linux-musleabihf, os: ubuntu-24.04, use-cross: true }
           - { target: i686-pc-windows-msvc        , os: windows-2022                  }
-          - { target: i686-unknown-linux-gnu      , os: ubuntu-22.04, use-cross: true }
-          - { target: i686-unknown-linux-musl     , os: ubuntu-22.04, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-13                      }
+          - { target: i686-unknown-linux-gnu      , os: ubuntu-24.04, use-cross: true }
+          - { target: i686-unknown-linux-musl     , os: ubuntu-24.04, use-cross: true }
           - { target: aarch64-apple-darwin        , os: macos-14                      }
           - { target: x86_64-pc-windows-gnu       , os: windows-2022                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2022                  }
           - { target: aarch64-pc-windows-msvc     , os: windows-11-arm                }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-22.04, use-cross: true }
-          - { target: x86_64-unknown-linux-musl   , os: ubuntu-22.04, use-cross: true }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-24.04, use-cross: true }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-24.04, use-cross: true }
     env:
       BUILD_CMD: cargo
     steps:


### PR DESCRIPTION
- Remove macos-13 because GitHub no longer supports it.
- Update the version of Ubuntu used.

See https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down

We'll need to remove the macos-13 before september 1