### PR TITLE
Fix fdfind bash completion symlink in Debian packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
+- Fix the `fdfind` bash completion symlink in Debian packages, see #1888 (@lawrence3699).
 
 # 10.4.2
 

--- a/scripts/create-deb.sh
+++ b/scripts/create-deb.sh
@@ -59,7 +59,7 @@ gzip -n --best "${DPKG_DIR}/usr/share/doc/${DPKG_BASENAME}/changelog"
 
 # Create symlinks so fdfind can be used as well:
 ln -s "/usr/bin/fd" "${DPKG_DIR}/usr/bin/fdfind"
-ln -s  './fd.bash' "${DPKG_DIR}/usr/share/bash-completion/completions/fdfind"
+ln -s  './fd' "${DPKG_DIR}/usr/share/bash-completion/completions/fdfind"
 ln -s  './fd.fish' "${DPKG_DIR}/usr/share/fish/vendor_completions.d/fdfind.fish"
 ln -s  './_fd' "${DPKG_DIR}/usr/share/zsh/vendor-completions/_fdfind"
 


### PR DESCRIPTION
Fixes #1888.

Before this change, `scripts/create-deb.sh` installed the bash completion file as `usr/share/bash-completion/completions/fd` but created the `fdfind` symlink as `./fd.bash`, which leaves a dangling symlink in the Debian package.

This updates the bash completion symlink to `./fd`, matching the installed file name. The fish and zsh `fdfind` symlinks already point to their installed completion file names, so this makes the bash packaging consistent with the sibling paths.

Validation:
- `bash -n scripts/create-deb.sh`
- `git diff --check`
- local packaging-layout fixture confirming `fdfind -> ./fd` resolves alongside the existing fish and zsh completion symlinks
