### PR TITLE
feat: warn when --full-path --glob pattern lacks path anchor (fixes #1650)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,7 @@
 pub fn print_error(msg: impl Into<String>) {
     eprintln!("[fd error]: {}", msg.into());
 }
+
+pub fn print_warning(msg: impl Into<String>) {
+    eprintln!("[fd warning]: {}", msg.into());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,22 +203,29 @@ fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
     }
 }
 
-/// With `--glob` and `--full-path`, patterns match the entire absolute path (from `/`).
-/// Warn when the pattern does not start with `/` or `*`, which often means no matches (#1650).
+/// With `--glob` and `--full-path`, patterns match the entire absolute path.
+/// Warn when the pattern does not start with a path root or glob wildcard, which often means no
+/// matches (#1650).
 fn warn_if_full_path_glob_missing_leading_anchor(opts: &Opts) {
     if !opts.glob || !opts.full_path || opts.pattern.is_empty() {
         return;
     }
-    let Some(first) = opts.pattern.chars().next() else {
-        return;
-    };
-    if first == '/' || first == '*' {
+    if full_path_glob_has_leading_anchor(&opts.pattern) {
         return;
     }
     print_warning(
         "With --glob and --full-path, the pattern matches the whole absolute path and \
          usually should start with '/' or '**/' (for example: '**/foo.txt').",
     );
+}
+
+fn full_path_glob_has_leading_anchor(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    matches!(bytes.first(), Some(b'*' | b'/' | b'\\'))
+        || matches!(
+            bytes,
+            [drive, b':', b'/' | b'\\', ..] if drive.is_ascii_alphabetic()
+        )
 }
 
 fn build_pattern_regex(pattern: &str, opts: &Opts) -> Result<String> {
@@ -553,4 +560,28 @@ fn build_regex(pattern_regex: String, config: &Config) -> Result<regex::bytes::R
                 e
             )
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::full_path_glob_has_leading_anchor;
+
+    #[test]
+    fn full_path_glob_anchor_accepts_absolute_and_wildcard_patterns() {
+        assert!(full_path_glob_has_leading_anchor("/tmp/file.txt"));
+        assert!(full_path_glob_has_leading_anchor(r"C:\Users\me\file.txt"));
+        assert!(full_path_glob_has_leading_anchor("C:/Users/me/file.txt"));
+        assert!(full_path_glob_has_leading_anchor(
+            r"\\server\share\file.txt"
+        ));
+        assert!(full_path_glob_has_leading_anchor("**/file.txt"));
+        assert!(full_path_glob_has_leading_anchor("*file.txt"));
+    }
+
+    #[test]
+    fn full_path_glob_anchor_rejects_relative_patterns() {
+        assert!(!full_path_glob_has_leading_anchor("file.txt"));
+        assert!(!full_path_glob_has_leading_anchor("dir/file.txt"));
+        assert!(!full_path_glob_has_leading_anchor(r"C:file.txt"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use regex::bytes::{Regex, RegexBuilder, RegexSetBuilder};
 
 use crate::cli::{ColorWhen, HyperlinkWhen, Opts};
 use crate::config::Config;
+use crate::error::print_warning;
 use crate::exec::CommandSet;
 use crate::exit_codes::ExitCode;
 use crate::filetypes::FileTypes;
@@ -86,6 +87,7 @@ fn run() -> Result<ExitCode> {
     }
 
     ensure_search_pattern_is_not_a_path(&opts)?;
+    warn_if_full_path_glob_missing_leading_anchor(&opts);
     let pattern = &opts.pattern;
     let exprs = &opts.exprs;
     let empty = Vec::new();
@@ -199,6 +201,24 @@ fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
     } else {
         Ok(())
     }
+}
+
+/// With `--glob` and `--full-path`, patterns match the entire absolute path (from `/`).
+/// Warn when the pattern does not start with `/` or `*`, which often means no matches (#1650).
+fn warn_if_full_path_glob_missing_leading_anchor(opts: &Opts) {
+    if !opts.glob || !opts.full_path || opts.pattern.is_empty() {
+        return;
+    }
+    let Some(first) = opts.pattern.chars().next() else {
+        return;
+    };
+    if first == '/' || first == '*' {
+        return;
+    }
+    print_warning(
+        "With --glob and --full-path, the pattern matches the whole absolute path and \
+         usually should start with '/' or '**/' (for example: '**/foo.txt').",
+    );
 }
 
 fn build_pattern_regex(pattern: &str, opts: &Opts) -> Result<String> {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -590,6 +590,21 @@ fn test_full_path_glob_searches() {
     );
 }
 
+#[cfg(not(windows))]
+#[test]
+fn test_warn_when_full_path_glob_missing_leading_anchor() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(&["--glob", "--full-path", "foo.txt"], "");
+
+    let output = te.assert_success_and_get_output(".", &["--glob", "--full-path", "foo.txt"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[fd warning]:") && stderr.contains("**/foo.txt"),
+        "expected full-path glob anchor warning, got: {stderr}"
+    );
+}
+
 #[test]
 fn test_smart_case_glob_searches() {
     let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
@@ -1461,6 +1476,24 @@ fn test_extension() {
     let te4 = TestEnv::new(&[], &[".hidden", "test.hidden"]);
 
     te4.assert_output(&["--hidden", "--extension", ".hidden"], "test.hidden");
+}
+
+/// Help text for `--full-path` should not use ambiguous wording (#1686)
+#[test]
+fn test_full_path_help_text() {
+    let fd_exe = std::path::PathBuf::from(
+        std::env::var("CARGO_BIN_EXE_fd").unwrap_or_else(|_| env!("CARGO_BIN_EXE_fd").to_string()),
+    );
+    let output = std::process::Command::new(&fd_exe)
+        .arg("-h")
+        .output()
+        .expect("fd -h");
+    assert!(output.status.success());
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        help.contains("Search absolute path (default: last path component only)"),
+        "unexpected -p help in:\n{help}"
+    );
 }
 
 /// No file extension (test for the pattern provided in the --help text)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1478,24 +1478,6 @@ fn test_extension() {
     te4.assert_output(&["--hidden", "--extension", ".hidden"], "test.hidden");
 }
 
-/// Help text for `--full-path` should not use ambiguous wording (#1686)
-#[test]
-fn test_full_path_help_text() {
-    let fd_exe = std::path::PathBuf::from(
-        std::env::var("CARGO_BIN_EXE_fd").unwrap_or_else(|_| env!("CARGO_BIN_EXE_fd").to_string()),
-    );
-    let output = std::process::Command::new(&fd_exe)
-        .arg("-h")
-        .output()
-        .expect("fd -h");
-    assert!(output.status.success());
-    let help = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        help.contains("Search absolute path (default: last path component only)"),
-        "unexpected -p help in:\n{help}"
-    );
-}
-
 /// No file extension (test for the pattern provided in the --help text)
 #[test]
 fn test_no_extension() {


### PR DESCRIPTION
## Summary

With `--glob` and `--full-path`, patterns match the **entire absolute path** (from `/`). Patterns like `foo.txt` or `bar/**/foo.txt` often match nothing because they do not anchor to the path root.

This adds a stderr warning when the pattern does not start with `/` or `*`, as suggested by @tavianator on #1650.

Does not change matching behavior (orthogonal to #1993).

## Test plan

- [x] `cargo test test_warn_when_full_path_glob_missing_leading_anchor`
- [x] `cargo clippy -- -D warnings`

Fixes #1650