### PR TITLE
docs: fix macOS spelling in BSD ls comment

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -385,7 +385,7 @@ fn determine_ls_command(colored_output: bool) -> Result<Vec<&'static str>> {
             // Assume ls is GNU ls
             gnu_ls("ls")
         } else {
-            // MacOS, DragonFlyBSD, FreeBSD
+            // macOS, DragonFlyBSD, FreeBSD
             use std::process::{Command, Stdio};
 
             // Use GNU ls, if available (support for --color=auto, better LS_COLORS support)


### PR DESCRIPTION
## Summary
- Fix the macOS spelling in the inline platform comment around GNU `ls` handling.

## Related issue
- N/A; trivial comment-only fix.

## Guideline alignment
- Comment-only change with no behavior impact, so no changelog entry is needed.

## Validation
- Not run; comment-only change.