### PR TITLE
build(deps): bump clap_complete from 4.5.61 to 4.5.62

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.61"
+version = "4.5.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39615915e2ece2550c0149addac32fb5bd312c657f43845bb9088cb9c8a7c992"
+checksum = "004eef6b14ce34759aa7de4aea3217e368f463f46a3ed3764ca4b5a4404003b4"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ anyhow = "1.0"
 etcetera = "0.11"
 normpath = "1.1.1"
 crossbeam-channel = "0.5.15"
-clap_complete = {version = "4.5.61", optional = true}
+clap_complete = {version = "4.5.62", optional = true}
 faccess = "0.2.4"
 jiff = "0.2.16"
 


### PR DESCRIPTION
## Summary

This PR updates `clap_complete` from version 4.5.61 to 4.5.62 to fix fish shell completion formatting issues.

## Problem

With version 4.5.61, fish shell completions for options with `ValueEnum` types (like `--type` and `--color`) were malformed. The completion generator produced output like:

```fish
-a "{file\t,directory\t,executable\tA file which is executable...,empty\t}"
```

This caused fish to fail parsing completions with errors like "Unknown command: default".

## Solution

Version 4.5.62 includes the fix from [clap-rs/clap#5874](https://github.com/clap-rs/clap/pull/5874) which changed the fish completion generator to use proper multi-line format with quotes:

```fish
-a "file\t''
directory\t''
executable\t'A file which is executable by the current effective user'
empty\t''"
```

## Testing

- All existing tests pass
- Verified fish completion generation produces correctly formatted output
- Tested that completions work properly in fish shell

## References

- Upstream issue: clap-rs/clap#5868
- Upstream fix: clap-rs/clap#5874

🤖 Generated with [Claude Code](https://claude.com/claude-code)