### PR TITLE
fix: show path-separator error regardless of directory existence

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,6 @@ fn set_working_dir(opts: &Opts) -> Result<()> {
 fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
     if !opts.full_path
         && opts.pattern.contains(std::path::MAIN_SEPARATOR)
-        && Path::new(&opts.pattern).is_dir()
     {
         Err(anyhow!(
             "The search pattern '{pattern}' contains a path-separation character ('{sep}') \


### PR DESCRIPTION
## Summary

The `'pattern contains a path separator'` error was only shown when the pattern happened to be an existing directory. This made the behavior inconsistent — `fd /` showed the error (because `/` is a directory), but `fd nonexistent/path` silently returned no results.

This PR removes the `Path::new(&opts.pattern).is_dir()` check so the error is shown consistently for any pattern containing a path separator character.

**Note:** On Windows, `\` is both the path separator and a regex escape character, so this fix may produce false positives for patterns like `\d`. A follow-up could be to only apply this check when the pattern is not a valid regex, but that's a larger change.

Closes #1873