### PR TITLE
fix: always error on patterns containing path separators

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -147,10 +147,7 @@ fn set_working_dir(opts: &Opts) -> Result<()> {
 
 /// Detect if the user accidentally supplied a path instead of a search pattern
 fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
-    if !opts.full_path
-        && opts.pattern.contains(std::path::MAIN_SEPARATOR)
-        && Path::new(&opts.pattern).is_dir()
-    {
+    if !opts.full_path && opts.pattern.contains(std::path::MAIN_SEPARATOR) {
         Err(anyhow!(
             "The search pattern '{pattern}' contains a path-separation character ('{sep}') \
              and will not lead to any search results.\n\n\


### PR DESCRIPTION
## Problem

`fd` only shows the "pattern contains path separator" error when the pattern also happens to be an existing directory. In all other cases it silently returns no results, which is inconsistent and confusing.

## Solution

Remove the directory existence check so any pattern containing a path separator triggers the same guidance unless `--full-path` is used.

## Validation

- Reviewed the existing path validation branch
- Verified the patch is a minimal logic change in `src/main.rs`
- Full `cargo build/test` could not be run on the Oracle host because the Rust toolchain is not installed there

Fixes #1873
