### PR TITLE
fix: show path separator error for all patterns with separators

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,6 @@ fn set_working_dir(opts: &Opts) -> Result<()> {
 fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
     if !opts.full_path
         && opts.pattern.contains(std::path::MAIN_SEPARATOR)
-        && Path::new(&opts.pattern).is_dir()
     {
         Err(anyhow!(
             "The search pattern '{pattern}' contains a path-separation character ('{sep}') \


### PR DESCRIPTION
The 'pattern contains path separator' error was only shown when the pattern was an existing directory. This caused inconsistent behavior where 'fd /' showed an error but 'fd /nonexistent/path' silently found nothing.

This fix removes the Path::is_dir() check so the error is shown consistently whenever a pattern contains a path separator, improving user experience with clear feedback.

Fixes #1873