### PR TITLE
refactor: Get io error from method

### DIFF
--- a/src/walk.rs
+++ b/src/walk.rs
@@ -487,26 +487,16 @@ impl WorkerState {
                     Err(ignore::Error::WithPath {
                         path,
                         err: inner_err,
-                    }) => match inner_err.as_ref() {
-                        ignore::Error::Io(io_error)
-                            if io_error.kind() == io::ErrorKind::NotFound
-                                && path
-                                    .symlink_metadata()
-                                    .ok()
-                                    .is_some_and(|m| m.file_type().is_symlink()) =>
-                        {
-                            DirEntry::broken_symlink(path)
-                        }
-                        _ => {
-                            return match tx.send(WorkerResult::Error(ignore::Error::WithPath {
-                                path,
-                                err: inner_err,
-                            })) {
-                                Ok(_) => WalkState::Continue,
-                                Err(_) => WalkState::Quit,
-                            };
-                        }
-                    },
+                    }) if inner_err
+                        .io_error()
+                        .is_some_and(|io_error| io_error.kind() == io::ErrorKind::NotFound)
+                        && path
+                            .symlink_metadata()
+                            .ok()
+                            .is_some_and(|m| m.file_type().is_symlink()) =>
+                    {
+                        DirEntry::broken_symlink(path)
+                    }
                     Err(err) => {
                         return match tx.send(WorkerResult::Error(err)) {
                             Ok(_) => WalkState::Continue,


### PR DESCRIPTION
use `ignore::Error::io_error()` to inspect the `std::io::Error` insted of pattern matching on `ignore::Error::Io`.

This avoids relying on the implementation of ignore and how it organizes the error. In particular, this would allow us to handle if the IO error was wrapped in a `WithDepth`, as would be the case if BurntSushi/ripgrep#3458 was merged.

This also allows us to remove some duplicate code.