### PR TITLE
Fix symlink for bash completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
     - #1667
     - #1813
 
+- Fix completions for alias `fdfind` in deb release, see #1888 (@skane-lukas)
+
 ## Changes
 
 - Minimum required rust version has been increased to 1.90.0. Notably, this means dropping fully support for intel Mac and Windows 7.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ $(EXE): Cargo.toml src/**/*.rs
 	cargo build --profile $(PROFILE) --locked
 
 .PHONY: completions
-completions: autocomplete/fd.bash autocomplete/fd.fish autocomplete/_fd.ps1 autocomplete/_fd
+completions: autocomplete/fd.bash autocomplete/fd.fish autocomplete/_fd.ps1 autocomplete/_fd autocomplete/_fdfind autocomplete/fdfind.bash autocomplete/fdfind.fish
 
 comp_dir=@mkdir -p autocomplete
 
@@ -29,9 +29,24 @@ autocomplete/_fd: contrib/completion/_fd
 	$(comp_dir)
 	cp $< $@
 
+autocomplete/_fdfind: contrib/completion/_fdfind
+	$(comp_dir)
+	cp $< $@
+
+autocomplete/fdfind.bash: contrib/completion/fdfind.bash
+	$(comp_dir)
+	cp $< $@
+
+autocomplete/fdfind.fish: contrib/completion/fdfind.fish
+	$(comp_dir)
+	cp $< $@
+
 install: $(EXE) completions
 	install -Dm755 $(EXE) $(DESTDIR)$(bindir)/fd
 	install -Dm644 autocomplete/fd.bash $(DESTDIR)/$(datadir)/bash-completion/completions/$(exe_name)
 	install -Dm644 autocomplete/fd.fish $(DESTDIR)/$(datadir)/fish/vendor_completions.d/$(exe_name).fish
-	install -Dm644 autocomplete/_fd $(DESTDIR)/$(datadir)/zsh/site-functions/_$(exe_name)
+	install -Dm644 autocomplete/_fd $(DESTDIR)/$(datadir)/zsh/site-functions/_fd
+	install -Dm644 autocomplete/fdfind.bash $(DESTDIR)/$(datadir)/zsh/site-functions/fdfind.bash
+	install -Dm644 autocomplete/fdfind.fish $(DESTDIR)/$(datadir)/zsh/site-functions/fdfind.fish
+	install -Dm644 autocomplete/_fdfind $(DESTDIR)/$(datadir)/zsh/site-functions/_fdfind
 	install -Dm644 doc/fd.1 $(DESTDIR)/$(datadir)/man/man1/$(exe_name).1

--- a/contrib/completion/_fdfind
+++ b/contrib/completion/_fdfind
@@ -1,0 +1,2 @@
+#compdef fdfind
+_fd "$@"

--- a/contrib/completion/fdfind.bash
+++ b/contrib/completion/fdfind.bash
@@ -1,0 +1,8 @@
+# Source fd completions
+source /usr/share/bash-completion/completions/fd
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+  complete -F _fd -o nosort -o bashdefault -o default fdfind
+else
+  complete -F _fd -o bashdefault -o default fdfind
+fi

--- a/contrib/completion/fdfind.fish
+++ b/contrib/completion/fdfind.fish
@@ -1,0 +1,1 @@
+complete -c fdfind --wraps fd

--- a/scripts/create-deb.sh
+++ b/scripts/create-deb.sh
@@ -57,11 +57,12 @@ install -Dm644 "LICENSE-APACHE" "${DPKG_DIR}/usr/share/doc/${DPKG_BASENAME}/LICE
 install -Dm644 "CHANGELOG.md" "${DPKG_DIR}/usr/share/doc/${DPKG_BASENAME}/changelog"
 gzip -n --best "${DPKG_DIR}/usr/share/doc/${DPKG_BASENAME}/changelog"
 
-# Create symlinks so fdfind can be used as well:
+# Create symlink and completions so fdfind can be used as well:
 ln -s "/usr/bin/fd" "${DPKG_DIR}/usr/bin/fdfind"
-ln -s  './fd.bash' "${DPKG_DIR}/usr/share/bash-completion/completions/fdfind"
-ln -s  './fd.fish' "${DPKG_DIR}/usr/share/fish/vendor_completions.d/fdfind.fish"
-ln -s  './_fd' "${DPKG_DIR}/usr/share/zsh/vendor-completions/_fdfind"
+
+install -Dm644 'autocomplete/fdfind.bash' "${DPKG_DIR}/usr/share/bash-completion/completions/fdfind"
+install -Dm644 'autocomplete/fdfind.fish' "${DPKG_DIR}/usr/share/fish/vendor_completions.d/fdfind.fish"
+install -Dm644 'autocomplete/_fdfind' "${DPKG_DIR}/usr/share/zsh/vendor-completions/_fdfind"
 
 cat > "${DPKG_DIR}/usr/share/doc/${DPKG_BASENAME}/copyright" <<EOF
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/


### PR DESCRIPTION
### Problem
In the deb package a broken symlink is created for bash completions to the alias command `fdfind`.

### Solution
Create static completion files that sources fd completions for fdfind for bash, zsh and fish
Install the completions in Makefile and create-deb.sh



### Changes
- Create static completion files in contrib/completion that sources fd completions for fdfind for bash, zsh and fish
- Changed symlink target for completion `fdfind` in `create-deb` from `./fd.bash` to `./fd`
- Update Makefile and create-deb.sh to install the new static completions.
- Updated `CHANGELOG.md` with the fix.

fixes #1888 