### PR TITLE
fix: normalize full-path matches for parent search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
+- Normalize `--full-path` matching for relative search paths such as `..`, see #1513 (@lawrence3699).
 
 # 10.4.2
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::io::{self, Write};
 use std::mem;
-use std::path::PathBuf;
+use std::path::{Component, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
@@ -13,6 +13,7 @@ use crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender, bounded};
 use etcetera::BaseStrategy;
 use ignore::overrides::{Override, OverrideBuilder};
 use ignore::{WalkBuilder, WalkParallel, WalkState};
+use normpath::PathExt;
 use regex::bytes::Regex;
 
 use crate::config::Config;
@@ -674,7 +675,18 @@ fn search_str_for_entry<'a>(
             return Cow::Borrowed(entry_path.as_os_str());
         }
         let path = entry_path.strip_prefix(".").unwrap_or(entry_path);
-        Cow::Owned(cwd.join(path).into())
+        let absolute_path = cwd.join(path);
+        if path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+        {
+            match absolute_path.normalize() {
+                Ok(normalized_path) => Cow::Owned(normalized_path.into()),
+                Err(_) => Cow::Owned(absolute_path.into()),
+            }
+        } else {
+            Cow::Owned(absolute_path.into())
+        }
     } else {
         match entry_path.file_name() {
             Some(filename) => Cow::Borrowed(filename),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1256,6 +1256,24 @@ fn test_normalized_absolute_path() {
     );
 }
 
+/// Full path matching should normalize relative search paths as well.
+#[test]
+fn test_full_path_normalizes_relative_search_path() {
+    let (te, abs_path) = get_test_env_with_abs_path(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output_subdirectory(
+        "one/two",
+        &[
+            "--full-path",
+            "-t",
+            "f",
+            &format!("{abs_path}/one/b.foo"),
+            "..",
+        ],
+        "../b.foo",
+    );
+}
+
 /// File type filter (--type)
 #[test]
 fn test_type() {


### PR DESCRIPTION
## Summary

Normalize `--full-path` matching for relative search paths containing `.` or `..`.

Fixes #1513.

## Before

From a nested directory, a full-path match against a parent search path could fail unless `--absolute-path` was also set. For example, from `one/two`:

```bash
fd --full-path -t f '<abs>/one/b.foo' ..
```

returned no results, while the same logical query started matching when `--absolute-path` was added.

## After

`--full-path` matching normalizes relative search paths with `.` or `..` before matching, so the result set no longer depends on `--absolute-path`.

## Why this is correct

The matching path was being built as `<cwd>/../...` and compared without normalization. This change only normalizes paths for matching when the relative entry path actually contains `.` or `..`, and falls back to the existing behavior if normalization fails.

## Testing

- `cargo test test_full_path_normalizes_relative_search_path -- --nocapture`
- `cargo test test_normalized_absolute_path -- --nocapture`
- `cargo test test_full_path -- --nocapture`
- `cargo test test_symlink_and_full_path -- --nocapture`
- `cargo test search_str_for_entry_with_relative_path -- --nocapture`
