### PR TITLE
docs: clarify full path help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Options:
   -a, --absolute-path              Show absolute instead of relative paths
   -l, --list-details               Use a long listing format with file metadata
   -L, --follow                     Follow symbolic links
-  -p, --full-path                  Search full abs. path (default: filename only)
+  -p, --full-path                  Search full path (default: final path component only)
   -d, --max-depth <depth>          Set maximum search depth (default: none)
   -E, --exclude <glob>             Exclude entries that match the given glob pattern
   -t, --type <filetype>            Filter by type: file (f), directory (d/dir), symlink (l),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -239,12 +239,12 @@ pub struct Opts {
     #[arg(long, overrides_with = "follow", hide = true, action = ArgAction::SetTrue)]
     no_follow: (),
 
-    /// By default, the search pattern is only matched against the filename (or directory name). Using this flag, the pattern is matched against the full (absolute) path. Example:
+    /// By default, the search pattern is only matched against the final path component. Using this flag, the pattern is matched against the full path. Example:
     ///   fd --glob -p '**/.git/config'
     #[arg(
         long,
         short = 'p',
-        help = "Search full abs. path (default: filename only)",
+        help = "Search full path (default: final path component only)",
         long_help,
         verbatim_doc_comment
     )]


### PR DESCRIPTION
## Summary

- clarify that `--full-path` searches the full path, not an absolute output path
- describe the default search target as the final path component
- update the README help snapshot to match

Fixes #1686.

## Checks

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -Dwarnings`
- `cargo test --locked`