### PR TITLE
feat: add --ignore-parent option to override --no-ignore-parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Features
+- Add `--ignore-parent` option to override `--no-ignore-parent`, see #1958 (@tmchow)
+
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,7 @@ pub struct Opts {
 
     /// Show search results from files and directories that would otherwise be
     /// ignored by '.gitignore', '.ignore', or '.fdignore' files in parent directories.
+    /// The flag can be overridden with --ignore-parent.
     #[arg(
         long,
         hide_short_help = true,
@@ -109,6 +110,10 @@ pub struct Opts {
         long_help
     )]
     pub no_ignore_parent: bool,
+
+    /// Overrides --no-ignore-parent
+    #[arg(long, overrides_with = "no_ignore_parent", hide = true, action = ArgAction::SetTrue)]
+    ignore_parent: (),
 
     /// Do not respect the global ignore file
     #[arg(long, hide = true)]


### PR DESCRIPTION
## Summary

Adds `--ignore-parent` to undo `--no-ignore-parent`, filling a gap in the existing override pattern.

## Why this matters

Three flags already have an override counterpart: `--ignore` undoes `--no-ignore`, `--ignore-vcs` undoes `--no-ignore-vcs`, and `--require-git` undoes `--no-require-git`. But `--no-ignore-parent` had no way to be reversed once set in an alias or config. Users who set `--no-ignore-parent` globally had no per-invocation escape hatch.

## Changes

- `src/cli.rs`: Added `--ignore-parent` with `overrides_with = "no_ignore_parent"`, matching the exact pattern used by `--ignore-vcs` (hidden flag, `ArgAction::SetTrue`, unit type). Updated the `no_ignore_parent` doc comment to reference the new override.
- `CHANGELOG.md`: Added entry under `## Features` in the Unreleased section.

No changes needed in `main.rs` since clap's `overrides_with` resets `no_ignore_parent` to `false` when `--ignore-parent` appears later on the command line.

## Testing

- `cargo check` passes
- Verified the new flag follows the identical struct pattern as `ignore_vcs` (cli.rs:77-79)

Fixes #1958

This contribution was developed with AI assistance (Claude Code).