### PR TITLE
feat: add --links filter for hard link count (fixes #1844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 - Add `--ignore-parent` option to override `--no-ignore-parent`, see #1958 (@tmchow)
 - Add `--exact` option to match the entire filename exactly (literal, non-substring).
+- Add `--links` filter to limit results by hard link count (Unix only), see #1844
 
 ## Bugfixes
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,9 @@ use crate::exec::CommandSet;
 use crate::filesystem;
 #[cfg(unix)]
 use crate::filter::OwnerFilter;
-use crate::filter::SizeFilter;
+use crate::filter::{SizeFilter, TimeFilter};
+#[cfg(unix)]
+use crate::filter::LinksFilter;
 
 #[derive(Parser)]
 #[command(
@@ -414,6 +416,23 @@ pub struct Opts {
         verbatim_doc_comment,
         )]
     pub size: Vec<SizeFilter>,
+
+    /// Filter results based on the number of hard links (Unix only).
+    ///
+    /// The filter can be provided as:
+    /// {n}    --links 2       (exactly 2 hard links)
+    /// {n}    --links +2      (at least 2 hard links)
+    /// {n}    --links -1      (at most 1 hard link)
+    #[cfg(unix)]
+    #[arg(
+        long,
+        value_parser = LinksFilter::from_string,
+        allow_hyphen_values = true,
+        value_name = "count",
+        help = "Limit results based on the number of hard links (Unix only)",
+        long_help
+    )]
+    pub links: Vec<LinksFilter>,
 
     /// Filter results based on the file modification time. Files with modification times
     /// greater than the argument are returned. The argument can be provided

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,12 @@ use regex::bytes::RegexSet;
 use crate::exec::CommandSet;
 use crate::filetypes::FileTypes;
 #[cfg(unix)]
+#[cfg(unix)]
 use crate::filter::OwnerFilter;
-use crate::filter::{SizeFilter, TimeFilter};
+use crate::filter::SizeFilter;
+use crate::filter::TimeFilter;
+#[cfg(unix)]
+use crate::filter::LinksFilter;
 use crate::fmt::FormatTemplate;
 
 /// Configuration options for *fd*.
