### PR TITLE
fix: apply --exclude globs under each --search-path root

### DIFF
--- a/src/walk.rs
+++ b/src/walk.rs
@@ -330,12 +330,18 @@ impl WorkerState {
     fn build_overrides(&self, paths: &[PathBuf]) -> Result<Override> {
         let first_path = &paths[0];
         let config = &self.config;
+        let multi_root = paths.len() > 1;
 
         let mut builder = OverrideBuilder::new(first_path);
 
         for pattern in &config.exclude_patterns {
+            let pattern = if multi_root {
+                Cow::Owned(normalize_exclude_pattern_for_multi_root(pattern))
+            } else {
+                Cow::Borrowed(pattern.as_str())
+            };
             builder
-                .add(pattern)
+                .add(pattern.as_ref())
                 .map_err(|e| anyhow!("Malformed exclude pattern: {}", e))?;
         }
 
@@ -687,6 +693,21 @@ fn search_str_for_entry<'a>(
     }
 }
 
+/// When multiple `--search-path` roots are used, exclude globs are matched relative to the
+/// first root in the `ignore` crate. Prefix with `**/` so the pattern applies under each root.
+fn normalize_exclude_pattern_for_multi_root(pattern: &str) -> String {
+    let (prefix, glob) = match pattern.strip_prefix('!') {
+        Some(rest) => ("!", rest),
+        None => ("", pattern),
+    };
+
+    if glob.starts_with("**/") || glob.starts_with('/') {
+        return pattern.to_string();
+    }
+
+    format!("{prefix}**/{glob}")
+}
+
 /// Recursively scan the given search path for files / pathnames matching the patterns.
 ///
 /// If the `--exec` argument was supplied, this will create a thread pool for executing
@@ -698,8 +719,24 @@ pub fn scan(paths: &[PathBuf], patterns: Vec<Regex>, config: Config) -> Result<E
 
 #[cfg(test)]
 mod tests {
-    use super::search_str_for_entry;
+    use super::{normalize_exclude_pattern_for_multi_root, search_str_for_entry};
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn normalize_exclude_pattern_for_multi_root_prefixes_relative_globs() {
+        assert_eq!(
+            normalize_exclude_pattern_for_multi_root("!ghi/def"),
+            "!**/ghi/def"
+        );
+        assert_eq!(
+            normalize_exclude_pattern_for_multi_root("!**/ghi/def"),
+            "!**/ghi/def"
+        );
+        assert_eq!(
+            normalize_exclude_pattern_for_multi_root("!/abs/path"),
+            "!/abs/path"
+        );
+    }
 
     #[test]
     fn search_str_for_entry_with_relative_path() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -590,21 +590,6 @@ fn test_full_path_glob_searches() {
     );
 }
 
-#[cfg(not(windows))]
-#[test]
-fn test_warn_when_full_path_glob_missing_leading_anchor() {
-    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
-
-    te.assert_output(&["--glob", "--full-path", "foo.txt"], "");
-
-    let output = te.assert_success_and_get_output(".", &["--glob", "--full-path", "foo.txt"]);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("[fd warning]:") && stderr.contains("**/foo.txt"),
-        "expected full-path glob anchor warning, got: {stderr}"
-    );
-}
-
 #[test]
 fn test_smart_case_glob_searches() {
     let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -590,6 +590,21 @@ fn test_full_path_glob_searches() {
     );
 }
 
+#[cfg(not(windows))]
+#[test]
+fn test_warn_when_full_path_glob_missing_leading_anchor() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(&["--glob", "--full-path", "foo.txt"], "");
+
+    let output = te.assert_success_and_get_output(".", &["--glob", "--full-path", "foo.txt"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[fd warning]:") && stderr.contains("**/foo.txt"),
+        "expected full-path glob anchor warning, got: {stderr}"
+    );
+}
+
 #[test]
 fn test_smart_case_glob_searches() {
     let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
@@ -1662,6 +1677,35 @@ fn test_excludes() {
         one/two/three/
         one/two/three/directory_foo/
         symlink",
+    );
+}
+
+/// Regression test for #1919
+#[test]
+fn test_exclude_with_multiple_search_paths() {
+    let te = TestEnv::new(
+        &["sp1/abc/def", "sp1/ghi/def", "sp2/abc/def", "sp2/ghi/def"],
+        &[
+            "sp1/abc/def/match.txt",
+            "sp1/ghi/def/excluded.txt",
+            "sp2/abc/def/match.txt",
+            "sp2/ghi/def/excluded.txt",
+        ],
+    );
+
+    te.assert_output(
+        &[
+            "--type",
+            "file",
+            "--search-path",
+            "sp1",
+            "--search-path",
+            "sp2",
+            "--exclude",
+            "ghi/def",
+        ],
+        "sp1/abc/def/match.txt
+        sp2/abc/def/match.txt",
     );
 }
 


### PR DESCRIPTION
## Summary

When multiple `--search-path` roots are given, `--exclude` patterns like `ghi/def` were only evaluated relative to the first root. Matching paths under other roots were not excluded unless the pattern was written as `**/ghi/def`.

This prefixes relative exclude globs with `**/` when more than one search path is configured, so the same pattern applies under every root.

Fixes #1919

## Test plan

- [x] Unit tests for `normalize_exclude_pattern_for_multi_root`
- [x] Integration test `test_exclude_with_multiple_search_paths`
- [x] Manual repro from the issue
- [x] `cargo test` / `cargo clippy -- -D warnings`