### PR TITLE
fix: correct subject-digest format for attest-build-provenance

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -280,14 +280,14 @@ jobs:
       if: steps.is-release.outputs.IS_RELEASE
       with:
         subject-name: ${{ steps.package.outputs.PKG_NAME }}
-        subject-digest: sha256::${{ steps.upload-tarball.artifact-digest }}
+        subject-digest: sha256:${{ steps.upload-tarball.artifact-digest }}
 
     - name: "Attest artifact: Debian package"
       uses: actions/attest-build-provenance@v4
       if: 'steps.is-release.outputs.IS_RELEASE && steps.debian-package.outputs.DPKG_NAME'
       with:
         subject-name: ${{ steps.debian-package.outputs.DPKG_NAME }}
-        subject-digest: sha256::${{ steps.upload-deb.outputs.artifact-digest }}
+        subject-digest: sha256:${{ steps.upload-deb.outputs.artifact-digest }}
 
     - name: Publish archives and packages
       uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0


### PR DESCRIPTION
## Problem

The GitHub Actions workflow fails for all release builds in v10.4.0 at the "Attest artifact" step due to an invalid digest format.

The workflow uses:
```yaml
subject-digest: sha256::${{ steps.upload-tarball.artifact-digest }}
```

This produces a double colon (`sha256::...`) which is invalid. The correct format is:
```yaml
subject-digest: sha256:${{ steps.upload-tarball.artifact-digest }}
```

## Impact

All release builds fail at the attestation step, preventing the creation and publishing of release artifacts (tarballs, .deb packages, etc.) for all platforms.

## Root Cause

The bug was introduced in PR #1901 which bumped actions/attest-build-provenance from v3 to v4. The new attestation steps were accidentally written with a double colon instead of a single colon after the `sha256` prefix.

## Fix

This change corrects the digest format in both attestation steps.

Fixes #1909

## Related

- PR #1901 (dependabot bump)
- CI run: https://github.com/sharkdp/fd/actions/runs/22794348628
