### PR TITLE
fix(build): Fix attestation

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -280,14 +280,14 @@ jobs:
       if: steps.is-release.outputs.IS_RELEASE
       with:
         subject-name: ${{ steps.package.outputs.PKG_NAME }}
-        subject-digest: sha256::${{ steps.upload-tarball.outputs.artifact-digest }}
+        subject-digest: sha256:${{ steps.upload-tarball.outputs.artifact-digest }}
 
     - name: "Attest artifact: Debian package"
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
       if: 'steps.is-release.outputs.IS_RELEASE && steps.debian-package.outputs.DPKG_NAME'
       with:
         subject-name: ${{ steps.debian-package.outputs.DPKG_NAME }}
-        subject-digest: sha256::${{ steps.upload-deb.outputs.artifact-digest }}
+        subject-digest: sha256:${{ steps.upload-deb.outputs.artifact-digest }}
 
     - name: Publish archives and packages
       uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0


### PR DESCRIPTION
Use the right output in the github action.

Also pin the versions of the upload-artifact and attest actions.