### PR TITLE
docs: Update Help String

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ use crate::filter::SizeFilter;
 #[command(
     name = "fd",
     version,
-    about = "A program to find entries in your filesystem with glob and regex based matching. By default, fd respects gitignore rules, ignores hidden directories, and is case insensitive.",
+    about = "A program to find entries in your filesystem with regex and glob based matching. By default, fd respects gitignore rules, ignores hidden directories, and is case insensitive.",
     after_long_help = "Bugs can be reported on GitHub: https://github.com/sharkdp/fd/issues",
     max_term_width = 98,
     args_override_self = true,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ use crate::filter::SizeFilter;
 #[command(
     name = "fd",
     version,
-    about = "A program to find entries in your filesystem with glob and regex based matching. By default, fd respects gitignore rules, ignores hidden directories, and is case insensitive.",
+    about = "A program to find entries in your filesystem with  regex and glob based matching. By default, fd respects gitignore rules, ignores hidden directories, and is case insensitive.",
     after_long_help = "Bugs can be reported on GitHub: https://github.com/sharkdp/fd/issues",
     max_term_width = 98,
     args_override_self = true,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,8 +22,8 @@ use crate::filter::SizeFilter;
 #[command(
     name = "fd",
     version,
-    about = "A program to find entries in your filesystem",
-    after_long_help = "Bugs can be reported on GitHub: https://github.com/sharkdp/fd/issues",
+    about = "A program to find entries in your filesystem with glob and regex based matching. By default, fd respects gitignore rules, ignores hidden directories, and is case insensitive.",
+    after_long_help = "Bugs can be reported on GitHub: https://github.com/sharkdp/fd/issues.",
     max_term_width = 98,
     args_override_self = true,
     group(ArgGroup::new("execs").args(&["exec", "exec_batch", "list_details"]).conflicts_with_all(&[

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,7 +23,7 @@ use crate::filter::SizeFilter;
     name = "fd",
     version,
     about = "A program to find entries in your filesystem with glob and regex based matching. By default, fd respects gitignore rules, ignores hidden directories, and is case insensitive.",
-    after_long_help = "Bugs can be reported on GitHub: https://github.com/sharkdp/fd/issues.",
+    after_long_help = "Bugs can be reported on GitHub: https://github.com/sharkdp/fd/issues",
     max_term_width = 98,
     args_override_self = true,
     group(ArgGroup::new("execs").args(&["exec", "exec_batch", "list_details"]).conflicts_with_all(&[


### PR DESCRIPTION
Updated help string to clarify that fd respects gitignore by default. Also added verbage to clarify that globbing and regex patterns are accepted without a flag.

This hopefully reduces confusion as seen in #612