### PR TITLE
fix: avoid skipping broken symlinks with --min-depth and --follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
+- Do not skip dangling symlinks when using `--min-depth` together with `--follow` (`-L`): broken-symlink entries have no walk depth and were incorrectly filtered. see #1962 (@cuiweixie).
 
 # 10.4.2
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -516,7 +516,7 @@ impl WorkerState {
                 };
 
                 if let Some(min_depth) = config.min_depth
-                    && entry.depth().is_none_or(|d| d < min_depth)
+                    && entry.depth().is_some_and(|d| d < min_depth)
                 {
                     return WalkState::Continue;
                 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1133,6 +1133,26 @@ fn test_min_depth() {
     );
 }
 
+/// Regression: `fd --min-depth 1 -L . testdir` must list a dangling symlink under `testdir/sub/`.
+/// (`DirEntry::broken_symlink` has no depth; `is_none_or` incorrectly skipped it.)
+#[cfg(unix)]
+#[test]
+fn test_min_depth_follow_broken_symlink_nested() {
+    use std::os::unix::fs::symlink;
+
+    // `testenv` always creates `symlink` -> `one/two`; that directory must exist.
+    let dirs = &["one/two", "testdir/sub"];
+    let files: &[&str] = &[];
+    let te = TestEnv::new(dirs, files);
+    symlink("/noexistent", te.test_root().join("testdir/sub/broken")).expect("symlink");
+
+    te.assert_output(
+        &["--min-depth", "1", "-L", ".", "testdir"],
+        "testdir/sub/
+        testdir/sub/broken",
+    );
+}
+
 /// Exact depth (--exact-depth)
 #[test]
 fn test_exact_depth() {


### PR DESCRIPTION
## Summary

- **Bug:** With `--min-depth` and `--follow` (`-L`), dangling symlinks were never listed. `DirEntry::broken_symlink` has `depth() == None`; `Option::is_none_or` treats `None` as matching the predicate, so every broken symlink was incorrectly skipped at the min-depth gate.
- **Fix:** Use `is_some_and` so we only skip when depth is known and below `min_depth`.

## Test

- Integration test `test_min_depth_follow_broken_symlink_nested` reproduces `fd --min-depth 1 -L . testdir` with `testdir/sub/broken` → `/noexistent`.

## Changelog

- Entry added under *Unreleased* → *Bugfixes* per CONTRIBUTING.