### PR TITLE
fix(size): avoid u64 overflow panic when parsing huge size args

### DIFF
--- a/src/filter/size.rs
+++ b/src/filter/size.rs
@@ -56,7 +56,7 @@ impl SizeFilter {
             _ => return None,
         };
 
-        let size = quantity * multiplier;
+        let size = quantity.checked_mul(multiplier)?;
         match limit_kind {
             "+" => Some(SizeFilter::Min(size)),
             "-" => Some(SizeFilter::Max(size)),
@@ -191,6 +191,8 @@ mod tests {
         ensure_invalid_unit_returns_none_3: "+1Mv",
         ensure_bib_format_returns_none: "+1bib",
         ensure_bb_format_returns_none: "+1bb",
+        ensure_overflow_returns_none_tib: "+17000000Ti",
+        ensure_overflow_returns_none_tb: "+20000000T",
     }
 
     #[test]


### PR DESCRIPTION

**Repo:** sharkdp/fd (⭐ 36000)
**Type:** bugfix
**Files changed:** 1
**Lines:** +3/-1

## What
`SizeFilter::parse_opt` in `src/filter/size.rs` multiplied the parsed quantity
by its unit multiplier using plain `*`. For values such as `+20000000T` or
`+17000000Ti`, that product overflows `u64` and panics in debug builds (and
wraps silently in release). This change replaces the multiplication with
`checked_mul(...)?`, making overflow cause the parser to return `None` — which
bubbles up as the normal "not a valid size constraint" error from the CLI.
Two regression tests are added alongside the existing failure cases.

## Why
A user-supplied CLI argument should never be able to crash fd or silently be
misinterpreted. The existing parser validates format via regex but does not
guard against numeric overflow of the final computed byte count. With this
fix, `fd --size +20000000T` produces a clean error message instead of an
arithmetic overflow panic / wrapped value.

## Testing
- `cargo test --bin fd size::` — 86 passed, 0 failed, including the two new
  `ensure_overflow_returns_none_*` cases.
- Before the fix, the new tests panic under `cargo test` (overflow); after,
  they pass.

## Risk
Low — change is a two-character semantic tweak confined to the size parser,
covered by pre-existing and new unit tests. No behavior change for valid
inputs.
