### PR TITLE
Add --no-matches-message flag for empty search results

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -609,6 +609,15 @@ pub struct Opts {
     )]
     pub show_errors: bool,
 
+    /// Print a message to stderr when the search completes with no matches.
+    #[arg(
+        long,
+        hide_short_help = true,
+        help = "Print a message when no matches are found",
+        long_help
+    )]
+    pub no_matches_message: bool,
+
     /// Change the current working directory of fd to the provided path. This
     /// means that search results will be shown with respect to the given base
     /// path. Note that relative paths which are passed to fd via the positional

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,12 @@ pub struct Config {
     /// Whether or not to display filesystem errors
     pub show_filesystem_errors: bool,
 
+    /// Whether to print a message when the search completes with no matches.
+    pub no_matches_message: bool,
+
+    /// The search pattern supplied on the command line (for status messages).
+    pub search_pattern: String,
+
     /// The separator used to print file paths.
     pub path_separator: Option<String>,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,7 @@
 pub fn print_error(msg: impl Into<String>) {
     eprintln!("[fd error]: {}", msg.into());
 }
+
+pub fn print_status(msg: impl Into<String>) {
+    eprintln!("[fd]: {}", msg.into());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,6 +370,8 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         #[cfg(unix)]
         owner_constraint,
         show_filesystem_errors: opts.show_errors,
+        no_matches_message: opts.no_matches_message,
+        search_pattern: opts.pattern.clone(),
         path_separator,
         actual_path_separator,
         max_results: opts.max_results(),

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -285,6 +285,19 @@ impl<'a, W: Write> ReceiverBuffer<'a, W> {
             self.stream()?;
         }
 
+        if self.num_results == 0
+            && self.config.no_matches_message
+            && self.config.is_printing()
+            && !self.config.quiet
+        {
+            let pattern = &self.config.search_pattern;
+            if pattern.is_empty() {
+                crate::error::print_status("No matches found");
+            } else {
+                crate::error::print_status(format!("No matches found for pattern: '{pattern}'"));
+            }
+        }
+
         if self.config.quiet {
             Err(ExitCode::HasResults(self.num_results > 0))
         } else {

--- a/tests/testenv/mod.rs
+++ b/tests/testenv/mod.rs
@@ -292,6 +292,46 @@ impl TestEnv {
         }
     }
 
+    /// Assert that stderr contains the expected substring and stdout is empty.
+    pub fn assert_stderr_contains(&self, args: &[&str], expected: &str) {
+        let output = self.run_command(Path::new("."), args);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(expected),
+            "expected stderr to contain '{expected}', got:\n{stderr}"
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "expected empty stdout, got:\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+
+    /// Assert that stderr is empty.
+    pub fn assert_stderr_empty(&self, args: &[&str]) {
+        let output = self.run_command(Path::new("."), args);
+        assert!(
+            output.stderr.is_empty(),
+            "expected empty stderr, got:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Assert that both stdout and stderr are empty (exit status is not checked).
+    pub fn assert_empty_stdout_and_stderr(&self, args: &[&str]) {
+        let output = self.run_command(Path::new("."), args);
+        assert!(
+            output.stdout.is_empty(),
+            "expected empty stdout, got:\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        assert!(
+            output.stderr.is_empty(),
+            "expected empty stderr, got:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     /// Assert that calling *fd* with the specified arguments produces the expected error.
     pub fn assert_error(&self, args: &[&str], expected: &str) -> process::ExitStatus {
         self.assert_error_subdirectory(".", args, Some(expected))

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -79,6 +79,28 @@ fn test_simple() {
     );
 }
 
+/// See: https://github.com/sharkdp/fd/issues/1819
+#[test]
+fn test_no_matches_message() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(&["--no-matches-message", "no_such_file"], "");
+    te.assert_stderr_contains(
+        &["--no-matches-message", "no_such_file"],
+        "[fd]: No matches found for pattern: 'no_such_file'",
+    );
+
+    te.assert_output(&["no_such_file"], "");
+    te.assert_stderr_empty(&["no_such_file"]);
+}
+
+#[test]
+fn test_no_matches_message_respects_quiet() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_empty_stdout_and_stderr(&["-q", "--no-matches-message", "no_such_file"]);
+}
+
 static AND_EXTRA_FILES: &[&str] = &[
     "a.foo",
     "one/b.foo",


### PR DESCRIPTION
## Summary

- Adds a new `--no-matches-message` flag that prints a status message to stderr when a search yields no results
- Message format: `[fd]: No matches found for pattern: '{pattern}'` (or `[fd]: No matches found` when no pattern is given)
- Respects `-q` / `--quiet` (no message printed)
- Default behavior remains unchanged (silent when no matches)

Fixes #1819

## Test plan

- [x] `cargo test test_no_matches_message` — verifies message is printed with the flag
- [x] `cargo test test_no_matches_message_respects_quiet` — verifies quiet mode suppresses the message
- [x] `cargo test` — full test suite passes (139 unit + 109 integration tests)