### PR TITLE
"Add cargo-binstall support"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,20 @@ use-jemalloc = ["tikv-jemallocator"]
 completions = ["clap_complete"]
 base = ["use-jemalloc"]
 default = ["use-jemalloc", "completions"]
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }.{ archive-format }"
+bin-dir = "{ bin }-v{ version }-{ target }/{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-gnu]
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.i686-pc-windows-msvc]
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-fmt = "zip"


### PR DESCRIPTION
Changes
[Cargo.toml](https://legendary-cod-g4554xrjwvrghvvgg.github.dev/): Added binstall metadata section with:
pkg-url template pointing to GitHub release assets
bin-dir specifying the binary location within archives
pkg-fmt defaulting to tgz (tar.gz)
Platform overrides for Windows targets to use zip format