### PR TITLE
Change --exclude value name from 'pattern' to 'glob'

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Options:
   -L, --follow                     Follow symbolic links
   -p, --full-path                  Search full abs. path (default: filename only)
   -d, --max-depth <depth>          Set maximum search depth (default: none)
-  -E, --exclude <pattern>          Exclude entries that match the given glob pattern
+  -E, --exclude <glob>             Exclude entries that match the given glob pattern
   -t, --type <filetype>            Filter by type: file (f), directory (d/dir), symlink (l),
                                    executable (x), empty (e), socket (s), pipe (p), char-device
                                    (c), block-device (b)

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -257,7 +257,7 @@ This option can be used repeatedly to allow for multiple possible file extension
 If you want to search for files without extension, you can use the regex '^[^.]+$'
 as a normal search pattern.
 .TP
-.BI "\-E, \-\-exclude " pattern
+.BI "\-E, \-\-exclude " glob
 Exclude files/directories that match the given glob pattern.
 This overrides any other ignore logic.
 Multiple exclude patterns can be specified.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -299,7 +299,7 @@ pub struct Opts {
     #[arg(
         long,
         short = 'E',
-        value_name = "pattern",
+        value_name = "glob",
         help = "Exclude entries that match the given glob pattern",
         long_help
     )]


### PR DESCRIPTION
## Summary

Fixes #1724

The summary line `-E, --exclude <pattern>` is misleading because fd defaults to regex for its main search pattern, but `--exclude` takes a glob. Users naturally assume `--exclude` also takes regex.

Changed the value placeholder from `pattern` to `glob` in:
- CLI help text (`value_name` in clap)
- Man page (`doc/fd.1`)
- README

## Test plan

- Verified the help text change is consistent across all three locations
- No behavioral change, documentation only