### PR TITLE
tests/testenv/mod.rs: Change how fd binary executable is located

### DIFF
--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -74,18 +74,8 @@ fn create_config_directory_with_global_ignore(ignore_file_content: &str) -> io::
 
 /// Find the *fd* executable.
 fn find_fd_exe() -> PathBuf {
-    // Tests exe is in target/debug/deps, the *fd* exe is in target/debug
-    let root = env::current_exe()
-        .expect("tests executable")
-        .parent()
-        .expect("tests executable directory")
-        .parent()
-        .expect("fd executable directory")
-        .to_path_buf();
-
-    let exe_name = if cfg!(windows) { "fd.exe" } else { "fd" };
-
-    root.join(exe_name)
+    // Read the location of the fd executable from the environment
+    PathBuf::from(env::var("CARGO_BIN_EXE_fd").unwrap_or(env!("CARGO_BIN_EXE_fd").to_string()))
 }
 
 /// Format an error message for when *fd* did not exit successfully.


### PR DESCRIPTION
This commit changes the way that the binary executable of fd is located during integration tests. Previously, the find_fd_exe function would just navigate in the parent directory and try to find the binary here. This method is not appropriate as it assumes that the test directory will have the same layout as the build directory, which also leaks the build time configuration.

With this patch, the location of the binary executable is read using the CARGO_BIN_EXE_fd environment variable. The code at first tries to read the variable at run time, and if it is not available it then uses the env! macro which returns the value of the variable exposed at compile time.

This way of reading the binary location makes the code more flexible and friendlier to cross compile. Closes #1838.