### PR TITLE
Fix PowerShell completion filename collision on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ $(EXE): Cargo.toml src/**/*.rs
 	cargo build --profile $(PROFILE) --locked
 
 .PHONY: completions
-completions: autocomplete/fd.bash autocomplete/fd.fish autocomplete/fd.ps1 autocomplete/_fd
+completions: autocomplete/fd.bash autocomplete/fd.fish autocomplete/_fd.ps1 autocomplete/_fd
 
 comp_dir=@mkdir -p autocomplete
 
@@ -21,7 +21,7 @@ autocomplete/fd.fish: $(EXE)
 	$(comp_dir)
 	$(EXE) --gen-completions fish > $@
 
-autocomplete/fd.ps1: $(EXE)
+autocomplete/_fd.ps1: $(EXE)
 	$(comp_dir)
 	$(EXE) --gen-completions powershell > $@
 

--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ your shell, you may need to source the file as well:
 - bash: you will need to source the fd.bash file in your ~/.bashrc file. Or put it in a directory of files that are all sourced.
 - zsh: move the "_fd" file to somewhere on your fpath
 - fish: Put fd.fish in ~/.config/fish/completions
-- powershell: Source the fd.ps1 file from one of the files in  the [profile scripts locations](https://learn.microsoft.com/en-us/powershell/scripting/learn/shell/creating-profiles?view=powershell-7.5).
+- powershell: Source the _fd.ps1 file from one of the files in  the [profile scripts locations](https://learn.microsoft.com/en-us/powershell/scripting/learn/shell/creating-profiles?view=powershell-7.5).
 
 ## Maintainers
 


### PR DESCRIPTION
## Fix PowerShell completion filename collision on Windows

### Problem
On Windows, both `fd.exe` and `fd.ps1` are placed in the same directory, causing a name collision since PowerShell treats both as callable with the name `fd`.

### Solution
Rename PowerShell completion file from `fd.ps1` to `_fd.ps1` to follow the convention used by other tools:
- ripgrep: `rg.exe` + `_rg.ps1`
- zoxide: `zoxide.exe` + `_zoxide.ps1`
- fd: `fd.exe` + `_fd.ps1` (after this fix)

### Changes
- Updated Makefile to generate `_fd.ps1` instead of `fd.ps1`
- Updated README.md to reference the correct filename in user instructions

Fixes #1798