### PR TITLE
feat: run --exec-batch batches in parallel when --threads is set (fixes #1760)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -940,6 +940,10 @@ impl clap::Args for Exec {
                        '{{':   literal '{' (for escaping)\n  \
                        '}}':   literal '}' (for escaping)\n\n\
                      If no placeholder is present, an implicit \"{}\" at the end is assumed.\n\n\
+                     By default, batch commands run sequentially on the main thread. If `--threads`\n\
+                     is explicitly set to a value greater than 1, multiple batches may run in\n\
+                     parallel (up to the given thread count). Command output is buffered in this\n\
+                     mode, similar to `--exec` with multiple threads.\n\n\
                      Examples:\n\n  \
                        - Find all test_*.py files and open them in your favorite editor:\n\n      \
                            fd -g 'test_*.py' -X vim\n\n  \

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,9 @@ pub struct Config {
     /// The number of threads to use.
     pub threads: usize,
 
+    /// Whether the user explicitly set `--threads` (as opposed to the default).
+    pub explicit_threads: bool,
+
     /// If true, the program doesn't print anything and will instead return an exit code of 0
     /// if there's at least one match. Otherwise, the exit code will be 1.
     pub quiet: bool,

--- a/src/exec/command.rs
+++ b/src/exec/command.rs
@@ -1,7 +1,10 @@
 use std::io;
 use std::io::Write;
+use std::sync::Mutex;
+use std::thread;
 
 use argmax::Command;
+use crossbeam_channel::unbounded;
 
 use crate::error::print_error;
 use crate::exit_codes::ExitCode;
@@ -96,6 +99,114 @@ pub fn execute_commands<I: Iterator<Item = io::Result<Command>>>(
     }
     output_buffer.write();
     ExitCode::Success
+}
+
+/// Execute a list of batch commands, optionally in parallel.
+pub fn execute_batch_commands(commands: Vec<Command>, parallel: bool, threads: usize) -> ExitCode {
+    if commands.is_empty() {
+        return ExitCode::Success;
+    }
+
+    if parallel && threads > 1 {
+        execute_batch_commands_parallel(commands, threads)
+    } else {
+        execute_batch_commands_sequential(commands)
+    }
+}
+
+fn execute_batch_commands_sequential(mut commands: Vec<Command>) -> ExitCode {
+    let mut exit_code = ExitCode::Success;
+
+    for mut cmd in commands.drain(..) {
+        match cmd.status() {
+            Ok(status) => {
+                if !status.success() {
+                    exit_code = ExitCode::GeneralError;
+                }
+            }
+            Err(err) => return handle_cmd_error(Some(&cmd), err),
+        }
+    }
+
+    exit_code
+}
+
+fn execute_batch_commands_parallel(commands: Vec<Command>, threads: usize) -> ExitCode {
+    let num_workers = threads.min(commands.len());
+    let (work_tx, work_rx) = unbounded::<Command>();
+    for cmd in commands {
+        let _ = work_tx.send(cmd);
+    }
+    drop(work_tx);
+
+    let (result_tx, result_rx) = unbounded::<BatchCommandResult>();
+    let stdout_lock = Mutex::new(());
+    let stderr_lock = Mutex::new(());
+
+    thread::scope(|scope| {
+        for _ in 0..num_workers {
+            let work_rx = work_rx.clone();
+            let result_tx = result_tx.clone();
+
+            scope.spawn(move || {
+                while let Ok(mut cmd) = work_rx.recv() {
+                    let result = match cmd.output() {
+                        Ok(output) => BatchCommandResult {
+                            stdout: output.stdout,
+                            stderr: output.stderr,
+                            success: output.status.success(),
+                            cmd,
+                            err: None,
+                        },
+                        Err(err) => BatchCommandResult {
+                            stdout: Vec::new(),
+                            stderr: Vec::new(),
+                            success: false,
+                            cmd,
+                            err: Some(err),
+                        },
+                    };
+
+                    if result_tx.send(result).is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+
+    drop(result_tx);
+
+    let mut exit_code = ExitCode::Success;
+
+    for result in result_rx {
+        if let Some(err) = result.err {
+            return handle_cmd_error(Some(&result.cmd), err);
+        }
+
+        {
+            let _lock = stdout_lock.lock().unwrap();
+            let _ = io::stdout().lock().write_all(&result.stdout);
+        }
+        {
+            let _lock = stderr_lock.lock().unwrap();
+            let _ = io::stderr().lock().write_all(&result.stderr);
+        }
+
+        if !result.success {
+            exit_code = ExitCode::GeneralError;
+        }
+    }
+
+    exit_code
+}
+
+struct BatchCommandResult {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    success: bool,
+    cmd: Command,
+    err: Option<io::Error>,
 }
 
 pub fn handle_cmd_error(cmd: Option<&Command>, err: io::Error) -> ExitCode {

--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -60,5 +60,11 @@ pub fn batch(
             }
         });
 
-    cmd.execute_batch(paths, config.batch_size, config.path_separator.as_deref())
+    cmd.execute_batch(
+        paths,
+        config.batch_size,
+        config.path_separator.as_deref(),
+        config.explicit_threads && config.threads > 1,
+        config.threads,
+    )
 }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -11,10 +11,10 @@ use anyhow::{Result, bail};
 use argmax::Command;
 
 use crate::exec::command::OutputBuffer;
-use crate::exit_codes::{ExitCode, merge_exitcodes};
+use crate::exit_codes::ExitCode;
 use crate::fmt::{FormatTemplate, Token};
 
-use self::command::{execute_commands, handle_cmd_error};
+use self::command::{execute_batch_commands, execute_commands, handle_cmd_error};
 pub use self::job::{batch, job};
 
 /// Execution mode of the command
@@ -90,36 +90,51 @@ impl CommandSet {
         execute_commands(commands, OutputBuffer::new(null_separator), buffer_output)
     }
 
-    pub fn execute_batch<I>(&self, paths: I, limit: usize, path_separator: Option<&str>) -> ExitCode
+    pub fn execute_batch<I>(
+        &self,
+        paths: I,
+        limit: usize,
+        path_separator: Option<&str>,
+        parallel: bool,
+        threads: usize,
+    ) -> ExitCode
     where
         I: Iterator<Item = PathBuf>,
     {
-        let builders: io::Result<Vec<_>> = self
+        match self.collect_batches(paths, limit, path_separator) {
+            Ok(commands) => execute_batch_commands(commands, parallel, threads),
+            Err(e) => handle_cmd_error(None, e),
+        }
+    }
+
+    fn collect_batches<I>(
+        &self,
+        paths: I,
+        limit: usize,
+        path_separator: Option<&str>,
+    ) -> io::Result<Vec<Command>>
+    where
+        I: Iterator<Item = PathBuf>,
+    {
+        let mut builders: Vec<CommandBuilder> = self
             .commands
             .iter()
             .map(|c| CommandBuilder::new(c, limit))
-            .collect();
+            .collect::<io::Result<_>>()?;
 
-        match builders {
-            Ok(mut builders) => {
-                for path in paths {
-                    for builder in &mut builders {
-                        if let Err(e) = builder.push(&path, path_separator) {
-                            return handle_cmd_error(Some(&builder.cmd), e);
-                        }
-                    }
-                }
+        let mut commands = Vec::new();
 
-                for builder in &mut builders {
-                    if let Err(e) = builder.finish() {
-                        return handle_cmd_error(Some(&builder.cmd), e);
-                    }
-                }
-
-                merge_exitcodes(builders.iter().map(|b| b.exit_code()))
+        for path in paths {
+            for builder in &mut builders {
+                builder.push(&path, path_separator, &mut commands)?;
             }
-            Err(e) => handle_cmd_error(None, e),
         }
+
+        for builder in &mut builders {
+            builder.finish(&mut commands)?;
+        }
+
+        Ok(commands)
     }
 }
 
@@ -132,7 +147,6 @@ struct CommandBuilder {
     cmd: Command,
     count: usize,
     limit: usize,
-    exit_code: ExitCode,
 }
 
 impl CommandBuilder {
@@ -160,7 +174,6 @@ impl CommandBuilder {
             cmd,
             count: 0,
             limit,
-            exit_code: ExitCode::Success,
         })
     }
 
@@ -173,9 +186,14 @@ impl CommandBuilder {
         Ok(cmd)
     }
 
-    fn push(&mut self, path: &Path, separator: Option<&str>) -> io::Result<()> {
+    fn push(
+        &mut self,
+        path: &Path,
+        separator: Option<&str>,
+        commands: &mut Vec<Command>,
+    ) -> io::Result<()> {
         if self.limit > 0 && self.count >= self.limit {
-            self.finish()?;
+            self.finish(commands)?;
         }
 
         let arg = self.path_arg.generate(path, separator);
@@ -183,7 +201,7 @@ impl CommandBuilder {
             .cmd
             .args_would_fit(iter::once(&arg).chain(&self.post_args))
         {
-            self.finish()?;
+            self.finish(commands)?;
         }
 
         self.cmd.try_arg(arg)?;
@@ -191,22 +209,15 @@ impl CommandBuilder {
         Ok(())
     }
 
-    fn finish(&mut self) -> io::Result<()> {
+    fn finish(&mut self, commands: &mut Vec<Command>) -> io::Result<()> {
         if self.count > 0 {
             self.cmd.try_args(&self.post_args)?;
-            if !self.cmd.status()?.success() {
-                self.exit_code = ExitCode::GeneralError;
-            }
-
-            self.cmd = Self::new_command(&self.pre_args)?;
+            let cmd = std::mem::replace(&mut self.cmd, Self::new_command(&self.pre_args)?);
+            commands.push(cmd);
             self.count = 0;
         }
 
         Ok(())
-    }
-
-    fn exit_code(&self) -> ExitCode {
-        self.exit_code
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,6 +312,7 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         min_depth: opts.min_depth(),
         prune: opts.prune,
         threads: opts.threads().get(),
+        explicit_threads: opts.threads.is_some(),
         max_buffer_time: opts.max_buffer_time,
         ls_colors,
         hyperlink,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2073,6 +2073,51 @@ fn test_exec_batch_with_limit() {
     );
 }
 
+#[test]
+fn test_exec_batch_parallel_with_explicit_threads() {
+    if cfg!(windows) {
+        return;
+    }
+
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    // With explicit --threads > 1 and a small batch size, batches should run in parallel.
+    // Each line is one batch invocation; all paths should still appear exactly once.
+    let output = te.assert_success_and_get_output(
+        ".",
+        &[
+            "foo",
+            "--batch-size=2",
+            "--threads=4",
+            "--exec-batch",
+            "echo",
+            "{}",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    for line in stdout.lines() {
+        assert_eq!(2, line.split_whitespace().count());
+    }
+
+    let mut paths: Vec<_> = stdout
+        .lines()
+        .flat_map(|line| line.split_whitespace())
+        .collect();
+    paths.sort_unstable();
+    assert_eq!(
+        &paths,
+        &[
+            "./a.foo",
+            "./one/b.foo",
+            "./one/two/C.Foo2",
+            "./one/two/c.foo",
+            "./one/two/three/d.foo",
+            "./one/two/three/directory_foo"
+        ],
+    );
+}
+
 /// Shell script execution (--exec) with a custom --path-separator
 #[test]
 fn test_exec_with_separator() {


### PR DESCRIPTION
## Summary

Fixes #1760.

`--exec-batch` previously ran every batch invocation sequentially, even when `--threads` was set. This change enables parallel batch execution when the user **explicitly** passes `--threads` with a value greater than 1.

Default behavior is unchanged: without an explicit `--threads` flag, batches still run sequentially on the main thread. This preserves streaming/interactive use cases discussed in the issue (linters, editors, incremental output).

When parallel mode is active, command output is buffered and written under stdout/stderr locks, similar to `--exec` with multiple threads.

## Changes

- Track whether `--threads` was explicitly provided (`Config::explicit_threads`)
- Refactor batch building to collect `Command` instances before execution
- Execute batches concurrently (up to the thread limit) when explicitly requested
- Document the new behavior in `--exec-batch` help text
- Add integration test for `--batch-size=2 --threads=4 --exec-batch`

## Test plan

- [x] `cargo test test_exec_batch`
- [x] `cargo test` (full suite, 108 tests)