### PR TITLE
feat[build]: Rearchitect release workflow

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -6,12 +6,16 @@ env:
 
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      release_version:
+        description: 'Tag of the release to create'
+        required: false
+        type: string
   pull_request:
   push:
     branches:
       - master
-    tags:
-      - '*'
 
 permissions:
   contents: read
@@ -268,45 +272,16 @@ jobs:
         name: ${{ steps.debian-package.outputs.DPKG_NAME }}
         path: ${{ steps.debian-package.outputs.DPKG_PATH }}
 
-    - name: Check for release
-      id: is-release
-      shell: bash
-      run: |
-        unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
-        echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
-
     - name: "Attest artifact: tarball"
       uses: actions/attest-build-provenance@v3
-      if: steps.is-release.outputs.IS_RELEASE
+      if: inputs.release_version
       with:
         subject-name: ${{ steps.package.outputs.PKG_NAME }}
         subject-digest: sha256::${{ steps.upload-tarball.artifact-digest }}
 
     - name: "Attest artifact: Debian package"
       uses: actions/attest-build-provenance@v3
-      if: 'steps.is-release.outputs.IS_RELEASE && steps.debian-package.outputs.DPKG_NAME'
+      if: 'inputs.release_version && steps.debian-package.outputs.DPKG_NAME'
       with:
         subject-name: ${{ steps.debian-package.outputs.DPKG_NAME }}
         subject-digest: sha256::${{ steps.upload-deb.outputs.artifact-digest }}
-
-    - name: Publish archives and packages
-      uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
-      if: steps.is-release.outputs.IS_RELEASE
-      with:
-        files: |
-          ${{ steps.package.outputs.PKG_PATH }}
-          ${{ steps.debian-package.outputs.DPKG_PATH }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  winget:
-    name: Publish to Winget
-    runs-on: ubuntu-latest
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
-        with:
-          identifier: sharkdp.fd
-          installers-regex: '-pc-windows-msvc\.zip$'
-          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+env:
+  VERSION: "${{ github.ref_name }}"
+
+jobs:
+  build:
+    uses: ./.github/workflows/CICD.yml
+    with:
+      release_version: "${{ github.ref_name }}"
+
+  publish:
+    name: Publish Release
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v6
+        with:
+          merge-multiple: true
+          path: artifacts
+      - name: Get CHANGELOG
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: CHANGLEOG.md
+      - name: Generate Release Notes
+        run: |
+          awk '/^# / { if (p) { exit }; p=1; next } p' CHANGELOG.md > notes.md
+      - name: Publish Release
+        env:
+          GH_TOKEN: "${{ github.token }}"
+        run: |
+          gh release create --notes-file notes.md \
+          --verify-tag "${VERSION}" artifacts/*
+
+  winget:
+    name: Publish to Winget
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: sharkdp.fd
+          installers-regex: '-pc-windows-msvc\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}
+

--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -36,11 +36,9 @@ necessary changes for the upcoming release.
       This will trigger the deployment via GitHub Actions.
       REMINDER: If your `origin` is a fork, don't forget to push to e.g. `upstream`
       instead.
-- [ ] Go to https://github.com/sharkdp/fd/releases/new to create the new
-      release. Select the new tag and also use it as the release title. For the
-      release notes, copy the corresponding section from `CHANGELOG.md` and
-      possibly add additional remarks for package maintainers.
-      Publish the release.
+- [ ] Go to https://github.com/sharkdp/fd/releases to create the new
+      release and wait for the new release to finish (creating the tag will automatically
+      create a new release). If necessary, make any adjustments to the release notes.
 - [ ] Check if the binary deployment works (archives and Debian packages should
       appear when the CI run *for the Git tag* has finished).
 - [ ] Publish to crates.io by running `cargo publish` in a *clean* repository.


### PR DESCRIPTION
This makes the following changes:

- Creates a new "release" workflow that re-uses the CIDCD workflow for build steps. This allows us to avoid having to check if it is a release in several steps.
- Remove dependency on third party action for release, and uses the `gh` command directly.
- Automatically generates release notes from the changelog.