### PR TITLE
fix: show glob-specific error for path separators in --glob patterns (fixes #1720)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `--exact` option to match the entire filename exactly (literal, non-substring).
 
 ## Bugfixes
+- Show a glob-specific error when `--glob` patterns contain a path separator, see #1720
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 - Fire the "search pattern contains a path separator" diagnostic for any pattern containing `/`, not just patterns that happen to name an existing directory. Preserves the legacy Windows behaviour that also flags native `\` separators when the pattern resolves to a real directory. See #1873.
 - Fix bug where passing "-" as a directory argument didn't actually search that directory, see #849 (@Sean-Kenneth-Doherty).

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,16 @@ fn ensure_search_pattern_is_not_a_path(opts: &Opts) -> Result<()> {
     }
 
     if should_warn {
+        if opts.glob {
+            return Err(anyhow!(
+                "The glob pattern '{pattern}' contains a path separator.\n\n\
+                 By default, `fd --glob` matches file names only, not directory paths. \
+                 To match against the full path, use:\n\n  \
+                 fd --glob --full-path '{pattern}'",
+                pattern = &opts.pattern,
+            ));
+        }
+
         Err(anyhow!(
             "The search pattern '{pattern}' contains a path-separation character \
              and will not lead to any search results.\n\n\

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -396,6 +396,18 @@ fn test_pattern_with_forward_slash_is_rejected() {
     );
 }
 
+/// With --glob, a path separator in the pattern should produce a glob-specific
+/// diagnostic (see sharkdp/fd#1720).
+#[test]
+fn test_glob_pattern_with_forward_slash_is_rejected() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_failure_with_error(
+        &["--glob", "foo/*.rs"],
+        "[fd error]: The glob pattern 'foo/*.rs' contains a path separator.",
+    );
+}
+
 /// --full-path is the user's explicit opt-in to regex-over-full-path matching,
 /// so a path-separation character in the pattern is expected and must not
 /// trigger the diagnostic.


### PR DESCRIPTION
## Summary

- When `--glob` is used with a pattern containing `/`, show a glob-specific error message
- Points users to `--glob --full-path` for matching against full paths

## Motivation

Fixes #1720. The existing path-separator diagnostic is regex-oriented; glob users benefit from guidance that mentions `--glob --full-path` explicitly.

## Example

```bash
$ fd --glob 'foo/*.rs'
[fd error]: The glob pattern 'foo/*.rs' contains a path separator.

By default, `fd --glob` matches file names only, not directory paths. To match against the full path, use:

  fd --glob --full-path 'foo/*.rs'
```

## Test plan

- [x] `cargo test test_glob_pattern_with_forward_slash_is_rejected`