### PR TITLE
refactor(walk): extract entry filtering and normalization logic

### DIFF
--- a/src/walk.rs
+++ b/src/walk.rs
@@ -302,6 +302,254 @@ impl<'a, W: Write> ReceiverBuffer<'a, W> {
     }
 }
 
+struct EntryFilter<'a> {
+    config: &'a Config,
+    patterns: &'a [Regex],
+}
+
+impl<'a> EntryFilter<'a> {
+    pub fn new(config: &'a Config, patterns: &'a [Regex]) -> Self {
+        Self { config, patterns }
+    }
+
+    /// Fast-path checks that operate on the raw ignore::DirEntry
+    fn evaluate_before_normalization(&self, entry: &ignore::DirEntry) -> Option<WalkState> {
+        if let Some(state) = self.check_ignore_file(entry) {
+            return Some(state);
+        }
+        if let Some(state) = self.check_root_dir(entry) {
+            return Some(state);
+        }
+        None
+    }
+
+    /// Evaluates a normalized entry against all configured constraints to determine its walk state.
+    fn evaluate(&self, entry: &DirEntry) -> Option<WalkState> {
+        if let Some(state) = self.check_min_depth(entry) {
+            return Some(state);
+        }
+        if let Some(state) = self.check_patterns(entry) {
+            return Some(state);
+        }
+        if let Some(state) = self.check_extensions(entry) {
+            return Some(state);
+        }
+        if let Some(state) = self.check_file_types(entry) {
+            return Some(state);
+        }
+        if let Some(state) = self.check_owner(entry) {
+            return Some(state);
+        }
+        if let Some(state) = self.check_size(entry) {
+            return Some(state);
+        }
+        if let Some(state) = self.check_modification_time(entry) {
+            return Some(state);
+        }
+        None
+    }
+
+    fn check_ignore_file(&self, entry: &ignore::DirEntry) -> Option<WalkState> {
+        // If the entry is a directory that contains a
+        // "ignore contain" file, we want to skip this
+        // directory.
+        // Check the filetype first to avoid unnecessary
+        // syscalls.
+        if entry.file_type().is_some_and(|t| t.is_dir()) {
+            let entry_path = entry.path();
+            if self
+                .config
+                .ignore_contain
+                .iter()
+                .any(|ic| entry_path.join(ic).exists())
+            {
+                return Some(WalkState::Skip);
+            }
+        }
+
+        None
+    }
+
+    fn check_root_dir(&self, entry: &ignore::DirEntry) -> Option<WalkState> {
+        if entry.depth() == 0 {
+            // Skip the root directory entry.
+            return Some(WalkState::Continue);
+        }
+
+        None
+    }
+
+    fn check_min_depth(&self, entry: &DirEntry) -> Option<WalkState> {
+        let Some(min_depth) = self.config.min_depth else {
+            return None;
+        };
+
+        if entry.depth().is_none_or(|depth| depth < min_depth) {
+            return Some(WalkState::Continue);
+        }
+
+        None
+    }
+
+    fn check_patterns(&self, entry: &DirEntry) -> Option<WalkState> {
+        let entry_path = entry.path();
+
+        let search_str = search_str_for_entry(entry_path, self.config.full_path_base.as_deref());
+
+        if !self
+            .patterns
+            .iter()
+            .all(|pat| pat.is_match(&filesystem::osstr_to_bytes(search_str.as_ref())))
+        {
+            return Some(WalkState::Continue);
+        }
+
+        None
+    }
+
+    fn check_extensions(&self, entry: &DirEntry) -> Option<WalkState> {
+        let entry_path = entry.path();
+        if let Some(ref exts_regex) = self.config.extensions {
+            if let Some(path_str) = entry_path.file_name() {
+                if !exts_regex.is_match(&filesystem::osstr_to_bytes(path_str)) {
+                    return Some(WalkState::Continue);
+                }
+            } else {
+                return Some(WalkState::Continue);
+            }
+        }
+        None
+    }
+
+    fn check_file_types(&self, entry: &DirEntry) -> Option<WalkState> {
+        if let Some(ref file_types) = self.config.file_types
+            && file_types.should_ignore(&entry)
+        {
+            return Some(WalkState::Continue);
+        }
+
+        None
+    }
+
+    fn check_size(&self, entry: &DirEntry) -> Option<WalkState> {
+        let entry_path = entry.path();
+        if !self.config.size_constraints.is_empty() {
+            if entry_path.is_file() {
+                if let Some(metadata) = entry.metadata() {
+                    let file_size = metadata.len();
+                    if self
+                        .config
+                        .size_constraints
+                        .iter()
+                        .any(|sc| !sc.is_within(file_size))
+                    {
+                        return Some(WalkState::Continue);
+                    }
+                } else {
+                    return Some(WalkState::Continue);
+                }
+            } else {
+                return Some(WalkState::Continue);
+            }
+        }
+
+        None
+    }
+
+    fn check_modification_time(&self, entry: &DirEntry) -> Option<WalkState> {
+        if !self.config.time_constraints.is_empty() {
+            let mut matched = false;
+            if let Some(metadata) = entry.metadata()
+                && let Ok(modified) = metadata.modified()
+            {
+                matched = self
+                    .config
+                    .time_constraints
+                    .iter()
+                    .all(|tf| tf.applies_to(&modified));
+            }
+            if !matched {
+                return Some(WalkState::Continue);
+            }
+        }
+
+        None
+    }
+
+    #[cfg(unix)]
+    fn check_owner(&self, entry: &DirEntry) -> Option<WalkState> {
+        if let Some(ref owner_constraint) = self.config.owner_constraint {
+            if let Some(metadata) = entry.metadata() {
+                if !owner_constraint.matches(metadata) {
+                    return Some(WalkState::Continue);
+                }
+            } else {
+                return Some(WalkState::Continue);
+            }
+        }
+
+        None
+    }
+
+    #[cfg(not(unix))]
+    #[inline]
+    fn check_owner(&self, _entry: &DirEntry) -> Option<WalkState> {
+        None
+    }
+}
+
+
+/// Converts an `ignore` walker entry into a `DirEntry`.
+///
+/// Normal entries are wrapped directly. Broken symlinks are recovered from
+/// `NotFound` errors and returned as `DirEntry::broken_symlink`. All other
+/// errors are forwarded to the worker result channel, returning `Continue` if
+/// the error was sent and `Quit` if the channel is closed.
+fn normalize_walk_entry(
+    entry: Result<ignore::DirEntry, ignore::Error>,
+    tx: &mut BatchSender,
+) -> Result<DirEntry, WalkState> {
+    match entry {
+        Ok(e) => Ok(DirEntry::normal(e)),
+
+        Err(ignore::Error::WithPath {
+            path,
+            err: inner_err,
+        }) => match inner_err.as_ref() {
+            ignore::Error::Io(io_error)
+                if io_error.kind() == io::ErrorKind::NotFound
+                    && path
+                        .symlink_metadata()
+                        .ok()
+                        .is_some_and(|m| m.file_type().is_symlink()) =>
+            {
+                Ok(DirEntry::broken_symlink(path))
+            }
+
+            _ => {
+                let result = tx.send(WorkerResult::Error(ignore::Error::WithPath {
+                    path,
+                    err: inner_err,
+                }));
+
+                match result {
+                    Ok(_) => Err(WalkState::Continue),
+                    Err(_) => Err(WalkState::Quit),
+                }
+            }
+        },
+
+        Err(err) => {
+            let result = tx.send(WorkerResult::Error(err));
+
+            match result {
+                Ok(_) => Err(WalkState::Continue),
+                Err(_) => Err(WalkState::Quit),
+            }
+        }
+    }
+}
+
 /// State shared by the sender and receiver threads.
 struct WorkerState {
     /// The search patterns.
@@ -445,6 +693,7 @@ impl WorkerState {
             let patterns = &self.patterns;
             let config = &self.config;
             let quit_flag = self.quit_flag.as_ref();
+            let filter = EntryFilter::new(config, patterns);
 
             let mut limit = 0x100;
             if let Some(cmd) = &config.command
@@ -461,148 +710,24 @@ impl WorkerState {
                     return WalkState::Quit;
                 }
 
+                
+
                 if let Ok(e) = &entry {
-                    // If the entry is a directory that contains a
-                    // "ignore contain" file", we want to skip this
-                    // directory.
-                    // Check the filetype first to avoid unnecessary
-                    // syscalls.
-                    if e.file_type().is_some_and(|t| t.is_dir()) {
-                        let entry_path = e.path();
-                        if config
-                            .ignore_contain
-                            .iter()
-                            .any(|ic| entry_path.join(ic).exists())
-                        {
-                            return WalkState::Skip;
-                        }
-                    }
-                    if e.depth() == 0 {
-                        // Skip the root directory entry.
-                        return WalkState::Continue;
+                    if let Some(state) = filter.evaluate_before_normalization(e) {
+                        return state;
                     }
                 }
-                let entry = match entry {
-                    Ok(e) => DirEntry::normal(e),
-                    Err(ignore::Error::WithPath {
-                        path,
-                        err: inner_err,
-                    }) => match inner_err.as_ref() {
-                        ignore::Error::Io(io_error)
-                            if io_error.kind() == io::ErrorKind::NotFound
-                                && path
-                                    .symlink_metadata()
-                                    .ok()
-                                    .is_some_and(|m| m.file_type().is_symlink()) =>
-                        {
-                            DirEntry::broken_symlink(path)
-                        }
-                        _ => {
-                            return match tx.send(WorkerResult::Error(ignore::Error::WithPath {
-                                path,
-                                err: inner_err,
-                            })) {
-                                Ok(_) => WalkState::Continue,
-                                Err(_) => WalkState::Quit,
-                            };
-                        }
-                    },
-                    Err(err) => {
-                        return match tx.send(WorkerResult::Error(err)) {
-                            Ok(_) => WalkState::Continue,
-                            Err(_) => WalkState::Quit,
-                        };
-                    }
+
+                let entry = match normalize_walk_entry(entry, &mut tx) {
+                    Ok(entry) => entry,
+                    Err(state) => return state,
                 };
 
-                if let Some(min_depth) = config.min_depth
-                    && entry.depth().is_none_or(|d| d < min_depth)
-                {
-                    return WalkState::Continue;
+                if let Some(state) = filter.evaluate(&entry) {
+                    return state;
                 }
 
-                // Check the name first, since it doesn't require metadata
-                let entry_path = entry.path();
-
-                let search_str = search_str_for_entry(entry_path, config.full_path_base.as_deref());
-
-                if !patterns
-                    .iter()
-                    .all(|pat| pat.is_match(&filesystem::osstr_to_bytes(search_str.as_ref())))
-                {
-                    return WalkState::Continue;
-                }
-
-                // Filter out unwanted extensions.
-                if let Some(ref exts_regex) = config.extensions {
-                    if let Some(path_str) = entry_path.file_name() {
-                        if !exts_regex.is_match(&filesystem::osstr_to_bytes(path_str)) {
-                            return WalkState::Continue;
-                        }
-                    } else {
-                        return WalkState::Continue;
-                    }
-                }
-
-                // Filter out unwanted file types.
-                if let Some(ref file_types) = config.file_types
-                    && file_types.should_ignore(&entry)
-                {
-                    return WalkState::Continue;
-                }
-
-                #[cfg(unix)]
-                {
-                    if let Some(ref owner_constraint) = config.owner_constraint {
-                        if let Some(metadata) = entry.metadata() {
-                            if !owner_constraint.matches(metadata) {
-                                return WalkState::Continue;
-                            }
-                        } else {
-                            return WalkState::Continue;
-                        }
-                    }
-                }
-
-                // Filter out unwanted sizes if it is a file and we have been given size constraints.
-                if !config.size_constraints.is_empty() {
-                    if entry_path.is_file() {
-                        if let Some(metadata) = entry.metadata() {
-                            let file_size = metadata.len();
-                            if config
-                                .size_constraints
-                                .iter()
-                                .any(|sc| !sc.is_within(file_size))
-                            {
-                                return WalkState::Continue;
-                            }
-                        } else {
-                            return WalkState::Continue;
-                        }
-                    } else {
-                        return WalkState::Continue;
-                    }
-                }
-
-                // Filter out unwanted modification times
-                if !config.time_constraints.is_empty() {
-                    let mut matched = false;
-                    if let Some(metadata) = entry.metadata()
-                        && let Ok(modified) = metadata.modified()
-                    {
-                        matched = config
-                            .time_constraints
-                            .iter()
-                            .all(|tf| tf.applies_to(&modified));
-                    }
-                    if !matched {
-                        return WalkState::Continue;
-                    }
-                }
-
-                if config.is_printing()
-                    && let Some(ls_colors) = &config.ls_colors
-                {
+                if config.is_printing() && let Some(ls_colors) = &config.ls_colors {
                     // Compute colors in parallel
                     entry.style(ls_colors);
                 }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -380,9 +380,7 @@ impl<'a> EntryFilter<'a> {
     }
 
     fn check_min_depth(&self, entry: &DirEntry) -> Option<WalkState> {
-        let Some(min_depth) = self.config.min_depth else {
-            return None;
-        };
+        let min_depth = self.config.min_depth?;
 
         if entry.depth().is_none_or(|depth| depth < min_depth) {
             return Some(WalkState::Continue);
@@ -423,7 +421,7 @@ impl<'a> EntryFilter<'a> {
 
     fn check_file_types(&self, entry: &DirEntry) -> Option<WalkState> {
         if let Some(ref file_types) = self.config.file_types
-            && file_types.should_ignore(&entry)
+            && file_types.should_ignore(entry)
         {
             return Some(WalkState::Continue);
         }
@@ -497,7 +495,6 @@ impl<'a> EntryFilter<'a> {
         None
     }
 }
-
 
 /// Converts an `ignore` walker entry into a `DirEntry`.
 ///
@@ -710,12 +707,10 @@ impl WorkerState {
                     return WalkState::Quit;
                 }
 
-                
-
-                if let Ok(e) = &entry {
-                    if let Some(state) = filter.evaluate_before_normalization(e) {
-                        return state;
-                    }
+                if let Ok(e) = &entry
+                    && let Some(state) = filter.evaluate_before_normalization(e)
+                {
+                    return state;
                 }
 
                 let entry = match normalize_walk_entry(entry, &mut tx) {
@@ -727,7 +722,9 @@ impl WorkerState {
                     return state;
                 }
 
-                if config.is_printing() && let Some(ls_colors) = &config.ls_colors {
+                if config.is_printing()
+                    && let Some(ls_colors) = &config.ls_colors
+                {
                     // Compute colors in parallel
                     entry.style(ls_colors);
                 }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -313,43 +313,43 @@ impl<'a> EntryFilter<'a> {
     }
 
     /// Fast-path checks that operate on the raw ignore::DirEntry
-    fn evaluate_before_normalization(&self, entry: &ignore::DirEntry) -> Option<WalkState> {
-        if let Some(state) = self.check_ignore_file(entry) {
-            return Some(state);
+    fn evaluate_raw(&self, entry: &ignore::DirEntry) -> Option<WalkState> {
+        if self.skip_ignore_dir(entry) {
+            return Some(WalkState::Skip);
         }
-        if let Some(state) = self.check_root_dir(entry) {
-            return Some(state);
+
+        if self.is_root_dir(entry) {
+            return Some(WalkState::Continue);
         }
+
         None
     }
 
     /// Evaluates a normalized entry against all configured constraints to determine its walk state.
     fn evaluate(&self, entry: &DirEntry) -> Option<WalkState> {
-        if let Some(state) = self.check_min_depth(entry) {
-            return Some(state);
+        #[cfg(unix)]
+        let fails_owner_constraints = self.fails_owner_constraints(entry);
+
+        #[cfg(not(unix))]
+        let fails_owner_constraints = false;
+
+        if self.is_below_min_depth(entry)
+            || self.fails_pattern_filter(entry)
+            || self.fails_extension_filter(entry)
+            || self.matches_ignored_file_type(entry)
+            || fails_owner_constraints
+            || self.fails_size_constraints(entry)
+            || self.fails_modification_time_constraints(entry)
+        {
+            return Some(WalkState::Continue);
         }
-        if let Some(state) = self.check_patterns(entry) {
-            return Some(state);
-        }
-        if let Some(state) = self.check_extensions(entry) {
-            return Some(state);
-        }
-        if let Some(state) = self.check_file_types(entry) {
-            return Some(state);
-        }
-        if let Some(state) = self.check_owner(entry) {
-            return Some(state);
-        }
-        if let Some(state) = self.check_size(entry) {
-            return Some(state);
-        }
-        if let Some(state) = self.check_modification_time(entry) {
-            return Some(state);
-        }
+
         None
     }
 
-    fn check_ignore_file(&self, entry: &ignore::DirEntry) -> Option<WalkState> {
+    // Check whether the given directory contains the file specified by `--ignore-contains`.
+    // This allows to skip the directory entirely.
+    fn skip_ignore_dir(&self, entry: &ignore::DirEntry) -> bool {
         // If the entry is a directory that contains a
         // "ignore contain" file, we want to skip this
         // directory.
@@ -363,33 +363,37 @@ impl<'a> EntryFilter<'a> {
                 .iter()
                 .any(|ic| entry_path.join(ic).exists())
             {
-                return Some(WalkState::Skip);
+                return true;
             }
         }
 
-        None
+        return false;
     }
 
-    fn check_root_dir(&self, entry: &ignore::DirEntry) -> Option<WalkState> {
+    /// Check if the entry is a root directory, and skip it if so,
+    /// so that we don't include the root search paths in the output.
+    fn is_root_dir(&self, entry: &ignore::DirEntry) -> bool {
         if entry.depth() == 0 {
-            // Skip the root directory entry.
-            return Some(WalkState::Continue);
+            return true;
         }
 
-        None
+        return false;
     }
 
-    fn check_min_depth(&self, entry: &DirEntry) -> Option<WalkState> {
-        let min_depth = self.config.min_depth?;
+    fn is_below_min_depth(&self, entry: &DirEntry) -> bool {
+        let Some(min_depth) = self.config.min_depth else {
+            return false;
+        };
 
         if entry.depth().is_none_or(|depth| depth < min_depth) {
-            return Some(WalkState::Continue);
+            return true;
         }
 
-        None
+        return false;
     }
 
-    fn check_patterns(&self, entry: &DirEntry) -> Option<WalkState> {
+    /// Returns whether the entry fails to match the configured patterns.
+    fn fails_pattern_filter(&self, entry: &DirEntry) -> bool {
         let entry_path = entry.path();
 
         let search_str = search_str_for_entry(entry_path, self.config.full_path_base.as_deref());
@@ -399,37 +403,56 @@ impl<'a> EntryFilter<'a> {
             .iter()
             .all(|pat| pat.is_match(&filesystem::osstr_to_bytes(search_str.as_ref())))
         {
-            return Some(WalkState::Continue);
+            return true;
         }
 
-        None
+        return false;
     }
 
-    fn check_extensions(&self, entry: &DirEntry) -> Option<WalkState> {
+    /// Returns whether the entry fails the configured extension filter.
+    fn fails_extension_filter(&self, entry: &DirEntry) -> bool {
         let entry_path = entry.path();
         if let Some(ref exts_regex) = self.config.extensions {
             if let Some(path_str) = entry_path.file_name() {
                 if !exts_regex.is_match(&filesystem::osstr_to_bytes(path_str)) {
-                    return Some(WalkState::Continue);
+                    return true;
                 }
             } else {
-                return Some(WalkState::Continue);
+                return true;
             }
         }
-        None
+        return false;
     }
 
-    fn check_file_types(&self, entry: &DirEntry) -> Option<WalkState> {
+    /// Returns whether the entry's file type should be ignored.
+    fn matches_ignored_file_type(&self, entry: &DirEntry) -> bool {
         if let Some(ref file_types) = self.config.file_types
             && file_types.should_ignore(entry)
         {
-            return Some(WalkState::Continue);
+            return true;
         }
 
-        None
+        return false;
     }
 
-    fn check_size(&self, entry: &DirEntry) -> Option<WalkState> {
+    #[cfg(unix)]
+    /// Returns whether the entry fails the configured owner constraint.
+    fn fails_owner_constraints(&self, entry: &DirEntry) -> bool {
+        if let Some(ref owner_constraint) = self.config.owner_constraint {
+            if let Some(metadata) = entry.metadata() {
+                if !owner_constraint.matches(metadata) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// Returns whether the entry failed configured size constraints.
+    fn fails_size_constraints(&self, entry: &DirEntry) -> bool {
         let entry_path = entry.path();
         if !self.config.size_constraints.is_empty() {
             if entry_path.is_file() {
@@ -441,20 +464,21 @@ impl<'a> EntryFilter<'a> {
                         .iter()
                         .any(|sc| !sc.is_within(file_size))
                     {
-                        return Some(WalkState::Continue);
+                        return true;
                     }
                 } else {
-                    return Some(WalkState::Continue);
+                    return true;
                 }
             } else {
-                return Some(WalkState::Continue);
+                return true;
             }
         }
 
-        None
+        return false;
     }
 
-    fn check_modification_time(&self, entry: &DirEntry) -> Option<WalkState> {
+    /// Returns whether the entry fails the configured modification time constraints.
+    fn fails_modification_time_constraints(&self, entry: &DirEntry) -> bool {
         if !self.config.time_constraints.is_empty() {
             let mut matched = false;
             if let Some(metadata) = entry.metadata()
@@ -467,32 +491,11 @@ impl<'a> EntryFilter<'a> {
                     .all(|tf| tf.applies_to(&modified));
             }
             if !matched {
-                return Some(WalkState::Continue);
+                return true;
             }
         }
 
-        None
-    }
-
-    #[cfg(unix)]
-    fn check_owner(&self, entry: &DirEntry) -> Option<WalkState> {
-        if let Some(ref owner_constraint) = self.config.owner_constraint {
-            if let Some(metadata) = entry.metadata() {
-                if !owner_constraint.matches(metadata) {
-                    return Some(WalkState::Continue);
-                }
-            } else {
-                return Some(WalkState::Continue);
-            }
-        }
-
-        None
-    }
-
-    #[cfg(not(unix))]
-    #[inline]
-    fn check_owner(&self, _entry: &DirEntry) -> Option<WalkState> {
-        None
+        return false;
     }
 }
 
@@ -695,7 +698,7 @@ impl WorkerState {
                 }
 
                 if let Ok(e) = &entry
-                    && let Some(state) = filter.evaluate_before_normalization(e)
+                    && let Some(state) = filter.evaluate_raw(e)
                 {
                     return state;
                 }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -367,7 +367,7 @@ impl<'a> EntryFilter<'a> {
             }
         }
 
-        return false;
+        false
     }
 
     /// Check if the entry is a root directory, and skip it if so,
@@ -377,7 +377,7 @@ impl<'a> EntryFilter<'a> {
             return true;
         }
 
-        return false;
+        false
     }
 
     fn is_below_min_depth(&self, entry: &DirEntry) -> bool {
@@ -389,7 +389,7 @@ impl<'a> EntryFilter<'a> {
             return true;
         }
 
-        return false;
+        false
     }
 
     /// Returns whether the entry fails to match the configured patterns.
@@ -406,7 +406,7 @@ impl<'a> EntryFilter<'a> {
             return true;
         }
 
-        return false;
+        false
     }
 
     /// Returns whether the entry fails the configured extension filter.
@@ -421,7 +421,7 @@ impl<'a> EntryFilter<'a> {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     /// Returns whether the entry's file type should be ignored.
@@ -432,7 +432,7 @@ impl<'a> EntryFilter<'a> {
             return true;
         }
 
-        return false;
+        false
     }
 
     #[cfg(unix)]
@@ -448,7 +448,7 @@ impl<'a> EntryFilter<'a> {
             }
         }
 
-        return false;
+        false
     }
 
     /// Returns whether the entry failed configured size constraints.
@@ -474,7 +474,7 @@ impl<'a> EntryFilter<'a> {
             }
         }
 
-        return false;
+        false
     }
 
     /// Returns whether the entry fails the configured modification time constraints.
@@ -495,7 +495,7 @@ impl<'a> EntryFilter<'a> {
             }
         }
 
-        return false;
+        false
     }
 }
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -313,20 +313,20 @@ impl<'a> EntryFilter<'a> {
     }
 
     /// Fast-path checks that operate on the raw ignore::DirEntry
-    fn evaluate_raw(&self, entry: &ignore::DirEntry) -> Option<WalkState> {
+    fn evaluate_raw(&self, entry: &ignore::DirEntry) -> Result<(), WalkState> {
         if self.skip_ignore_dir(entry) {
-            return Some(WalkState::Skip);
+            return Err(WalkState::Skip);
         }
 
         if self.is_root_dir(entry) {
-            return Some(WalkState::Continue);
+            return Err(WalkState::Continue);
         }
 
-        None
+        Ok(())
     }
 
     /// Evaluates a normalized entry against all configured constraints to determine its walk state.
-    fn evaluate(&self, entry: &DirEntry) -> Option<WalkState> {
+    fn evaluate(&self, entry: &DirEntry) -> Result<(), WalkState> {
         #[cfg(unix)]
         let fails_owner_constraints = self.fails_owner_constraints(entry);
 
@@ -341,10 +341,10 @@ impl<'a> EntryFilter<'a> {
             || self.fails_size_constraints(entry)
             || self.fails_modification_time_constraints(entry)
         {
-            return Some(WalkState::Continue);
+            return Err(WalkState::Continue);
         }
 
-        None
+        Ok(())
     }
 
     // Check whether the given directory contains the file specified by `--ignore-contains`.
@@ -699,7 +699,7 @@ impl WorkerState {
                 }
 
                 if let Ok(e) = &entry
-                    && let Some(state) = filter.evaluate_raw(e)
+                    && let Err(state) = filter.evaluate_raw(e)
                 {
                     return state;
                 }
@@ -709,7 +709,7 @@ impl WorkerState {
                     Err(state) => return state,
                 };
 
-                if let Some(state) = filter.evaluate(&entry) {
+                if let Err(state) = filter.evaluate(&entry) {
                     return state;
                 }
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -380,6 +380,7 @@ impl<'a> EntryFilter<'a> {
         false
     }
 
+    /// Returns whether `entry` is shallower than the configured minimum depth.
     fn is_below_min_depth(&self, entry: &DirEntry) -> bool {
         let Some(min_depth) = self.config.min_depth else {
             return false;

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -512,16 +512,16 @@ fn normalize_walk_entry(
         Err(ignore::Error::WithPath {
             path,
             err: inner_err,
-        }) => if inner_err
-              .io_error()
-              .is_some_and(|io_error| io_error.kind() == io::ErrorKind::NotFound)
-              && path
-                  .symlink_metadata()
-                  .ok()
-                  .is_some_and(|m| m.file_type().is_symlink()) =>
+        }) if inner_err
+            .io_error()
+            .is_some_and(|io_error| io_error.kind() == io::ErrorKind::NotFound)
+            && path
+                .symlink_metadata()
+                .ok()
+                .is_some_and(|m| m.file_type().is_symlink()) =>
         {
-            DirEntry::broken_symlink(path)
-        },
+            Ok(DirEntry::broken_symlink(path))
+        }
 
         Err(err) => {
             let result = tx.send(WorkerResult::Error(err));


### PR DESCRIPTION
This PR refactors the directory traversal logic in WorkerState to improve readability and maintainability. Previously, the evaluation of filtering constraints (depth, patterns, extensions, size, time) was implemented as a large block of inline conditionals within the core walk loop.

This change extracts that logic into a dedicated EntryFilter struct, cleanly separating the traversal mechanics from the filtering rules. All existing traversal behavior and the execution order of the filter checks are strictly preserved.

## Changes

This PR cleans up the walk entry processing so the main loop is easier to read and reason about.

* Moved file filtering logic into a new `EntryFilter` helper, with separate methods for pattern, size, owner, and other checks.

* Added `normalize_walk_entry` to handle `ignore::DirEntry` conversion, broken symlink recovery, and walker errors outside of the main loop.

* Moved Unix-specific owner-check logic into `check_owner`, keeping the main path less cluttered with platform-specific conditionals.
