### PR TITLE
ci: add riscv64 to release build matrix

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -106,6 +106,7 @@ jobs:
           - { target: x86_64-pc-windows-gnu       , os: windows-2022                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2022                  }
           - { target: aarch64-pc-windows-msvc     , os: windows-11-arm                }
+          - { target: riscv64gc-unknown-linux-gnu  , os: ubuntu-24.04-riscv             }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-24.04, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-24.04, use-cross: true }
     env:


### PR DESCRIPTION
Adds `riscv64gc-unknown-linux-gnu` to the release build matrix using native RISE riscv64 runners (`ubuntu-24.04-riscv`) instead of cross-compilation. This avoids the known cross-rs riscv64 issues (cross-rs/cross#1719).

One-line matrix addition, no `use-cross` needed since the build runs natively on riscv64 hardware.

**RISE runners**: `ubuntu-24.04-riscv` is a native riscv64 runner provided by the [RISE Project](https://riseproject.dev/), free for open source. To enable: install the [RISE runners GitHub App](https://github.com/apps/rise-risc-v-runners). Already used by numpy, Apache Arrow, llama.cpp, and others. Without the app, the job stays queued with no runner available.

Build validated on native riscv64: https://github.com/gounthar/fd/actions/runs/23355355302

Closes #1937