### PR TITLE
chore: fix typo in tests/tests.rs

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2465,7 +2465,7 @@ fn test_max_results() {
     assert_just_one_result_with_option("--max-results=1");
     assert_just_one_result_with_option("-1");
 
-    // check that --max-results & -1 conflic with --exec
+    // check that --max-results & -1 conflict with --exec
     te.assert_failure(&["thing", "--max-results=0", "--exec=cat"]);
     te.assert_failure(&["thing", "-1", "--exec=cat"]);
     te.assert_failure(&["thing", "--max-results=1", "-1", "--exec=cat"]);


### PR DESCRIPTION
fix typo in tests/tests.rs