### PR TITLE
feat(build): enable jemalloc on musl and riscv64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ libc = "0.2"
 # Catalina. See https://github.com/sharkdp/fd/issues/498 for details.
 # This has to be kept in sync with src/main.rs where the allocator for
 # the program is set.
-[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_os = "freebsd"), not(target_os = "openbsd"), not(target_os = "illumos"), not(all(target_env = "musl", target_pointer_width = "32")), not(target_arch = "riscv64")))'.dependencies]
+[target.'cfg(all(not(windows), not(target_os = "android"), not(target_os = "macos"), not(target_os = "freebsd"), not(target_os = "openbsd"), not(target_os = "illumos")))'.dependencies]
 tikv-jemallocator = {version = "0.6.0", optional = true}
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,6 @@ use crate::regex_helper::{pattern_has_uppercase_char, pattern_matches_strings_wi
     not(target_os = "freebsd"),
     not(target_os = "openbsd"),
     not(target_os = "illumos"),
-    not(all(target_env = "musl", target_pointer_width = "32")),
-    not(target_arch = "riscv64"),
     feature = "use-jemalloc"
 ))]
 #[global_allocator]


### PR DESCRIPTION
Alpine Linux vendors a custom patch to enable jemalloc for all arches, which seems to work fine in practice.