### PR TITLE
Fix --list-details failing with "Argument list too long" (fixes #1775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 - Fire the "search pattern contains a path separator" diagnostic for any pattern containing `/`, not just patterns that happen to name an existing directory. Preserves the legacy Windows behaviour that also flags native `\` separators when the pattern resolves to a real directory. See #1873.
 - Fix bug where passing "-" as a directory argument didn't actually search that directory, see #849 (@Sean-Kenneth-Doherty).
+- Fix `--list-details` failing with "Argument list too long" when matching many files, see #1775.
 
 # 10.4.2
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -498,7 +498,6 @@ pub struct Opts {
         long,
         value_name = "size",
         hide_short_help = true,
-        requires("exec_batch"),
         value_parser = value_parser!(usize),
         default_value_t,
         help = "Max number of arguments to run as a batch size with -X",

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -17,6 +17,20 @@ use crate::fmt::{FormatTemplate, Token};
 use self::command::{execute_commands, handle_cmd_error};
 pub use self::job::{batch, job};
 
+/// Returns true if an I/O error indicates that a command line exceeded OS limits.
+fn is_argument_list_too_long(err: &io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        // E2BIG: argmax uses this when no more arguments can be added.
+        err.raw_os_error() == Some(7)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = err;
+        false
+    }
+}
+
 /// Execution mode of the command
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecutionMode {
@@ -186,7 +200,18 @@ impl CommandBuilder {
             self.finish()?;
         }
 
-        self.cmd.try_arg(arg)?;
+        match self.cmd.try_arg(&arg) {
+            Ok(_) => {}
+            Err(err) if is_argument_list_too_long(&err) => {
+                if self.count > 0 {
+                    self.finish()?;
+                    self.cmd.try_arg(arg)?;
+                } else {
+                    return Err(err);
+                }
+            }
+            Err(err) => return Err(err),
+        }
         self.count += 1;
         Ok(())
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2628,11 +2628,7 @@ fn test_list_details_many_files() {
     let te = TestEnv::new(&["many/"], &[]);
     let many_dir = te.test_root().join("many");
     for i in 0..40_000 {
-        fs::write(
-            many_dir.join(format!("list_details_batch_{i:06}.txt")),
-            b"",
-        )
-        .unwrap();
+        fs::write(many_dir.join(format!("list_details_batch_{i:06}.txt")), b"").unwrap();
     }
 
     te.assert_success_and_get_output("many", &["--list-details"]);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2618,6 +2618,26 @@ fn test_list_details() {
     te.assert_success_and_get_output(".", &["--list-details"]);
 }
 
+/// `--list-details` runs `ls` in batch mode; make sure large result sets are split
+/// across multiple invocations instead of failing with "Argument list too long".
+#[test]
+#[cfg(unix)]
+fn test_list_details_many_files() {
+    use std::fs;
+
+    let te = TestEnv::new(&["many/"], &[]);
+    let many_dir = te.test_root().join("many");
+    for i in 0..40_000 {
+        fs::write(
+            many_dir.join(format!("list_details_batch_{i:06}.txt")),
+            b"",
+        )
+        .unwrap();
+    }
+
+    te.assert_success_and_get_output("many", &["--list-details"]);
+}
+
 #[test]
 fn test_single_and_multithreaded_execution() {
     let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);


### PR DESCRIPTION
## Summary

Fixes #1775.

When `--list-details` matches a very large number of files, fd can fail with:

```
[fd error]: Problem while executing command: Argument list too long (os error 7)
```

This happens when argmax's size estimate allows another path argument but `try_arg` still returns `E2BIG`. The batch executor now flushes the current `ls` invocation and retries instead of aborting.

Also removes the clap restriction that prevented using `--batch-size` together with `--list-details`.

## Test plan

- [x] `cargo test test_list_details_many_files` (40k files, ~15s)
- [x] `cargo test exec_batch` (existing batch tests)

Made with [Cursor](https://cursor.com)