### PR TITLE
chore: Update os matrix

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -99,12 +99,13 @@ jobs:
           - { target: aarch64-unknown-linux-musl  , os: ubuntu-24.04, use-cross: true }
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-24.04, use-cross: true }
           - { target: arm-unknown-linux-musleabihf, os: ubuntu-24.04, use-cross: true }
-          - { target: i686-pc-windows-msvc        , os: windows-2022                  }
+          - { target: i686-pc-windows-msvc        , os: windows-2025                  }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-24.04, use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-24.04, use-cross: true }
-          - { target: aarch64-apple-darwin        , os: macos-14                      }
-          - { target: x86_64-pc-windows-gnu       , os: windows-2022                  }
-          - { target: x86_64-pc-windows-msvc      , os: windows-2022                  }
+          - { target: x86_64-apple-darwin         , os: macos-26-intel                }
+          - { target: aarch64-apple-darwin        , os: macos-26                      }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2025                  }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2025                  }
           - { target: aarch64-pc-windows-msvc     , os: windows-11-arm                }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-24.04, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-24.04, use-cross: true }


### PR DESCRIPTION
Update the versions of Windows and Mac OSes used in build matrix.

Also add back intel Mac since on the latest version that is still supported until 2027.

Fixes: #1945
Fixes: #1918