### PR TITLE
fix: report path-separator patterns consistently on Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
+- Report path-separator patterns consistently on Unix even when the pattern is not an existing directory, see #1873 (@cl2t).
 
 # 10.4.2
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,10 +147,15 @@ fn set_working_dir(opts: &Opts) -> Result<()> {
 
 /// Detect if the user accidentally supplied a path instead of a search pattern
 fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
-    if !opts.full_path
+    #[cfg(windows)]
+    let should_error = !opts.full_path
         && opts.pattern.contains(std::path::MAIN_SEPARATOR)
-        && Path::new(&opts.pattern).is_dir()
-    {
+        && Path::new(&opts.pattern).is_dir();
+
+    #[cfg(not(windows))]
+    let should_error = !opts.full_path && opts.pattern.contains(std::path::MAIN_SEPARATOR);
+
+    if should_error {
         Err(anyhow!(
             "The search pattern '{pattern}' contains a path-separation character ('{sep}') \
              and will not lead to any search results.\n\n\

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1572,6 +1572,26 @@ fn test_symlink_and_full_path_abs_path() {
         ),
     );
 }
+
+#[cfg(not(windows))]
+#[test]
+fn test_path_pattern_with_separator_reports_error_for_nonexistent_directory() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_failure_with_error(
+        &["dir1/dir2"],
+        "[fd error]: The search pattern 'dir1/dir2' contains a path-separation character ('/') and will not lead to any search results.
+
+If you want to search for all files inside the 'dir1/dir2' directory, use a match-all pattern:
+
+  fd . 'dir1/dir2'
+
+Instead, if you want your pattern to match the full file path, use:
+
+  fd --full-path 'dir1/dir2'",
+    );
+}
+
 /// Exclude patterns (--exclude)
 #[test]
 fn test_excludes() {


### PR DESCRIPTION
## Summary

Fixes #1873.

Report the path-separator pattern error consistently on Unix even when the pattern is not an existing directory.
Windows behavior is left unchanged because \ can also be a regex escape.

## Testing

- cargo test test_path_pattern_with_separator_reports_error_for_nonexistent_directory -- --exact
- cargo test --test tests
- cargo fmt --all --check