### PR TITLE
Add tests for search_str_for_entry without base dir

### DIFF
--- a/src/walk.rs
+++ b/src/walk.rs
@@ -735,4 +735,20 @@ mod tests {
             PathBuf::from("bar")
         );
     }
+
+    #[test]
+    fn search_str_no_base_dir_with_plain_relative_path() {
+        assert_eq!(
+            search_str_for_entry(Path::new("foo/bar"), None),
+            PathBuf::from("bar")
+        );
+    }
+
+    #[test]
+    fn search_str_no_base_dir_with_file_in_current_dir() {
+        assert_eq!(
+            search_str_for_entry(Path::new("foo"), None),
+            PathBuf::from("foo")
+        );
+    }
 }


### PR DESCRIPTION
Adds test coverage for `search_str_for_entry` when no full_path_base is provided.

## Details
When full-path matching is disabled, `search_str_for_entry` should return only the file name from the entry path. This PR adds tests for two common cases:

* `foo/bar` returns `bar`
* `foo` returns `foo`