### PR TITLE
feat: add --ignore-parent flag to undo --no-ignore-parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Features
+- Add `--ignore-parent` option to undo `--no-ignore-parent`, see #1958 (@Ai-chan-0411)
+
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,6 +110,10 @@ pub struct Opts {
     )]
     pub no_ignore_parent: bool,
 
+    /// Overrides --no-ignore-parent
+    #[arg(long, overrides_with = "no_ignore_parent", hide = true, action = ArgAction::SetTrue)]
+    ignore_parent: (),
+
     /// Do not respect the global ignore file
     #[arg(long, hide = true)]
     pub no_global_ignore_file: bool,


### PR DESCRIPTION
I noticed that `--no-ignore-vcs` has a corresponding `--ignore-vcs` override, and `--no-ignore` has `--ignore`, but `--no-ignore-parent` had no counterpart. This makes it awkward to undo `--no-ignore-parent` in shell aliases or config files where earlier flags need to be selectively reverted.

This adds a hidden `--ignore-parent` flag following the exact same pattern already used by `--ignore-vcs` and `--ignore`: it uses `overrides_with` to cancel `--no-ignore-parent` when both are present, and it's hidden from help output since it's only needed as a negation toggle.

The change is two lines of attribute macro plus the unit field — no runtime logic changes since clap handles the override resolution automatically.

Closes #1958