### PR TITLE
Fix --min-depth for broken symlinks

### DIFF
--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -11,7 +11,7 @@ use crate::filesystem::strip_current_dir;
 #[derive(Debug)]
 enum DirEntryInner {
     Normal(ignore::DirEntry),
-    BrokenSymlink(PathBuf),
+    BrokenSymlink(PathBuf, usize),
 }
 
 #[derive(Debug)]
@@ -31,9 +31,9 @@ impl DirEntry {
         }
     }
 
-    pub fn broken_symlink(path: PathBuf) -> Self {
+    pub fn broken_symlink(path: PathBuf, depth: usize) -> Self {
         Self {
-            inner: DirEntryInner::BrokenSymlink(path),
+            inner: DirEntryInner::BrokenSymlink(path, depth),
             metadata: OnceCell::new(),
             style: OnceCell::new(),
         }
@@ -42,14 +42,14 @@ impl DirEntry {
     pub fn path(&self) -> &Path {
         match &self.inner {
             DirEntryInner::Normal(e) => e.path(),
-            DirEntryInner::BrokenSymlink(pathbuf) => pathbuf.as_path(),
+            DirEntryInner::BrokenSymlink(pathbuf, _) => pathbuf.as_path(),
         }
     }
 
     pub fn into_path(self) -> PathBuf {
         match self.inner {
             DirEntryInner::Normal(e) => e.into_path(),
-            DirEntryInner::BrokenSymlink(p) => p,
+            DirEntryInner::BrokenSymlink(p, _) => p,
         }
     }
 
@@ -74,7 +74,7 @@ impl DirEntry {
     pub fn file_type(&self) -> Option<FileType> {
         match &self.inner {
             DirEntryInner::Normal(e) => e.file_type(),
-            DirEntryInner::BrokenSymlink(_) => self.metadata().map(|m| m.file_type()),
+            DirEntryInner::BrokenSymlink(..) => self.metadata().map(|m| m.file_type()),
         }
     }
 
@@ -82,7 +82,7 @@ impl DirEntry {
         self.metadata
             .get_or_init(|| match &self.inner {
                 DirEntryInner::Normal(e) => e.metadata().ok(),
-                DirEntryInner::BrokenSymlink(path) => path.symlink_metadata().ok(),
+                DirEntryInner::BrokenSymlink(path, _) => path.symlink_metadata().ok(),
             })
             .as_ref()
     }
@@ -90,7 +90,7 @@ impl DirEntry {
     pub fn depth(&self) -> Option<usize> {
         match &self.inner {
             DirEntryInner::Normal(e) => Some(e.depth()),
-            DirEntryInner::BrokenSymlink(_) => None,
+            DirEntryInner::BrokenSymlink(_, depth) => Some(*depth),
         }
     }
 
@@ -132,7 +132,7 @@ impl Colorable for DirEntry {
     fn file_name(&self) -> OsString {
         let name = match &self.inner {
             DirEntryInner::Normal(e) => e.file_name(),
-            DirEntryInner::BrokenSymlink(path) => {
+            DirEntryInner::BrokenSymlink(path, _) => {
                 // Path::file_name() only works if the last component is Normal,
                 // but we want it for all component types, so we open code it.
                 // Copied from LsColors::style_for_path_with_metadata().

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -495,7 +495,8 @@ impl WorkerState {
                                     .ok()
                                     .is_some_and(|m| m.file_type().is_symlink()) =>
                         {
-                            DirEntry::broken_symlink(path)
+                            let broken_path = path.clone();
+                            DirEntry::broken_symlink(broken_path, 1)
                         }
                         _ => {
                             return match tx.send(WorkerResult::Error(ignore::Error::WithPath {


### PR DESCRIPTION
Fixes #1017

Broken symlinks were returning None for depth(), causing min-depth checks to fail. This commit tracks depth for BrokenSymlink entries and returns it properly.