### PR TITLE
docs(security): clarify where to send vulnerability reports (#1827)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ To report a security vulnerability, please provide the following information:
    - Provide a detailed description of the security vulnerability.
    - Include as much information as possible to help us understand and address the issue.
 
-Send this information, along with any additional relevant details, to <email AT somewhere or other channel>.
+Send this information, along with any additional relevant details, to our [vulnerability reporting form](https://github.com/sharkdp/fd/security/advisories/new).
 
 ## Confidentiality
 


### PR DESCRIPTION
This PR addresses issue #1827
Changes:
- Replaced the placeholder with a direct link to the GitHub vulnerability reporting form: https://github.com/sharkdp/fd/security/advisories/new
