### PR TITLE
feat: add --only-restricted to show hidden and ignored paths (fixes #1894)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,6 +127,17 @@ pub struct Opts {
         )]
     rg_alias_hidden_ignore: u8,
 
+    /// Show only files and directories that would normally be hidden or ignored.
+    /// Can be combined with `--hidden` or `--no-ignore` to show only ignored or only
+    /// hidden paths, respectively.
+    #[arg(
+        long,
+        hide_short_help = true,
+        long_help,
+        conflicts_with = "rg_alias_hidden_ignore"
+    )]
+    pub only_restricted: bool,
+
     /// Case-sensitive search (default: smart case)
     #[arg(
         long,

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use crate::filter::{SizeFilter, TimeFilter};
 use crate::fmt::FormatTemplate;
 
 /// Configuration options for *fd*.
+#[derive(Clone)]
 pub struct Config {
     /// Whether the search is case-sensitive or case-insensitive.
     pub case_sensitive: bool,
@@ -133,9 +134,23 @@ pub struct Config {
 
     /// Names that should stop traversal down their parent. (e.g. https://bford.info/cachedir/).
     pub ignore_contain: Vec<String>,
+
+    /// Show only paths that would normally be hidden or ignored.
+    pub only_restricted: bool,
 }
 
 impl Config {
+    /// Disable hidden/ignore filters while preserving other settings.
+    pub fn without_restriction_filters(mut self) -> Self {
+        self.ignore_hidden = false;
+        self.read_fdignore = false;
+        self.read_vcsignore = false;
+        self.read_global_ignore = false;
+        self.read_parent_ignore = false;
+        self.only_restricted = false;
+        self
+    }
+
     /// Check whether results are being printed.
     pub fn is_printing(&self) -> bool {
         self.command.is_none()

--- a/src/filetypes.rs
+++ b/src/filetypes.rs
@@ -4,7 +4,7 @@ use crate::filesystem;
 use faccess::PathExt;
 
 /// Whether or not to show
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FileTypes {
     pub files: bool,
     pub directories: bool,

--- a/src/filter/time.rs
+++ b/src/filter/time.rs
@@ -3,7 +3,7 @@ use jiff::{Span, Timestamp, Zoned, civil::DateTime, tz::TimeZone};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Filter based on time ranges.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TimeFilter {
     Before(SystemTime),
     After(SystemTime),

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,9 @@ fn run() -> Result<ExitCode> {
 
     let config = construct_config(opts, &pattern_regexps)?;
 
-    ensure_use_hidden_option_for_leading_dot_pattern(&config, &pattern_regexps)?;
+    if !config.only_restricted {
+        ensure_use_hidden_option_for_leading_dot_pattern(&config, &pattern_regexps)?;
+    }
 
     let regexps = pattern_regexps
         .into_iter()
@@ -375,6 +377,7 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         max_results: opts.max_results(),
         strip_cwd_prefix: opts.strip_cwd_prefix(|| !(opts.null_separator || has_command)),
         ignore_contain: opts.ignore_contain,
+        only_restricted: opts.only_restricted,
     })
 }
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -24,6 +24,8 @@ use crate::exit_codes::{ExitCode, merge_exitcodes};
 use crate::filesystem;
 use crate::output;
 
+type PathPredicate = dyn Fn(&Path) -> bool + Send + Sync;
+
 /// The receiver thread can either be buffering results or directly streaming to the console.
 #[derive(PartialEq)]
 enum ReceiverMode {
@@ -333,7 +335,7 @@ struct WorkerState {
     /// Collect matching paths instead of printing them.
     path_collector: Option<Arc<Mutex<HashSet<PathBuf>>>>,
     /// Skip matching paths for which this returns false.
-    path_filter: Option<Arc<dyn Fn(&Path) -> bool + Send + Sync>>,
+    path_filter: Option<Arc<PathPredicate>>,
 }
 
 impl WorkerState {
@@ -356,7 +358,7 @@ impl WorkerState {
         self
     }
 
-    fn with_path_filter(mut self, path_filter: Arc<dyn Fn(&Path) -> bool + Send + Sync>) -> Self {
+    fn with_path_filter(mut self, path_filter: Arc<PathPredicate>) -> Self {
         self.path_filter = Some(path_filter);
         self
     }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::io::{self, Write};
 use std::mem;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
@@ -134,6 +135,8 @@ struct ReceiverBuffer<'a, W> {
     quit_flag: &'a AtomicBool,
     /// The ^C notifier.
     interrupt_flag: &'a AtomicBool,
+    /// Collect matching paths instead of printing them.
+    path_collector: Option<&'a Arc<Mutex<HashSet<PathBuf>>>>,
     /// Receiver for worker results.
     rx: Receiver<Batch>,
     /// Standard output.
@@ -161,6 +164,7 @@ impl<'a, W: Write> ReceiverBuffer<'a, W> {
             config,
             quit_flag,
             interrupt_flag,
+            path_collector: state.path_collector.as_ref(),
             rx,
             stdout,
             mode: ReceiverMode::Buffering,
@@ -201,6 +205,20 @@ impl<'a, W: Write> ReceiverBuffer<'a, W> {
                 for result in batch {
                     match result {
                         WorkerResult::Entry(dir_entry) => {
+                            if let Some(collector) = self.path_collector {
+                                collector
+                                    .lock()
+                                    .unwrap()
+                                    .insert(dir_entry.path().to_path_buf());
+                                self.num_results += 1;
+                                if let Some(max_results) = self.config.max_results
+                                    && self.num_results >= max_results
+                                {
+                                    return self.stop();
+                                }
+                                continue;
+                            }
+
                             if self.config.quiet {
                                 return Err(ExitCode::HasResults(true));
                             }
@@ -312,6 +330,10 @@ struct WorkerState {
     quit_flag: Arc<AtomicBool>,
     /// Flag specifically for quitting due to ^C
     interrupt_flag: Arc<AtomicBool>,
+    /// Collect matching paths instead of printing them.
+    path_collector: Option<Arc<Mutex<HashSet<PathBuf>>>>,
+    /// Skip matching paths for which this returns false.
+    path_filter: Option<Arc<dyn Fn(&Path) -> bool + Send + Sync>>,
 }
 
 impl WorkerState {
@@ -324,7 +346,19 @@ impl WorkerState {
             config,
             quit_flag,
             interrupt_flag,
+            path_collector: None,
+            path_filter: None,
         }
+    }
+
+    fn with_path_collector(mut self, path_collector: Arc<Mutex<HashSet<PathBuf>>>) -> Self {
+        self.path_collector = Some(path_collector);
+        self
+    }
+
+    fn with_path_filter(mut self, path_filter: Arc<dyn Fn(&Path) -> bool + Send + Sync>) -> Self {
+        self.path_filter = Some(path_filter);
+        self
     }
 
     fn build_overrides(&self, paths: &[PathBuf]) -> Result<Override> {
@@ -441,10 +475,12 @@ impl WorkerState {
 
     /// Spawn the sender threads.
     fn spawn_senders(&self, walker: WalkParallel, tx: Sender<Batch>) {
+        let path_filter = self.path_filter.clone();
         walker.run(|| {
             let patterns = &self.patterns;
             let config = &self.config;
             let quit_flag = self.quit_flag.as_ref();
+            let path_filter = path_filter.clone();
 
             let mut limit = 0x100;
             if let Some(cmd) = &config.command
@@ -607,6 +643,12 @@ impl WorkerState {
                     entry.style(ls_colors);
                 }
 
+                if let Some(filter) = &path_filter
+                    && !filter(entry_path)
+                {
+                    return WalkState::Continue;
+                }
+
                 let send_result = tx.send(WorkerResult::Entry(entry));
 
                 if send_result.is_err() {
@@ -693,7 +735,36 @@ fn search_str_for_entry<'a>(
 /// jobs in parallel from a given command line and the discovered paths. Otherwise, each
 /// path will simply be written to standard output.
 pub fn scan(paths: &[PathBuf], patterns: Vec<Regex>, config: Config) -> Result<ExitCode> {
+    if config.only_restricted {
+        return scan_only_restricted(paths, patterns, config);
+    }
+
     WorkerState::new(patterns, config).scan(paths)
+}
+
+fn scan_only_restricted(
+    paths: &[PathBuf],
+    patterns: Vec<Regex>,
+    mut config: Config,
+) -> Result<ExitCode> {
+    config.only_restricted = false;
+
+    let collector = Arc::new(Mutex::new(HashSet::new()));
+    WorkerState::new(patterns.clone(), config.clone())
+        .with_path_collector(Arc::clone(&collector))
+        .scan(paths)?;
+
+    let restricted = Arc::try_unwrap(collector)
+        .expect("path collector should have a single owner")
+        .into_inner()
+        .unwrap();
+
+    let unrestricted_config = config.without_restriction_filters();
+    let path_filter = Arc::new(move |path: &Path| !restricted.contains(path));
+
+    WorkerState::new(patterns, unrestricted_config)
+        .with_path_filter(path_filter)
+        .scan(paths)
 }
 
 #[cfg(test)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -722,6 +722,44 @@ fn test_no_ignore() {
     );
 }
 
+/// Restricted-only search (--only-restricted)
+#[test]
+fn test_only_restricted() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(
+        &["--only-restricted", "foo"],
+        ".hidden.foo
+        fdignored.foo
+        gitignored.foo",
+    );
+}
+
+#[test]
+fn test_only_restricted_with_hidden() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(
+        &["--only-restricted", "--hidden", "foo"],
+        "fdignored.foo
+        gitignored.foo",
+    );
+}
+
+#[test]
+fn test_only_restricted_with_no_ignore() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(&["--only-restricted", "--no-ignore", "foo"], ".hidden.foo");
+}
+
+#[test]
+fn test_only_restricted_with_hidden_and_no_ignore() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(&["--only-restricted", "--hidden", "--no-ignore", "foo"], "");
+}
+
 /// .gitignore and .fdignore
 #[test]
 fn test_gitignore_and_fdignore() {


### PR DESCRIPTION
## Summary

Adds `--only-restricted` to list paths that would normally be hidden or ignored, while still applying the search pattern and other filters.

This supports use cases like searching only in `$XDG_CONFIG_HOME` or finding files matched by `.gitignore` rules.

Implementation: collect matching paths from a restricted scan, then emit paths from an unrestricted scan that were not in the restricted set.

## Examples

```bash
# hidden + ignored matches only
fd --only-restricted foo

# ignored matches only
fd --only-restricted --hidden foo

# hidden matches only
fd --only-restricted --no-ignore foo
```

Fixes #1894

## Test plan

- [x] `cargo test test_only_restricted`
- [x] Added tests for combinations with `--hidden` and `--no-ignore`

Made with [Cursor](https://cursor.com)