### PR TITLE
build: Reduce debug info for dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,16 @@ tempfile = "3.23"
 filetime = "0.2"
 test-case = "3.3"
 
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false
+
+[profile.debugging]
+inherits = "dev"
+debug = true
+
 [profile.release]
 lto = true
 strip = true


### PR DESCRIPTION
Hopefully this will sped up dev builds. Adds a new debugging profile if
full debug symbols are needed.
