### PR TITLE
feat: respect .gitignore in Jujutsu (.jj) repositories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ mod walk;
 
 use std::env;
 use std::io::IsTerminal;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -98,7 +98,7 @@ fn run() -> Result<ExitCode> {
         .map(|pat| build_pattern_regex(pat, &opts))
         .collect::<Result<Vec<String>>>()?;
 
-    let config = construct_config(opts, &pattern_regexps)?;
+    let config = construct_config(opts, &pattern_regexps, &search_paths)?;
 
     ensure_use_hidden_option_for_leading_dot_pattern(&config, &pattern_regexps)?;
 
@@ -227,7 +227,11 @@ fn check_path_separator_length(path_separator: Option<&str>) -> Result<()> {
     }
 }
 
-fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config> {
+fn construct_config(
+    mut opts: Opts,
+    pattern_regexps: &[String],
+    search_paths: &[PathBuf],
+) -> Result<Config> {
     // The search will be case-sensitive if the command line flag is set or
     // if any of the patterns has an uppercase character (smart case).
     let case_sensitive = !opts.ignore_case
@@ -295,7 +299,10 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         ignore_hidden: !(opts.hidden || opts.rg_alias_ignore()),
         read_fdignore: !(opts.no_ignore || opts.rg_alias_ignore()),
         read_vcsignore: !(opts.no_ignore || opts.rg_alias_ignore() || opts.no_ignore_vcs),
-        require_git_to_read_vcsignore: !opts.no_require_git,
+        require_git_to_read_vcsignore: walk::should_require_git_to_read_vcsignore(
+            search_paths,
+            opts.no_require_git,
+        ),
         read_parent_ignore: !opts.no_ignore_parent,
         read_global_ignore: !(opts.no_ignore
             || opts.rg_alias_ignore()

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -696,9 +696,27 @@ pub fn scan(paths: &[PathBuf], patterns: Vec<Regex>, config: Config) -> Result<E
     WorkerState::new(patterns, config).scan(paths)
 }
 
+/// Whether the `ignore` crate should require a `.git` directory to apply gitignore rules.
+///
+/// Jujutsu repositories use a `.jj` directory and still rely on `.gitignore` files. When a
+/// search path is inside such a repository, treat it like `--no-require-git` unless the user
+/// explicitly passes `--require-git`.
+pub fn should_require_git_to_read_vcsignore(
+    search_paths: &[PathBuf],
+    no_require_git: bool,
+) -> bool {
+    if no_require_git {
+        return false;
+    }
+
+    !search_paths
+        .iter()
+        .any(|path| path.ancestors().any(|ancestor| ancestor.join(".jj").is_dir()))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::search_str_for_entry;
+    use super::{search_str_for_entry, should_require_git_to_read_vcsignore};
     use std::path::{Path, PathBuf};
 
     #[test]
@@ -734,5 +752,18 @@ mod tests {
             search_str_for_entry(Path::new("./foo/bar"), None),
             PathBuf::from("bar")
         );
+    }
+
+    #[test]
+    fn should_require_git_in_jujutsu_repo() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join(".jj")).unwrap();
+
+        assert!(!should_require_git_to_read_vcsignore(
+            &[root.join("src")],
+            false
+        ));
+        assert!(!should_require_git_to_read_vcsignore(&[root.join("src")], true));
     }
 }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
+use std::env;
 use std::ffi::OsStr;
 use std::io::{self, Write};
 use std::mem;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
@@ -709,14 +710,27 @@ pub fn should_require_git_to_read_vcsignore(
         return false;
     }
 
+    let current_dir = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     !search_paths
         .iter()
-        .any(|path| path.ancestors().any(|ancestor| ancestor.join(".jj").is_dir()))
+        .all(|path| has_jj_ancestor(path, &current_dir))
+}
+
+fn has_jj_ancestor(path: &Path, current_dir: &Path) -> bool {
+    let search_path = if path.is_absolute() {
+        Cow::Borrowed(path)
+    } else {
+        Cow::Owned(current_dir.join(path))
+    };
+
+    search_path
+        .ancestors()
+        .any(|ancestor| ancestor.join(".jj").is_dir())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{search_str_for_entry, should_require_git_to_read_vcsignore};
+    use super::{has_jj_ancestor, search_str_for_entry, should_require_git_to_read_vcsignore};
     use std::path::{Path, PathBuf};
 
     #[test]
@@ -764,6 +778,33 @@ mod tests {
             &[root.join("src")],
             false
         ));
-        assert!(!should_require_git_to_read_vcsignore(&[root.join("src")], true));
+        assert!(!should_require_git_to_read_vcsignore(
+            &[root.join("src")],
+            true
+        ));
+    }
+
+    #[test]
+    fn should_require_git_for_mixed_jujutsu_and_non_jujutsu_paths() {
+        let jujutsu_temp = tempfile::tempdir().unwrap();
+        let normal_temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(jujutsu_temp.path().join(".jj")).unwrap();
+
+        assert!(should_require_git_to_read_vcsignore(
+            &[
+                jujutsu_temp.path().join("src"),
+                normal_temp.path().join("src")
+            ],
+            false
+        ));
+    }
+
+    #[test]
+    fn detects_jujutsu_repo_for_relative_search_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir(root.join(".jj")).unwrap();
+
+        assert!(has_jj_ancestor(Path::new("src"), root));
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -851,6 +851,25 @@ fn test_custom_ignore_precedence() {
     te.assert_output(&["--no-ignore", "foo"], "inner/foo");
 }
 
+/// Respect .gitignore in Jujutsu repositories with a `.jj` directory (fixes #1817)
+#[test]
+fn test_jujutsu_repo_respects_gitignore() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    fs::remove_dir(te.test_root().join(".git")).unwrap();
+    fs::create_dir(te.test_root().join(".jj")).unwrap();
+
+    te.assert_output(
+        &["foo"],
+        "a.foo
+        one/b.foo
+        one/two/c.foo
+        one/two/C.Foo2
+        one/two/three/d.foo
+        one/two/three/directory_foo/",
+    );
+}
+
 /// Don't require git to respect gitignore (--no-require-git)
 #[test]
 fn test_respect_ignore_files() {


### PR DESCRIPTION
## Summary

Fixes #1817.

Jujutsu repositories use a `.jj` directory and still rely on `.gitignore` files, but fd only applies gitignore rules without a `.git` directory when `--no-require-git` is passed.

When any search path is inside a Jujutsu repository (a `.jj` directory exists in an ancestor path), automatically treat the search like `--no-require-git` unless the user explicitly passes `--require-git`.

## Test plan

- [x] `cargo test --locked jujutsu`
- [x] New integration test `test_jujutsu_repo_respects_gitignore`
- [x] Unit test `should_require_git_in_jujutsu_repo`