### PR TITLE
fix: allow --ignore-vcs to override --no-ignore-vcs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,6 +68,7 @@ pub struct Opts {
     ///The flag can be overridden with --ignore-vcs.
     #[arg(
         long,
+        overrides_with = "ignore_vcs",
         hide_short_help = true,
         help = "Do not respect .gitignore files",
         long_help


### PR DESCRIPTION
## Summary
- Fix flag ordering so `--ignore-vcs` correctly overrides `--no-ignore-vcs` when specified later
- Previously, `--no-ignore-vcs` always took precedence regardless of order

## Root Cause
The `--ignore-vcs` and `--no-ignore-vcs` flags did not use mutual override semantics, so the negation flag always won.

## Testing
- Verified `fd --no-ignore-vcs --ignore-vcs` now respects VCS ignore rules
- Existing test suite passes

Fixes #1758

Made with [Cursor](https://cursor.com)