### PR TITLE
[codex] Reject overflowing size filters

### DIFF
--- a/src/filter/size.rs
+++ b/src/filter/size.rs
@@ -56,7 +56,7 @@ impl SizeFilter {
             _ => return None,
         };
 
-        let size = quantity * multiplier;
+        let size = quantity.checked_mul(multiplier)?;
         match limit_kind {
             "+" => Some(SizeFilter::Min(size)),
             "-" => Some(SizeFilter::Max(size)),
@@ -191,6 +191,7 @@ mod tests {
         ensure_invalid_unit_returns_none_3: "+1Mv",
         ensure_bib_format_returns_none: "+1bib",
         ensure_bb_format_returns_none: "+1bb",
+        ensure_overflow_returns_none: "+18446744073709551615t",
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Use checked multiplication while parsing --size values so overflowing inputs are rejected.

## Validation
- size parser tests, CLI check, cargo fmt check, and diff check passed in Docker.

## Notes
- Opened as a draft PR for maintainer review.
