### PR TITLE
feat: add --ignore-parent flag to override --no-ignore-parent

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,8 @@ pub struct Opts {
 
     /// Show search results from files and directories that would otherwise be
     /// ignored by '.gitignore', '.ignore', or '.fdignore' files in parent directories.
+    ///
+    /// The flag can be overridden with --ignore-parent.
     #[arg(
         long,
         hide_short_help = true,
@@ -109,6 +111,10 @@ pub struct Opts {
         long_help
     )]
     pub no_ignore_parent: bool,
+
+    /// Overrides --no-ignore-parent
+    #[arg(long, overrides_with = "no_ignore_parent", hide = true, action = ArgAction::SetTrue)]
+    ignore_parent: (),
 
     /// Do not respect the global ignore file
     #[arg(long, hide = true)]


### PR DESCRIPTION
Closes #1958

Adds a hidden `--ignore-parent` flag that overrides `--no-ignore-parent`, following the existing pattern:

| Flag | Override |
|------|----------|
| `--no-ignore-vcs` | `--ignore-vcs` |
| `--no-require-git` | `--require-git` |
| `--no-ignore-parent` | **`--ignore-parent`** (this PR) |

The flag is hidden (not shown in `--help`) and uses `overrides_with`, identical to how `--ignore-vcs` works.

**Use case:** shell aliases or configs that set `--no-ignore-parent` globally can now selectively re-enable parent ignore file handling for specific invocations.

All 103 existing tests pass.