### PR TITLE
docs: clarify --full-path help text (fixes #1686)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ To really search *all* files and directories, simply combine the hidden and igno
 everything (`-HI`) or use `-u`/`--unrestricted`.
 
 ### Matching the full path
-By default, *fd* only matches the filename of each file. However, using the `--full-path` or `-p` option,
-you can match against the full path.
+By default, *fd* only matches the last path component of each entry. However, using the `--full-path` or `-p` option,
+you can match against the absolute path.
 
 ```bash
 > fd -p -g '**/.git/config'
@@ -322,7 +322,7 @@ Options:
   -a, --absolute-path              Show absolute instead of relative paths
   -l, --list-details               Use a long listing format with file metadata
   -L, --follow                     Follow symbolic links
-  -p, --full-path                  Search full abs. path (default: filename only)
+  -p, --full-path                  Search absolute path (default: last path component only)
   -d, --max-depth <depth>          Set maximum search depth (default: none)
   -E, --exclude <glob>             Exclude entries that match the given glob pattern
   -t, --type <filetype>            Filter by type: file (f), directory (d/dir), symlink (l),
@@ -400,9 +400,9 @@ use the options `-u`/`--unrestricted` option (or `-HI` to enable hidden and igno
 > fd -u …
 ```
 
-Also remember that by default, `fd` only searches based on the filename and
-doesn't compare the pattern to the full path. If you want to search based on the
-full path (similar to the `-path` option of `find`) you need to use the `--full-path`
+Also remember that by default, `fd` only searches based on the last path component and
+doesn't compare the pattern to the absolute path. If you want to search based on the
+absolute path (similar to the `-path` option of `find`) you need to use the `--full-path`
 (or `-p`) option.
 
 ### Colorized output

--- a/contrib/completion/_fd
+++ b/contrib/completion/_fd
@@ -76,7 +76,7 @@ _fd() {
     "$no(no-ignore-full --no-ignore-vcs --no-require-git)--no-require-git[don't require git repo to respect gitignores]"
 
     + '(match-full)' # match against full path
-    {-p,--full-path}'[match the pattern against the full path instead of the basename]'
+    {-p,--full-path}'[match the pattern against the absolute path instead of the last path component]'
 
     + '(follow)' # follow symlinks
     {-L,--follow}'[follow symbolic links to directories]'

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -136,10 +136,10 @@ By default, fd does not descend into symlinked directories. Using this flag, sym
 also traversed. The flag can be overridden with '--no-follow'.
 .TP
 .B \-p, \-\-full\-path
-By default, the search pattern is only matched against the filename (or directory name). Using
+By default, the search pattern is only matched against the last path component (file or directory name). Using
 this flag, the
 .I pattern
-is matched against the full path.
+is matched against the absolute path.
 .TP
 .B \-0, \-\-print0
 Separate search results by the null character (instead of newlines). Useful for piping results to

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -239,12 +239,12 @@ pub struct Opts {
     #[arg(long, overrides_with = "follow", hide = true, action = ArgAction::SetTrue)]
     no_follow: (),
 
-    /// By default, the search pattern is only matched against the filename (or directory name). Using this flag, the pattern is matched against the full (absolute) path. Example:
+    /// By default, the search pattern is only matched against the last path component (file or directory name). Using this flag, the pattern is matched against the absolute path. Example:
     ///   fd --glob -p '**/.git/config'
     #[arg(
         long,
         short = 'p',
-        help = "Search full abs. path (default: filename only)",
+        help = "Search absolute path (default: last path component only)",
         long_help,
         verbatim_doc_comment
     )]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ pub struct Config {
     pub case_sensitive: bool,
 
     /// Cached current working directory for absolute path construction.
-    /// Populated when `--full-path` is set; `None` means search by filename only.
+    /// Populated when `--full-path` is set; `None` means search by last path component only.
     pub full_path_base: Option<PathBuf>,
 
     /// Whether to ignore hidden files and directories (or not).

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1466,7 +1466,8 @@ fn test_extension() {
 /// Help text for `--full-path` should not use ambiguous wording (#1686)
 #[test]
 fn test_full_path_help_text() {
-    let fd_exe = std::path::PathBuf::from(std::env::var("CARGO_BIN_EXE_fd").expect("CARGO_BIN_EXE_fd"));
+    let fd_exe =
+        std::path::PathBuf::from(std::env::var("CARGO_BIN_EXE_fd").expect("CARGO_BIN_EXE_fd"));
     let output = std::process::Command::new(&fd_exe)
         .arg("-h")
         .output()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1466,8 +1466,9 @@ fn test_extension() {
 /// Help text for `--full-path` should not use ambiguous wording (#1686)
 #[test]
 fn test_full_path_help_text() {
-    let fd_exe =
-        std::path::PathBuf::from(std::env::var("CARGO_BIN_EXE_fd").expect("CARGO_BIN_EXE_fd"));
+    let fd_exe = std::path::PathBuf::from(
+        std::env::var("CARGO_BIN_EXE_fd").unwrap_or_else(|_| env!("CARGO_BIN_EXE_fd").to_string()),
+    );
     let output = std::process::Command::new(&fd_exe)
         .arg("-h")
         .output()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1463,6 +1463,22 @@ fn test_extension() {
     te4.assert_output(&["--hidden", "--extension", ".hidden"], "test.hidden");
 }
 
+/// Help text for `--full-path` should not use ambiguous wording (#1686)
+#[test]
+fn test_full_path_help_text() {
+    let fd_exe = std::path::PathBuf::from(std::env::var("CARGO_BIN_EXE_fd").expect("CARGO_BIN_EXE_fd"));
+    let output = std::process::Command::new(&fd_exe)
+        .arg("-h")
+        .output()
+        .expect("fd -h");
+    assert!(output.status.success());
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        help.contains("Search absolute path (default: last path component only)"),
+        "unexpected -p help in:\n{help}"
+    );
+}
+
 /// No file extension (test for the pattern provided in the --help text)
 #[test]
 fn test_no_extension() {


### PR DESCRIPTION
## Summary

Clarifies `--full-path` / `-p` documentation so users understand:

- By default, patterns match the **last path component** (not "filename only" / ambiguous "full path").
- With `-p`, patterns match the **absolute path** (not a relative path from the search root).

Updates `src/cli.rs`, `doc/fd.1`, `README.md` (prose + `--help` snapshot), zsh completion, and an internal comment in `src/config.rs`.

Fixes #1686.

## Context

Follows feedback on #1996 from @tmccombs:

- Keep **absolute** in the description of what `-p` matches (see also #839).
- Prefer **last path component** over "final" / "filename only" for the default behavior.

## Checks

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -Dwarnings`
- [x] `cargo test --locked`