### PR TITLE
fix: normalize --full-path matches for parent search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
+- Normalize `--full-path` matches for parent search paths so `..` roots do not change the result set, see #1513 (@lawrence3699).
 
 # 10.4.2
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -13,6 +13,7 @@ use crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender, bounded};
 use etcetera::BaseStrategy;
 use ignore::overrides::{Override, OverrideBuilder};
 use ignore::{WalkBuilder, WalkParallel, WalkState};
+use normpath::PathExt;
 use regex::bytes::Regex;
 
 use crate::config::Config;
@@ -674,7 +675,17 @@ fn search_str_for_entry<'a>(
             return Cow::Borrowed(entry_path.as_os_str());
         }
         let path = entry_path.strip_prefix(".").unwrap_or(entry_path);
-        Cow::Owned(cwd.join(path).into())
+        let joined = cwd.join(path);
+        // Keep --full-path matching stable even when the search root contains
+        // redundant components such as `.` or `..`.
+        match joined.normalize() {
+            Ok(normalized) => {
+                let normalized = filesystem::absolute_path(normalized.as_path())
+                    .unwrap_or_else(|_| normalized.into_path_buf());
+                Cow::Owned(normalized.into_os_string())
+            }
+            Err(_) => Cow::Owned(joined.into_os_string()),
+        }
     } else {
         match entry_path.file_name() {
             Some(filename) => Cow::Borrowed(filename),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -602,6 +602,34 @@ fn test_full_path() {
     );
 }
 
+#[test]
+fn test_full_path_normalizes_parent_components() {
+    let (te, abs_path) = get_test_env_with_abs_path(DEFAULT_DIRS, DEFAULT_FILES);
+    let prefix = escape(&abs_path);
+
+    te.assert_output_subdirectory(
+        "one/two",
+        &["--full-path", &format!("^{prefix}/one/b\\.foo$"), ".."],
+        "../b.foo",
+    );
+}
+
+#[test]
+fn test_full_path_parent_components_do_not_overmatch() {
+    let (te, abs_path) = get_test_env_with_abs_path(DEFAULT_DIRS, DEFAULT_FILES);
+    let prefix = escape(&abs_path);
+
+    te.assert_output_subdirectory(
+        "one/two",
+        &[
+            "--full-path",
+            &format!("^{prefix}/one/.*/.*/b\\.foo$"),
+            "..",
+        ],
+        "",
+    );
+}
+
 /// Hidden files (--hidden)
 #[test]
 fn test_hidden() {


### PR DESCRIPTION
Fixes #1513.

`--full-path` currently joins the working directory with each relative entry path for matching, but it leaves parent components intact. That makes the result set depend on whether the search root was spelled with `..`.

Before:
- from `<root>/one/two`, `fd --full-path -t f <root>/one/b.foo ..` produced no result
- from `<root>/one/two`, `fd --full-path -t f <root>/one/.*/.*/b.foo ..` incorrectly matched `../b.foo`

After:
- `--full-path` normalizes the joined path before matching, so parent-root searches behave the same as their normalized equivalents

Validation:
- `cargo test --quiet test_full_path_normalizes_parent_components`
- `cargo test --quiet test_full_path_parent_components_do_not_overmatch`
- `cargo test --quiet full_path`
- `cargo test --quiet absolute_path`
- `cargo test --quiet search_str_for_entry`
- `cargo fmt --check`
