### PR TITLE
scripts/create-deb: make fdfind bash completion actually work

### DIFF
--- a/scripts/create-deb.sh
+++ b/scripts/create-deb.sh
@@ -59,7 +59,19 @@ gzip -n --best "${DPKG_DIR}/usr/share/doc/${DPKG_BASENAME}/changelog"
 
 # Create symlinks so fdfind can be used as well:
 ln -s "/usr/bin/fd" "${DPKG_DIR}/usr/bin/fdfind"
-ln -s  './fd.bash' "${DPKG_DIR}/usr/share/bash-completion/completions/fdfind"
+# bash completion binds handlers to command names via `complete -F _fd fd`,
+# so a bare symlink to fd.bash does nothing for the `fdfind` alias. Install
+# a separate file that sources fd.bash and registers the handler under the
+# fdfind name as well. See https://github.com/sharkdp/fd/issues/1888.
+cat > "${DPKG_DIR}/usr/share/bash-completion/completions/fdfind" <<'FDFIND_BASH'
+# Reuse the fd bash completion for the `fdfind` alias shipped on Debian/Ubuntu.
+if [ -r /usr/share/bash-completion/completions/fd ]; then
+    . /usr/share/bash-completion/completions/fd
+    complete -F _fd fdfind
+fi
+FDFIND_BASH
+# Fish and zsh look up completion files by command name, so the symlink
+# approach works for them.
 ln -s  './fd.fish' "${DPKG_DIR}/usr/share/fish/vendor_completions.d/fdfind.fish"
 ln -s  './_fd' "${DPKG_DIR}/usr/share/zsh/vendor-completions/_fdfind"
 


### PR DESCRIPTION
Fixes #1888.

## Problem

After \`dpkg -i fd_10.3.0_amd64.deb\`, bash completion works for \`fd\` but not for the \`fdfind\` alias:

```
$ fdfind <TAB>      # nothing
$ fd     <TAB>      # works
```

## Root cause

\`scripts/create-deb.sh\` creates a filesystem symlink from \`fdfind\` → \`fd.bash\`:

```sh
ln -s './fd.bash' "${DPKG_DIR}/usr/share/bash-completion/completions/fdfind"
```

But bash completion is registered **by command name**, via the \`complete -F _fd fd\` directive inside the generated \`fd.bash\` file. Sourcing the same file a second time under the \`fdfind\` name still only registers the handler for \`fd\`, because the \`complete\` argument is hard-coded.

This is different from fish and zsh, which look up completion files by filename matching the command name — symlinks work there.

## Fix

Replace the bash symlink with a small wrapper file that sources \`fd.bash\` and registers the handler under the \`fdfind\` name too:

```sh
# /usr/share/bash-completion/completions/fdfind
if [ -r /usr/share/bash-completion/completions/fd ]; then
    . /usr/share/bash-completion/completions/fd
    complete -F _fd fdfind
fi
```

Fish and zsh symlinks are untouched.

## Testing

Manual on Ubuntu 24.04 after installing the rebuilt .deb:
- \`fd <TAB>\` completes flags ✅
- \`fdfind <TAB>\` completes flags ✅ (previously: nothing)

The guard (\`if [ -r ... ]\`) makes the wrapper safe if for some reason \`fd.bash\` is missing (e.g. user-removed).