### PR TITLE
fix: Avoid panic on overflow when parsing --size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Handle invalid working directories gracefully when using `--full-path`, see #1900 (@Xavrir).
 - Fire the "search pattern contains a path separator" diagnostic for any pattern containing `/`, not just patterns that happen to name an existing directory. Preserves the legacy Windows behaviour that also flags native `\` separators when the pattern resolves to a real directory. See #1873.
 - Fix bug where passing "-" as a directory argument didn't actually search that directory, see #849 (@Sean-Kenneth-Doherty).
+- Don't panic if the argument to `--size` overflows.
 
 # 10.4.2
 

--- a/src/filter/size.rs
+++ b/src/filter/size.rs
@@ -56,7 +56,7 @@ impl SizeFilter {
             _ => return None,
         };
 
-        let size = quantity * multiplier;
+        let size = quantity.checked_mul(multiplier)?;
         match limit_kind {
             "+" => Some(SizeFilter::Min(size)),
             "-" => Some(SizeFilter::Max(size)),
@@ -191,6 +191,8 @@ mod tests {
         ensure_invalid_unit_returns_none_3: "+1Mv",
         ensure_bib_format_returns_none: "+1bib",
         ensure_bb_format_returns_none: "+1bb",
+        ensure_overflow_returns_none_1: "+18446745t",
+        ensure_overflow_returns_none_2: "+16777217Ti",
     }
 
     #[test]


### PR DESCRIPTION
Avoid panic if the argument to --size would result in an integer
overflow when multiplying by the unit.

Actually, it's worse in release builds, because the multiplying *won't*
panic, and will instead silently wrap around.


Thanks to @Bojun-Vvibe for the [original PR](#1981)