### PR TITLE
docs: document PowerShell placeholder quoting requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 
-## Documentation
-- Document PowerShell placeholder quoting requirement in the troubleshooting section, see #735 (@YoshKoz)
-
 # 10.4.2
 
 ## Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 
+## Documentation
+- Document PowerShell placeholder quoting requirement in the troubleshooting section, see #735 (@YoshKoz)
+
 # 10.4.2
 
 ## Bugfixes

--- a/README.md
+++ b/README.md
@@ -444,22 +444,10 @@ you can use `export -f my_function` to make available to child processes. You wo
 need to call `fd -x bash -c 'my_function "$1"' bash`. For other use cases or shells, use
 a (temporary) shell script.
 
-### Placeholders (`{}`, `{/}`, `{//}`, `{.}`, `{/.}`) in PowerShell
+### Placeholders in `-x`/`-X`
 
-In PowerShell (both Windows PowerShell and PowerShell 7+), curly braces `{}` are reserved
-for script blocks. Passing them unquoted to `fd -x`/`fd -X` will cause PowerShell to
-interpret them before `fd` sees them, breaking the placeholder. Wrap any placeholder in
-single quotes (or escape the braces with backticks):
-
-``` powershell
-# Won't work — PowerShell parses `{/}` as a script block:
-fd -e txt -x echo {/}
-
-# Works — single quotes pass `{/}` through to fd untouched:
-fd -e txt -x echo '{/}'
-```
-
-The same rule applies to `{}`, `{//}`, `{.}`, and `{/.}`.
+Depending on your shell, you may need to quote the placeholders (`{}`, `{/}`, `{//}`,
+`{.}`, `{/.}`) to prevent the shell from interpreting them before `fd` sees them.
 
 ## Integration with other programs
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,23 @@ you can use `export -f my_function` to make available to child processes. You wo
 need to call `fd -x bash -c 'my_function "$1"' bash`. For other use cases or shells, use
 a (temporary) shell script.
 
+### Placeholders (`{}`, `{/}`, `{//}`, `{.}`, `{/.}`) in PowerShell
+
+In PowerShell (both Windows PowerShell and PowerShell 7+), curly braces `{}` are reserved
+for script blocks. Passing them unquoted to `fd -x`/`fd -X` will cause PowerShell to
+interpret them before `fd` sees them, breaking the placeholder. Wrap any placeholder in
+single quotes (or escape the braces with backticks):
+
+``` powershell
+# Won't work — PowerShell parses `{/}` as a script block:
+fd -e txt -x echo {/}
+
+# Works — single quotes pass `{/}` through to fd untouched:
+fd -e txt -x echo '{/}'
+```
+
+The same rule applies to `{}`, `{//}`, `{.}`, and `{/.}`.
+
 ## Integration with other programs
 
 ### Using fd with `fzf`


### PR DESCRIPTION
Closes #735.

In #735 the maintainer asked for the troubleshooting section to mention that `{}` placeholders need to be escaped in PowerShell. Adds:

- A new "Placeholders (`{}`, `{/}`, `{//}`, `{.}`, `{/.}`) in PowerShell" subsection under **Troubleshooting** with a working/non-working example.
- A matching changelog entry.

No code changes.