### PR TITLE
fix: hint shell builtins in command-not-found error (fixes #1944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 - Fire the "search pattern contains a path separator" diagnostic for any pattern containing `/`, not just patterns that happen to name an existing directory. Preserves the legacy Windows behaviour that also flags native `\` separators when the pattern resolves to a real directory. See #1873.
+- Hint that a command is a shell builtin when `-x`/`-X` fails with "command not found", see #1944 (@kimjune01)
 
 # 10.4.2
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ To really search *all* files and directories, simply combine the hidden and igno
 everything (`-HI`) or use `-u`/`--unrestricted`.
 
 ### Matching the full path
-By default, *fd* only matches the filename of each file. However, using the `--full-path` or `-p` option,
-you can match against the full path.
+By default, *fd* only matches the last path component of each entry. However, using the `--full-path` or `-p` option,
+you can match against the absolute path.
 
 ```bash
 > fd -p -g '**/.git/config'
@@ -322,7 +322,7 @@ Options:
   -a, --absolute-path              Show absolute instead of relative paths
   -l, --list-details               Use a long listing format with file metadata
   -L, --follow                     Follow symbolic links
-  -p, --full-path                  Search full abs. path (default: filename only)
+  -p, --full-path                  Search absolute path (default: last path component only)
   -d, --max-depth <depth>          Set maximum search depth (default: none)
   -E, --exclude <glob>             Exclude entries that match the given glob pattern
   -t, --type <filetype>            Filter by type: file (f), directory (d/dir), symlink (l),
@@ -400,9 +400,9 @@ use the options `-u`/`--unrestricted` option (or `-HI` to enable hidden and igno
 > fd -u …
 ```
 
-Also remember that by default, `fd` only searches based on the filename and
-doesn't compare the pattern to the full path. If you want to search based on the
-full path (similar to the `-path` option of `find`) you need to use the `--full-path`
+Also remember that by default, `fd` only searches based on the last path component and
+doesn't compare the pattern to the absolute path. If you want to search based on the
+absolute path (similar to the `-path` option of `find`) you need to use the `--full-path`
 (or `-p`) option.
 
 ### Colorized output
@@ -436,13 +436,21 @@ use a character class with a single hyphen character:
 > fd '[-]pattern'
 ```
 
-### "Command not found" for `alias`es or shell functions
+### "Command not found" with `-x`/`-X`
 
-Shell `alias`es and shell functions can not be used for command execution via `fd -x` or
-`fd -X`. In `zsh`, you can make the alias global via `alias -g myalias="…"`. In `bash`,
-you can use `export -f my_function` to make available to child processes. You would still
-need to call `fd -x bash -c 'my_function "$1"' bash`. For other use cases or shells, use
-a (temporary) shell script.
+`fd` runs commands in a child process. Shell **builtins** (such as `cd`, `export`, or `source`)
+are not standalone programs, so `fd -x cd` fails with "command not found". Invoke a shell
+explicitly instead:
+
+``` bash
+fd -t d -x sh -c 'cd "$1"' sh {}
+```
+
+Shell **aliases** and **functions** are also unavailable unless you run them through a shell.
+In `zsh`, you can make an alias global via `alias -g myalias="…"`. In `bash`, you can use
+`export -f my_function` to export a function to child processes. You would still need to call
+`fd -x bash -c 'my_function "$1"' bash`. For other use cases or shells, use a (temporary)
+shell script.
 
 ### Placeholders in `-x`/`-X`
 

--- a/src/exec/command.rs
+++ b/src/exec/command.rs
@@ -98,18 +98,83 @@ pub fn execute_commands<I: Iterator<Item = io::Result<Command>>>(
     ExitCode::Success
 }
 
+/// Common shell builtins that typically do not exist as standalone executables.
+/// When fd encounters a "command not found" error for one of these, it hints
+/// that the user may be trying to use a shell builtin.
+const SHELL_BUILTINS: &[&str] = &[
+    ".", "alias", "bg", "bind", "cd", "command", "declare", "dirs", "eval", "exec", "exit",
+    "export", "fg", "hash", "help", "history", "jobs", "let", "local", "logout", "popd", "pushd",
+    "read", "readonly", "return", "set", "shift", "shopt", "source", "suspend", "times", "trap",
+    "type", "typeset", "unalias", "unset", "wait",
+];
+
+fn is_shell_builtin(program: &str) -> bool {
+    SHELL_BUILTINS.iter().any(|&b| b == program)
+}
+
+fn command_not_found_message(program: &str) -> String {
+    if is_shell_builtin(program) {
+        format!(
+            "Command not found: {program}. Note: {program} is a shell builtin, \
+             not a standalone program. To run shell builtins, invoke a shell explicitly, \
+             e.g. fd -x sh -c '{program} ... \"$1\"' sh {{}}",
+        )
+    } else {
+        format!("Command not found: {program}")
+    }
+}
+
 pub fn handle_cmd_error(cmd: Option<&Command>, err: io::Error) -> ExitCode {
     match (cmd, err) {
         (Some(cmd), err) if err.kind() == io::ErrorKind::NotFound => {
-            print_error(format!(
-                "Command not found: {}",
-                cmd.get_program().to_string_lossy()
-            ));
+            let program = cmd.get_program().to_string_lossy();
+            print_error(command_not_found_message(&program));
             ExitCode::GeneralError
         }
         (_, err) => {
             print_error(format!("Problem while executing command: {err}"));
             ExitCode::GeneralError
         }
+    }
+}
+
+#[cfg(test)]
+mod builtin_tests {
+    use super::*;
+
+    #[test]
+    fn detects_known_builtins() {
+        assert!(is_shell_builtin("cd"));
+        assert!(is_shell_builtin("export"));
+        assert!(is_shell_builtin("source"));
+        assert!(is_shell_builtin("eval"));
+        assert!(is_shell_builtin("."));
+    }
+
+    #[test]
+    fn rejects_non_builtins() {
+        assert!(!is_shell_builtin("grep"));
+        assert!(!is_shell_builtin("ls"));
+        assert!(!is_shell_builtin(""));
+        assert!(!is_shell_builtin("CD"));
+        // These typically exist as standalone executables
+        assert!(!is_shell_builtin("echo"));
+        assert!(!is_shell_builtin("printf"));
+        assert!(!is_shell_builtin("test"));
+    }
+
+    #[test]
+    fn builtin_message_includes_hint() {
+        let msg = command_not_found_message("cd");
+        assert!(msg.starts_with("Command not found: cd."));
+        assert!(msg.contains("shell builtin"));
+        assert!(msg.contains("sh -c"));
+    }
+
+    #[test]
+    fn non_builtin_message_is_plain() {
+        let msg = command_not_found_message("nonexistent");
+        assert_eq!(msg, "Command not found: nonexistent");
+        assert!(!msg.contains("shell builtin"));
     }
 }

--- a/src/exec/command.rs
+++ b/src/exec/command.rs
@@ -109,7 +109,7 @@ const SHELL_BUILTINS: &[&str] = &[
 ];
 
 fn is_shell_builtin(program: &str) -> bool {
-    SHELL_BUILTINS.iter().any(|&b| b == program)
+    SHELL_BUILTINS.contains(&program)
 }
 
 fn command_not_found_message(program: &str) -> String {


### PR DESCRIPTION
## Summary

When `fd -x`/`-X` fails with "command not found" for a known shell builtin (e.g. `cd`), print a clearer error that explains builtins must be run via an explicit shell invocation.

Fixes #1944.

## Context

Implementation follows the approach discussed in #1944 and aligns with [PR #1994](https://github.com/sharkdp/fd/pull/1994) by @kimjune01. That PR currently fails CI on `clippy::manual-contains`; this branch includes the same feature plus:

```rust
SHELL_BUILTINS.contains(&program)  // instead of .iter().any(...)
```

Happy to close this in favor of #1994 if the author updates their branch — goal is to get a green CI fix merged.

## Checks

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -Dwarnings`
- [x] `cargo test --locked`