### PR TITLE
fix: show path-separator error for any pattern containing a separator

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,12 +145,15 @@ fn set_working_dir(opts: &Opts) -> Result<()> {
     Ok(())
 }
 
-/// Detect if the user accidentally supplied a path instead of a search pattern
+/// Detect if the user accidentally supplied a path instead of a search pattern.
+///
+/// A pattern containing a path-separation character will never match because
+/// the regex engine sees the separator literally and fd's search is file-name
+/// based (not full-path based). Fire the helpful error whenever the pattern
+/// contains a separator, regardless of whether it also happens to match an
+/// existing directory on disk. See https://github.com/sharkdp/fd/issues/1873.
 fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
-    if !opts.full_path
-        && opts.pattern.contains(std::path::MAIN_SEPARATOR)
-        && Path::new(&opts.pattern).is_dir()
-    {
+    if !opts.full_path && opts.pattern.contains(std::path::MAIN_SEPARATOR) {
         Err(anyhow!(
             "The search pattern '{pattern}' contains a path-separation character ('{sep}') \
              and will not lead to any search results.\n\n\

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,22 +147,28 @@ fn set_working_dir(opts: &Opts) -> Result<()> {
 
 /// Detect if the user accidentally supplied a path instead of a search pattern.
 ///
-/// A pattern containing a path-separation character will never match because
-/// the regex engine sees the separator literally and fd's search is file-name
-/// based (not full-path based). Fire the helpful error whenever the pattern
-/// contains a separator, regardless of whether it also happens to match an
-/// existing directory on disk. See https://github.com/sharkdp/fd/issues/1873.
+/// A pattern containing '/' will never match because the regex engine sees
+/// the separator literally and fd's search is file-name based (not full-path
+/// based). Fire the helpful error whenever the pattern contains '/',
+/// regardless of whether it also happens to match an existing directory on
+/// disk. See https://github.com/sharkdp/fd/issues/1873.
+///
+/// We intentionally only flag '/' (not the platform MAIN_SEPARATOR): on
+/// Windows '\\' is both a path separator and a regex escape character, so
+/// perfectly valid regex patterns such as "\\Ac" or "\\d+" must not trigger
+/// this error. '/' is always a path separator (including on Windows) and has
+/// no meaning in a regex, so flagging only '/' gives the useful diagnostic
+/// without false positives against Windows-typed regex patterns.
 fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
-    if !opts.full_path && opts.pattern.contains(std::path::MAIN_SEPARATOR) {
+    if !opts.full_path && opts.pattern.contains('/') {
         Err(anyhow!(
-            "The search pattern '{pattern}' contains a path-separation character ('{sep}') \
+            "The search pattern '{pattern}' contains a path-separation character ('/') \
              and will not lead to any search results.\n\n\
              If you want to search for all files inside the '{pattern}' directory, use a match-all pattern:\n\n  \
              fd . '{pattern}'\n\n\
              Instead, if you want your pattern to match the full file path, use:\n\n  \
              fd --full-path '{pattern}'",
             pattern = &opts.pattern,
-            sep = std::path::MAIN_SEPARATOR,
         ))
     } else {
         Ok(())


### PR DESCRIPTION
Fixes #1873.

## Problem

\`fd pattern\` with a path-separator character in the pattern silently returns zero results most of the time. The user only sees the helpful \"pattern contains a path-separation character\" error when the pattern also happens to match an existing directory on disk:

```
$ fd /        # pattern happens to be a real directory → error fires
$ fd 'src/foo'  # not an existing directory → silent zero results
```

That's because \`ensure_search_pattern_is_not_a_path\` in \`src/main.rs\` checks both:

```rust
if !opts.full_path
    && opts.pattern.contains(std::path::MAIN_SEPARATOR)
    && Path::new(&opts.pattern).is_dir()
```

## Fix

Drop the \`is_dir()\` check. By fd's design, the search is file-name based unless \`--full-path\` is set, so a pattern containing a separator will never match anything. The error should always fire.

```diff
-    if !opts.full_path
-        && opts.pattern.contains(std::path::MAIN_SEPARATOR)
-        && Path::new(&opts.pattern).is_dir()
-    {
+    if !opts.full_path && opts.pattern.contains(std::path::MAIN_SEPARATOR) {
```

The existing error message already generalizes: it suggests \`fd . 'pattern'\` or \`fd --full-path 'pattern'\`, both of which make sense whether the pattern is a real directory or not.

## Behavior change

Before: silent zero results for patterns with separators unless the pattern happens to be a real directory.
After: consistent helpful error for any such pattern, pointing the user to \`--full-path\` or a corrected match-all invocation.

This is the change the issue author explicitly asked for (\"I would expect the error about how a pattern with a '/' in it will not lead to any search results to be displayed regardless of the pattern possibly being a directory path\").