### PR TITLE
Fix attest

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -259,6 +259,7 @@ jobs:
       with:
         name: ${{ steps.package.outputs.PKG_NAME }}
         path: ${{ steps.package.outputs.PKG_PATH }}
+        compression-level: 0 # tarball is already compressed
 
     - name: "Artifact upload: Debian package"
       id: upload-deb
@@ -267,6 +268,7 @@ jobs:
       with:
         name: ${{ steps.debian-package.outputs.DPKG_NAME }}
         path: ${{ steps.debian-package.outputs.DPKG_PATH }}
+        compression-level: 0 # deb files are already compressed
 
     - name: Check for release
       id: is-release


### PR DESCRIPTION
fix: correct attestation subjects
    
  Use the original files as the source, rather than the file that is
  uploaded to the artifact, as that is actually a zip file (what?)
  
  Fixes: #1936

  fix(ci): Remove unnecessary compression
    
  Don't compress something that is already compressed.
