### PR TITLE
Clarify that -e/--extension matches all entry types

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Options:
   -t, --type <filetype>            Filter by type: file (f), directory (d/dir), symlink (l),
                                    executable (x), empty (e), socket (s), pipe (p), char-device
                                    (c), block-device (b)
-  -e, --extension <ext>            Filter by file extension
+  -e, --extension <ext>            Filter by extension (applies to all entry types)
   -S, --size <size>                Limit results based on the size of files
       --changed-within <date|dur>  Filter by file modification time (newer than)
       --changed-before <date|dur>  Filter by file modification time (older than)

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -250,9 +250,11 @@ Examples:
 .RE
 .TP
 .BI "\-e, \-\-extension " ext
-Filter search results by file extension
+Filter search results by extension
 .IR ext .
-This option can be used repeatedly to allow for multiple possible file extensions.
+This applies to all entry types, not just files. Use \fB\-\-type\fR to restrict
+the search to specific types.
+This option can be used repeatedly to allow for multiple possible extensions.
 
 If you want to search for files without extension, you can use the regex '^[^.]+$'
 as a normal search pattern.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -368,7 +368,7 @@ pub struct Opts {
         long = "extension",
         short = 'e',
         value_name = "ext",
-        help = "Filter by file extension",
+        help = "Filter by extension (applies to all entry types)",
         long_help
     )]
     pub extensions: Option<Vec<String>>,


### PR DESCRIPTION
## Summary

Fixes #1693

The help text said "Filter by file extension" which led users to expect only files would be matched. However, directories with matching extensions (e.g. `a.b/`) are also returned, which is correct behavior per UNIX convention.

Updated the help text to "Filter by extension (applies to all entry types)" in:
- CLI help text
- Man page (also added a note about using `--type` to restrict)
- README

## Test plan

- No behavioral change, documentation only
- Wording aligns with collaborator and community feedback on the issue