### PR TITLE
fix: hint shell builtins in command-not-found error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 - Fire the "search pattern contains a path separator" diagnostic for any pattern containing `/`, not just patterns that happen to name an existing directory. Preserves the legacy Windows behaviour that also flags native `\` separators when the pattern resolves to a real directory. See #1873.
+- Hint that a command is a shell builtin when `-x`/`-X` fails with "command not found", see #1944 (@leno23)
 
 # 10.4.2
 

--- a/README.md
+++ b/README.md
@@ -436,13 +436,21 @@ use a character class with a single hyphen character:
 > fd '[-]pattern'
 ```
 
-### "Command not found" for `alias`es or shell functions
+### "Command not found" with `-x`/`-X`
 
-Shell `alias`es and shell functions can not be used for command execution via `fd -x` or
-`fd -X`. In `zsh`, you can make the alias global via `alias -g myalias="…"`. In `bash`,
-you can use `export -f my_function` to make available to child processes. You would still
-need to call `fd -x bash -c 'my_function "$1"' bash`. For other use cases or shells, use
-a (temporary) shell script.
+`fd` runs commands in a child process. Shell **builtins** (such as `cd`, `export`, or `source`)
+are not standalone programs, so `fd -x cd` fails with "command not found". Invoke a shell
+explicitly instead:
+
+```bash
+fd -t d -x sh -c 'cd "$1"' sh {}
+```
+
+Shell **aliases** and **functions** are also unavailable unless you run them through a shell.
+In `zsh`, you can make an alias global via `alias -g myalias="…"`. In `bash`, you can use
+`export -f my_function` to export a function to child processes. You would still need to call
+`fd -x bash -c 'my_function "$1"' bash`. For other use cases or shells, use a (temporary)
+shell script.
 
 ### Placeholders in `-x`/`-X`
 

--- a/src/exec/command.rs
+++ b/src/exec/command.rs
@@ -98,18 +98,75 @@ pub fn execute_commands<I: Iterator<Item = io::Result<Command>>>(
     ExitCode::Success
 }
 
+/// Common shell builtins that typically do not exist as standalone executables.
+const SHELL_BUILTINS: &[&str] = &[
+    ".", "alias", "bg", "bind", "cd", "command", "declare", "dirs", "eval", "exec", "exit",
+    "export", "fg", "hash", "help", "history", "jobs", "let", "local", "logout", "popd", "pushd",
+    "read", "readonly", "return", "set", "shift", "shopt", "source", "suspend", "times", "trap",
+    "type", "typeset", "unalias", "unset", "wait",
+];
+
+fn is_shell_builtin(program: &str) -> bool {
+    SHELL_BUILTINS.contains(&program)
+}
+
+fn command_not_found_message(program: &str) -> String {
+    if is_shell_builtin(program) {
+        format!(
+            "Command not found: {program}. Note: {program} is a shell builtin, \
+             not a standalone program. To run shell builtins, invoke a shell explicitly, \
+             e.g. fd -t d -x sh -c 'cd \"$1\"' sh {{}}",
+        )
+    } else {
+        format!("Command not found: {program}")
+    }
+}
+
 pub fn handle_cmd_error(cmd: Option<&Command>, err: io::Error) -> ExitCode {
     match (cmd, err) {
         (Some(cmd), err) if err.kind() == io::ErrorKind::NotFound => {
-            print_error(format!(
-                "Command not found: {}",
-                cmd.get_program().to_string_lossy()
-            ));
+            let program = cmd.get_program().to_string_lossy();
+            print_error(command_not_found_message(&program));
             ExitCode::GeneralError
         }
         (_, err) => {
             print_error(format!("Problem while executing command: {err}"));
             ExitCode::GeneralError
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_known_builtins() {
+        assert!(is_shell_builtin("cd"));
+        assert!(is_shell_builtin("export"));
+        assert!(is_shell_builtin("source"));
+        assert!(is_shell_builtin("."));
+    }
+
+    #[test]
+    fn rejects_non_builtins() {
+        assert!(!is_shell_builtin("grep"));
+        assert!(!is_shell_builtin("ls"));
+        assert!(!is_shell_builtin(""));
+        assert!(!is_shell_builtin("CD"));
+        assert!(!is_shell_builtin("echo"));
+    }
+
+    #[test]
+    fn builtin_message_includes_hint() {
+        let msg = command_not_found_message("cd");
+        assert!(msg.contains("shell builtin"));
+        assert!(msg.contains("sh -c"));
+    }
+
+    #[test]
+    fn non_builtin_message_is_plain() {
+        let msg = command_not_found_message("nonexistent");
+        assert_eq!(msg, "Command not found: nonexistent");
     }
 }


### PR DESCRIPTION
## Summary
- When `-x`/`-X` fails with "command not found" for a known shell builtin (e.g. `cd`), append a hint that builtins must be run through a shell
- Update the README troubleshooting section to cover builtins alongside aliases/functions
- Add unit tests for builtin detection and error message formatting

Fixes #1944

## Test plan
- [x] `cargo test exec::command`
- [x] `cargo clippy -- -D warnings`
- [ ] `fd -t d -x cd` shows the new hint message