### PR TITLE
fix: stop walk on broken pipe with --glob (fixes #1479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `--ignore-parent` option to override `--no-ignore-parent`, see #1958 (@tmchow)
 
 ## Bugfixes
+- Stop the directory walk when stdout hits a broken pipe (e.g. closed downstream reader with `--glob`), see #1479 (@leno23).
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 - Fire the "search pattern contains a path separator" diagnostic for any pattern containing `/`, not just patterns that happen to name an existing directory. Preserves the legacy Windows behaviour that also flags native `\` separators when the pattern resolves to a real directory. See #1873.
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -250,9 +250,11 @@ impl<'a, W: Write> ReceiverBuffer<'a, W> {
 
     /// Output a path.
     fn print(&mut self, entry: &DirEntry) -> Result<(), ExitCode> {
-        if let Err(e) = output::print_entry(&mut self.stdout, entry, self.config)
-            && e.kind() != ::std::io::ErrorKind::BrokenPipe
-        {
+        if let Err(e) = output::print_entry(&mut self.stdout, entry, self.config) {
+            if e.kind() == io::ErrorKind::BrokenPipe {
+                self.quit_flag.store(true, Ordering::Relaxed);
+                return Err(ExitCode::GeneralError);
+            }
             print_error(format!("Could not write to output: {e}"));
             return Err(ExitCode::GeneralError);
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2801,3 +2801,37 @@ fn test_ignore_contain_precedence_over_root_check() {
     let expected = "";
     te.assert_output(&["--ignore-contain=CACHEDIR.TAG", "."], expected);
 }
+
+/// When a downstream process closes the pipe, fd should stop walking promptly.
+#[test]
+#[cfg(unix)]
+fn test_broken_pipe_stops_glob_search() {
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let te = TestEnv::new(&["bulk"], &[]);
+    let root = te.test_root();
+    for i in 0..2000 {
+        std::fs::File::create(root.join(format!("bulk/file_{i}.txt"))).expect("test file");
+    }
+
+    let mut child = Command::new(te.test_exe())
+        .current_dir(te.test_root())
+        .args(["--no-config", "-g", "*"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn fd");
+
+    drop(child.stdout.take());
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = child.wait();
+        let _ = tx.send(());
+    });
+
+    rx.recv_timeout(Duration::from_secs(3))
+        .expect("fd should exit soon after stdout is closed");
+}


### PR DESCRIPTION
## Summary

Fixes #1479: when a downstream process closes the pipe early (e.g. `fd -g '*' / | head`), fd kept walking until the search finished.

## Cause

`ReceiverBuffer::print` ignored `BrokenPipe` from `print_entry`, so the parallel walker never saw `quit_flag` set.

## Fix

On `BrokenPipe`, set `quit_flag` and stop the receiver loop (same as `flush()` on a closed pipe).

## Testing

- `cargo test test_broken_pipe_stops_glob_search` (Unix): spawns `fd -g '*'`, closes stdout, asserts exit within 3s on a 2000-file tree
- `cargo clippy -- -D warnings`