@@ -108,6 +112,10 @@ pub struct Config {
 
     /// Constraints on last modification time of files
     pub time_constraints: Vec<TimeFilter>,
+
+    #[cfg(unix)]
+    /// Constraints on the number of hard links
+    pub link_constraints: Vec<LinksFilter>,
 
     #[cfg(unix)]
     /// User/group ownership constraint

--- a/src/filter/links.rs
+++ b/src/filter/links.rs
@@ -1,0 +1,96 @@
+use std::sync::OnceLock;
+
+use anyhow::anyhow;
+use regex::Regex;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LinksFilter {
+    Max(u64),
+    Min(u64),
+    Equals(u64),
+}
+
+static LINKS_CAPTURES: OnceLock<Regex> = OnceLock::new();
+
+impl LinksFilter {
+    pub fn from_string(s: &str) -> anyhow::Result<Self> {
+        LinksFilter::parse_opt(s)
+            .ok_or_else(|| anyhow!("'{}' is not a valid link count constraint. See 'fd --help'.", s))
+    }
+
+    fn parse_opt(s: &str) -> Option<Self> {
+        let pattern = LINKS_CAPTURES.get_or_init(|| Regex::new(r"^([+-]?)(\d+)$").unwrap());
+        let captures = pattern.captures(s)?;
+        let limit_kind = captures.get(1).map_or("", |m| m.as_str());
+        let count = captures
+            .get(2)
+            .and_then(|v| v.as_str().parse::<u64>().ok())?;
+
+        match limit_kind {
+            "+" => Some(LinksFilter::Min(count)),
+            "-" => Some(LinksFilter::Max(count)),
+            "" => Some(LinksFilter::Equals(count)),
+            _ => None,
+        }
+    }
+
+    pub fn is_within(&self, links: u64) -> bool {
+        match *self {
+            LinksFilter::Max(limit) => links <= limit,
+            LinksFilter::Min(limit) => links >= limit,
+            LinksFilter::Equals(limit) => links == limit,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_exact_link_count() {
+        assert_eq!(
+            LinksFilter::from_string("2").unwrap(),
+            LinksFilter::Equals(2)
+        );
+    }
+
+    #[test]
+    fn parse_minimum_link_count() {
+        assert_eq!(
+            LinksFilter::from_string("+2").unwrap(),
+            LinksFilter::Min(2)
+        );
+    }
+
+    #[test]
+    fn parse_maximum_link_count() {
+        assert_eq!(
+            LinksFilter::from_string("-1").unwrap(),
+            LinksFilter::Max(1)
+        );
+    }
+
+    #[test]
+    fn is_within_exact() {
+        let filter = LinksFilter::Equals(2);
+        assert!(filter.is_within(2));
+        assert!(!filter.is_within(1));
+    }
+
+    #[test]
+    fn is_within_minimum() {
+        let filter = LinksFilter::Min(2);
+        assert!(filter.is_within(2));
+        assert!(filter.is_within(3));
+        assert!(!filter.is_within(1));
+    }
+
+    #[test]
+    fn is_within_maximum() {
+        let filter = LinksFilter::Max(1);
+        assert!(filter.is_within(1));
+        assert!(filter.is_within(0));
+        assert!(!filter.is_within(2));
+    }
+}

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -2,10 +2,14 @@ pub use self::size::SizeFilter;
 pub use self::time::TimeFilter;
 
 #[cfg(unix)]
+pub use self::links::LinksFilter;
+#[cfg(unix)]
 pub use self::owner::OwnerFilter;
 
 mod size;
 mod time;
 
+#[cfg(unix)]
+mod links;
 #[cfg(unix)]
 mod owner;

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,6 +250,8 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
     check_path_separator_length(path_separator.as_deref())?;
 
     let size_limits = std::mem::take(&mut opts.size);
+    #[cfg(unix)]
+    let link_limits = std::mem::take(&mut opts.links);
     let time_constraints = extract_time_constraints(&opts)?;
     #[cfg(unix)]
     let owner_constraint: Option<OwnerFilter> = opts.owner.and_then(OwnerFilter::filter_ignore);
@@ -366,6 +368,8 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         exclude_patterns: opts.exclude.iter().map(|p| String::from("!") + p).collect(),
         ignore_files: std::mem::take(&mut opts.ignore_file),
         size_constraints: size_limits,
+        #[cfg(unix)]
+        link_constraints: link_limits,
         time_constraints,
         #[cfg(unix)]
         owner_constraint,

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -584,6 +584,24 @@ impl WorkerState {
                     }
                 }
 
+                #[cfg(unix)]
+                if !config.link_constraints.is_empty() {
+                    if let Some(metadata) = entry.metadata() {
+                        use std::os::unix::fs::MetadataExt;
+
+                        let nlink = metadata.nlink();
+                        if config
+                            .link_constraints
+                            .iter()
+                            .any(|constraint| !constraint.is_within(nlink))
+                        {
+                            return WalkState::Continue;
+                        }
+                    } else {
+                        return WalkState::Continue;
+                    }
+                }
+
                 // Filter out unwanted modification times
                 if !config.time_constraints.is_empty() {
                     let mut matched = false;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2342,6 +2342,28 @@ fn test_size() {
     te.assert_output(&["", "--size", "4ki"], "4_kibibytes.foo");
 }
 
+/// Filtering by hard link count (--links, Unix only)
+#[cfg(unix)]
+#[test]
+fn test_links_filter() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+    fs::hard_link(
+        te.test_root().join("a.foo"),
+        te.test_root().join("a.foo.hardlink"),
+    )
+    .unwrap();
+
+    te.assert_output(
+        &["--type", "f", "--links", "2"],
+        "a.foo
+        a.foo.hardlink",
+    );
+
+    te.assert_output(&["--type", "f", "--links", "+1", "a.foo.hardlink"], "a.foo.hardlink");
+
+    te.assert_output(&["--type", "f", "--links", "-1", "a.foo.hardlink"], "");
+}
+
 #[cfg(test)]
 fn create_file_with_modified<P: AsRef<Path>>(path: P, duration_in_secs: u64) {
     let st = SystemTime::now() - Duration::from_secs(duration_in_secs);


### PR DESCRIPTION
## Summary

- Adds `--links` to filter search results by hard link count (Unix only)
- Supports the same constraint syntax as `--size`: exact count, `+N` (at least), `-N` (at most)

## Motivation

Fixes #1844. Brings fd closer to find(1)'s `-links` option for use cases like finding singly-linked files or hard-linked duplicates.

## Example

```bash
# Files with exactly one hard link
fd --type f --links 1

# Files with more than one hard link
fd --type f --links +1

# Directories with at most one hard link (leaf directories on some filesystems)
fd --type d --links -1
```

## Test plan

- [x] Unit tests for `--links` parsing and matching logic
- [x] Integration test `test_links_filter` with hard-linked files