### PR TITLE
fix: prepend **/ to glob patterns when using --full-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `--ignore-parent` option to override `--no-ignore-parent`, see #1958 (@tmchow)
 
 ## Bugfixes
+- Fix `--glob` patterns not working correctly when used with `--full-path`, see #1650 (@argon17)
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 - Fire the "search pattern contains a path separator" diagnostic for any pattern containing `/`, not just patterns that happen to name an existing directory. Preserves the legacy Windows behaviour that also flags native `\` separators when the pattern resolves to a real directory. See #1873.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,17 @@ fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
 
 fn build_pattern_regex(pattern: &str, opts: &Opts) -> Result<String> {
     Ok(if opts.glob && !pattern.is_empty() {
-        let glob = GlobBuilder::new(pattern).literal_separator(true).build()?;
+        let normalized_pattern = if opts.full_path
+            && !pattern.starts_with('/')
+            && !pattern.starts_with("**/")
+        {
+            format!("**/{pattern}")
+        } else {
+            pattern.to_owned()
+        };
+        let glob = GlobBuilder::new(&normalized_pattern)
+            .literal_separator(true)
+            .build()?;
         glob.regex().to_owned()
     } else if opts.fixed_strings {
         // Treat pattern as literal string if '--fixed-strings' is used

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,14 +203,12 @@ fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
 
 fn build_pattern_regex(pattern: &str, opts: &Opts) -> Result<String> {
     Ok(if opts.glob && !pattern.is_empty() {
-        let normalized_pattern = if opts.full_path
-            && !pattern.starts_with('/')
-            && !pattern.starts_with("**/")
-        {
-            format!("**/{pattern}")
-        } else {
-            pattern.to_owned()
-        };
+        let normalized_pattern =
+            if opts.full_path && !pattern.starts_with('/') && !pattern.starts_with("**/") {
+                format!("**/{pattern}")
+            } else {
+                pattern.to_owned()
+            };
         let glob = GlobBuilder::new(&normalized_pattern)
             .literal_separator(true)
             .build()?;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -588,6 +588,28 @@ fn test_full_path_glob_searches() {
         &["--glob", "--full-path", "**/one/*/*/*.foo"],
         " one/two/three/d.foo",
     );
+
+    te.assert_output(
+        &["--glob", "--full-path", "c.foo"],
+        "one/two/c.foo",
+    );
+
+    te.assert_output(
+        &["--glob", "--full-path", "one/**/c.foo"],
+        "one/two/c.foo",
+    );
+
+    te.assert_output(
+        &["--glob", "--full-path", "one/**/*.foo"],
+        "one/b.foo
+        one/two/c.foo
+        one/two/three/d.foo",
+    );
+
+    te.assert_output(
+        &["--glob", "--full-path", "two/**/d.foo"],
+        "one/two/three/d.foo",
+    );
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -589,15 +589,9 @@ fn test_full_path_glob_searches() {
         " one/two/three/d.foo",
     );
 
-    te.assert_output(
-        &["--glob", "--full-path", "c.foo"],
-        "one/two/c.foo",
-    );
+    te.assert_output(&["--glob", "--full-path", "c.foo"], "one/two/c.foo");
 
-    te.assert_output(
-        &["--glob", "--full-path", "one/**/c.foo"],
-        "one/two/c.foo",
-    );
+    te.assert_output(&["--glob", "--full-path", "one/**/c.foo"], "one/two/c.foo");
 
     te.assert_output(
         &["--glob", "--full-path", "one/**/*.foo"],


### PR DESCRIPTION
When using '--glob' with '--full-path' together, **globset** always generates fully-anchored regexes (^...$), so patterns like 'c.foo' or 'one/**/c.foo' never matches against the absolute path, because the regex requires the match to start at the very beginning of the string, but the full path will always start with '/'.

Fixed by prepending **/ to the glob pattern when '--full-path' is set and the pattern doesn't already start with / or **/.

Fixes #1650
