### PR TITLE
docs: clarify that -e/--extension matches all entry types

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Options:
   -t, --type <filetype>            Filter by type: file (f), directory (d/dir), symlink (l),
                                    executable (x), empty (e), socket (s), pipe (p), char-device
                                    (c), block-device (b)
-  -e, --extension <ext>            Filter by file extension
+  -e, --extension <ext>            Filter by extension
   -S, --size <size>                Limit results based on the size of files
       --changed-within <date|dur>  Filter by file modification time (newer than)
       --changed-before <date|dur>  Filter by file modification time (older than)

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -252,9 +252,9 @@ Examples:
 .BI "\-e, \-\-extension " ext
 Filter search results by extension
 .IR ext .
-By default, this applies to all entry types. Use \fB\-\-type\fR to restrict
-the search to specific types.
 This option can be used repeatedly to allow for multiple possible extensions.
+By default, extension filters apply to both files and directories. Use
+\fB\-\-type\fR to restrict the search to specific types.
 
 If you want to search for files without extension, you can use the regex '^[^.]+$'
 as a normal search pattern.

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -136,10 +136,10 @@ By default, fd does not descend into symlinked directories. Using this flag, sym
 also traversed. The flag can be overridden with '--no-follow'.
 .TP
 .B \-p, \-\-full\-path
-By default, the search pattern is only matched against the last path component (file or directory name). Using
+By default, the search pattern is only matched against the filename (or directory name). Using
 this flag, the
 .I pattern
-is matched against the absolute path.
+is matched against the full path.
 .TP
 .B \-0, \-\-print0
 Separate search results by the null character (instead of newlines). Useful for piping results to

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -136,10 +136,10 @@ By default, fd does not descend into symlinked directories. Using this flag, sym
 also traversed. The flag can be overridden with '--no-follow'.
 .TP
 .B \-p, \-\-full\-path
-By default, the search pattern is only matched against the filename (or directory name). Using
+By default, the search pattern is only matched against the last path component (file or directory name). Using
 this flag, the
 .I pattern
-is matched against the full path.
+is matched against the absolute path.
 .TP
 .B \-0, \-\-print0
 Separate search results by the null character (instead of newlines). Useful for piping results to
@@ -250,9 +250,11 @@ Examples:
 .RE
 .TP
 .BI "\-e, \-\-extension " ext
-Filter search results by file extension
+Filter search results by extension
 .IR ext .
-This option can be used repeatedly to allow for multiple possible file extensions.
+By default, this applies to all entry types. Use \fB\-\-type\fR to restrict
+the search to specific types.
+This option can be used repeatedly to allow for multiple possible extensions.
 
 If you want to search for files without extension, you can use the regex '^[^.]+$'
 as a normal search pattern.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -239,12 +239,12 @@ pub struct Opts {
     #[arg(long, overrides_with = "follow", hide = true, action = ArgAction::SetTrue)]
     no_follow: (),
 
-    /// By default, the search pattern is only matched against the last path component (file or directory name). Using this flag, the pattern is matched against the absolute path. Example:
+    /// By default, the search pattern is only matched against the filename (or directory name). Using this flag, the pattern is matched against the full (absolute) path. Example:
     ///   fd --glob -p '**/.git/config'
     #[arg(
         long,
         short = 'p',
-        help = "Search absolute path (default: last path component only)",
+        help = "Search full abs. path (default: filename only)",
         long_help,
         verbatim_doc_comment
     )]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -239,12 +239,12 @@ pub struct Opts {
     #[arg(long, overrides_with = "follow", hide = true, action = ArgAction::SetTrue)]
     no_follow: (),
 
-    /// By default, the search pattern is only matched against the filename (or directory name). Using this flag, the pattern is matched against the full (absolute) path. Example:
+    /// By default, the search pattern is only matched against the last path component (file or directory name). Using this flag, the pattern is matched against the absolute path. Example:
     ///   fd --glob -p '**/.git/config'
     #[arg(
         long,
         short = 'p',
-        help = "Search full abs. path (default: filename only)",
+        help = "Search absolute path (default: last path component only)",
         long_help,
         verbatim_doc_comment
     )]
@@ -364,8 +364,9 @@ pub struct Opts {
     )]
     pub filetype: Option<Vec<FileType>>,
 
-    /// (Additionally) filter search results by their file extension. Multiple
-    /// allowable file extensions can be specified.
+    /// Filter results by extension. By default, this matches all entry types
+    /// (including directories whose names end with the extension). Use `--type`
+    /// to restrict the search to specific types. Multiple extensions can be specified.
     ///
     /// If you want to search for files without extension,
     /// you can use the regex '^[^.]+$' as a normal search pattern.
@@ -373,7 +374,7 @@ pub struct Opts {
         long = "extension",
         short = 'e',
         value_name = "ext",
-        help = "Filter by file extension",
+        help = "Filter by extension",
         long_help
     )]
     pub extensions: Option<Vec<String>>,


### PR DESCRIPTION
## Summary

Clarifies documentation for `-e` / `--extension` (#1693): the filter matches any entry whose name ends with the extension, including directories (e.g. `clojure.zip/`), not only regular files.

Follows maintainer feedback on #1922:
- Short help (`-h`): minimal — "Filter by extension"
- Long help (`--help`) and `fd.1`: note that `--type` can restrict entry types

## Test plan

- [x] `cargo clippy -- -D warnings`
- [x] Doc-only change (no runtime behavior change)