### PR TITLE
feat(output): implement YAML output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Add `--yaml` flag for YAML format output. 
 
 ## Bugfixes
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -647,6 +647,16 @@ pub struct Opts {
     )]
     search_path: Vec<PathBuf>,
 
+    /// Print results as YAML objects so you can use it with tools like yq and nushell.
+    #[arg(
+        long,
+        value_name = "yaml",
+        conflicts_with("format"),
+        conflicts_with("list_details"),
+        help = "Print results as YAML objects so you can use it with tools like yq and nushell."
+    )]
+    pub yaml: bool,
+
     /// By default, relative paths are prefixed with './' when -x/--exec,
     /// -X/--exec-batch, or -0/--print0 are given, to reduce the risk of a
     /// path starting with '-' being treated as a command line option. Use

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,9 @@ pub struct Config {
 
     /// Whether or not to use hyperlinks on paths
     pub hyperlink: bool,
+
+    /// Whether or not to print the result as a JSON object
+    pub yaml: bool,
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,6 +326,7 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         actual_path_separator,
         max_results: opts.max_results(),
         strip_cwd_prefix: opts.strip_cwd_prefix(|| !(opts.null_separator || has_command)),
+        yaml: opts.yaml,
     })
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::io::{self, Write};
-use std::os::unix::fs::PermissionsExt;
 
 use lscolors::{Indicator, LsColors, Style};
 
@@ -8,6 +7,9 @@ use crate::config::Config;
 use crate::dir_entry::DirEntry;
 use crate::fmt::FormatTemplate;
 use crate::hyperlink::PathUrl;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 fn replace_path_separator(path: &str, new_path_separator: &str) -> String {
     path.replace(std::path::MAIN_SEPARATOR, new_path_separator)
@@ -183,7 +185,7 @@ fn print_entry_yaml_obj<W: Write>(
     config: &Config,
 ) -> io::Result<()> {
     let path = entry.stripped_path(config);
-    let path_string = path.to_string_lossy();
+    let path_string = path.to_string_lossy().escape_default().to_string();
     let file_type = entry
         .file_type()
         .map(|ft| {
@@ -208,10 +210,13 @@ fn print_entry_yaml_obj<W: Write>(
     if !metadata.is_none() {
         if let Some(meta) = metadata {
             result.push_str(&format!("  size: {}\n", meta.len()));
-            result.push_str(&format!(
-                "  mode: {:o}\n",
-                meta.permissions().mode() & 0o7777
-            ));
+            #[cfg(unix)]
+            {
+                result.push_str(&format!(
+                    "  mode: {:o}\n",
+                    meta.permissions().mode() & 0o7777
+                ));
+            }
             if let Ok(modified) = meta.modified() {
                 if let Ok(duration) = modified.duration_since(std::time::UNIX_EPOCH) {
                     result.push_str(&format!("  modified: {}\n", duration.as_secs()));


### PR DESCRIPTION
Implement `--yaml` switch for YAML format output, which allows using `yq` or nushell to interact with the result. 

<img width="2880" height="1800" alt="nushell result" src="https://github.com/user-attachments/assets/9adc6946-cd1e-466b-8096-20c96de81b80" />

Actually I was initially working on #1765, but could not reach to a perfect state. JSON *afraids* trailing commas, making it *not so easy* to statelessly stream the result without a buffer. Considering a large number of potiential results, it would be memory-consuming to store all lines and print them at last. 

On the other side, the YAML format, while infamous for its complexity on parsing, is friendly for streaming output. No need for serializing or extra dependencies, the simple and fast `write!` is all you need.

There are tools like `yq` that work just like beloved `jq`, and nushell supports YAML as well, so I suggest this PR might be able to close #1765. 