### PR TITLE
fix: --print0 now works with --exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## Bugfixes
 
+- `--print0` combined with `--exec` will now print a `\0` between the output of each entry. Note that if there are multiple instances
+  of `--exec`, the `\0` will be between each _set_ of commands, _not_ between each individual command run. Fixes #1797.
+
 
 ## Changes
 

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -449,6 +449,9 @@ option.
 
 If no placeholder is present, an implicit "{}" at the end is assumed.
 
+If --print0 is also given, then a null character (\\0) will be printed between the output for each found entry.
+This allows another program to easily distinguish the output for each file if the command(s) produce multiple lines.
+
 Examples:
 
   - find all *.zip files and unzip them:
@@ -462,6 +465,10 @@ Examples:
   - Convert all *.jpg files to *.png files:
 
         fd -e jpg -x convert {} {.}.png
+
+  - Run stat for each *.txt file, separated by null characters
+
+        fd -0 -e txt -x stat
 .RE
 .TP
 .BI "\-X, \-\-exec-batch " command

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -1,5 +1,3 @@
-use std::sync::Mutex;
-
 use crate::config::Config;
 use crate::error::print_error;
 use crate::exit_codes::{merge_exitcodes, ExitCode};
@@ -13,7 +11,6 @@ use super::CommandSet;
 pub fn job(
     results: impl IntoIterator<Item = WorkerResult>,
     cmd: &CommandSet,
-    out_perm: &Mutex<()>,
     config: &Config,
 ) -> ExitCode {
     // Output should be buffered when only running a single thread
@@ -37,7 +34,7 @@ pub fn job(
         let code = cmd.execute(
             dir_entry.stripped_path(config),
             config.path_separator.as_deref(),
-            out_perm,
+            config.null_separator,
             buffer_output,
         );
         ret = merge_exitcodes([ret, code]);

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -6,11 +6,11 @@ use std::io;
 use std::iter;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::Mutex;
 
 use anyhow::{bail, Result};
 use argmax::Command;
 
+use crate::exec::command::OutputBuffer;
 use crate::exit_codes::{merge_exitcodes, ExitCode};
 use crate::fmt::{FormatTemplate, Token};
 
@@ -80,14 +80,14 @@ impl CommandSet {
         &self,
         input: &Path,
         path_separator: Option<&str>,
-        out_perm: &Mutex<()>,
+        null_separator: bool,
         buffer_output: bool,
     ) -> ExitCode {
         let commands = self
             .commands
             .iter()
             .map(|c| c.generate(input, path_separator));
-        execute_commands(commands, out_perm, buffer_output)
+        execute_commands(commands, OutputBuffer::new(null_separator), buffer_output)
     }
 
     pub fn execute_batch<I>(&self, paths: I, limit: usize, path_separator: Option<&str>) -> ExitCode

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -413,8 +413,6 @@ impl WorkerState {
             if cmd.in_batch_mode() {
                 exec::batch(rx.into_iter().flatten(), cmd, config)
             } else {
-                let out_perm = Mutex::new(());
-
                 thread::scope(|scope| {
                     // Each spawned job will store its thread handle in here.
                     let threads = config.threads;
@@ -423,8 +421,8 @@ impl WorkerState {
                         let rx = rx.clone();
 
                         // Spawn a job thread that will listen for and execute inputs.
-                        let handle = scope
-                            .spawn(|| exec::job(rx.into_iter().flatten(), cmd, &out_perm, config));
+                        let handle =
+                            scope.spawn(|| exec::job(rx.into_iter().flatten(), cmd, config));
 
                         // Push the handle of the spawned thread into the vector for later joining.
                         handles.push(handle);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1826,6 +1826,21 @@ fn test_exec_multi() {
     );
 }
 
+#[cfg(not(windows))]
+#[test]
+fn test_exec_nulls() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+    te.assert_output(
+        &["foo", "--print0", "--exec", "printf", "p=%s"],
+        "p=./a.fooNULL
+        p=./one/b.fooNULL
+        p=./one/two/C.Foo2NULL
+        p=./one/two/c.fooNULL
+        p=./one/two/three/d.fooNULL
+        p=./one/two/three/directory_fooNULL",
+    );
+}
+
 #[test]
 fn test_exec_batch() {
     let (te, abs_path) = get_test_env_with_abs_path(DEFAULT_DIRS, DEFAULT_FILES);


### PR DESCRIPTION
If you use --print0 with --exec, it will now print a \0 between each set
of commands run. That is, between the output for the commands run for
each found item.

Fixes: #1797
