### PR TITLE
Remove external ls dependency for --list-details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,8 @@ dependencies = [
  "tempfile",
  "test-case",
  "tikv-jemallocator",
+ "unix_mode",
+ "users",
 ]
 
 [[package]]
@@ -846,6 +848,22 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unix_mode"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55eedc365f81a3c32aea49baf23fa965e3cd85bcc28fb8045708c7388d124ef"
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ crossbeam-channel = "0.5.15"
 clap_complete = {version = "4.6.5", optional = true}
 faccess = "0.2.4"
 jiff = "0.2.27"
+unix_mode = "0.1"
 
 [dependencies.clap]
 version = "4.6.1"
@@ -58,6 +59,7 @@ features = ["nu-ansi-term"]
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31.1", default-features = false, features = ["signal", "user", "hostname"] }
+users = "0.11"
 
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
 libc = "0.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,9 @@ pub struct Config {
 
     /// Names that should stop traversal down their parent. (e.g. https://bford.info/cachedir/).
     pub ignore_contain: Vec<String>,
+    
+    /// Whether or not to print details
+    pub list_details: bool,
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,7 +133,7 @@ pub struct Config {
 
     /// Names that should stop traversal down their parent. (e.g. https://bford.info/cachedir/).
     pub ignore_contain: Vec<String>,
-    
+
     /// Whether or not to print details
     pub list_details: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,7 +295,7 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         HyperlinkWhen::Never => false,
         HyperlinkWhen::Auto => colored_output,
     };
-    let command = extract_command(&mut opts, colored_output)?;
+    let command = extract_command(&mut opts)?;
     let has_command = command.is_some();
 
     let full_path_base = if opts.full_path {
@@ -389,108 +389,12 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         max_results: opts.max_results(),
         strip_cwd_prefix: opts.strip_cwd_prefix(|| !(opts.null_separator || has_command)),
         ignore_contain: opts.ignore_contain,
+        list_details: opts.list_details,
     })
 }
 
-fn extract_command(opts: &mut Opts, colored_output: bool) -> Result<Option<CommandSet>> {
-    opts.exec
-        .command
-        .take()
-        .map(Ok)
-        .or_else(|| {
-            if !opts.list_details {
-                return None;
-            }
-
-            let res = determine_ls_command(colored_output)
-                .map(|cmd| CommandSet::new_batch([cmd]).unwrap());
-            Some(res)
-        })
-        .transpose()
-}
-
-fn determine_ls_command(colored_output: bool) -> Result<Vec<&'static str>> {
-    #[allow(unused)]
-    let gnu_ls = |command_name| {
-        let color_arg = if colored_output {
-            "--color=always"
-        } else {
-            "--color=never"
-        };
-        // Note: we use short options here (instead of --long-options) to support more
-        // platforms (like BusyBox).
-        vec![
-            command_name,
-            "-l", // long listing format
-            "-h", // human readable file sizes
-            "-d", // list directories themselves, not their contents
-            color_arg,
-        ]
-    };
-    let cmd: Vec<&str> = if cfg!(unix) {
-        if !cfg!(any(
-            target_os = "macos",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )) {
-            // Assume ls is GNU ls
-            gnu_ls("ls")
-        } else {
-            // macOS, DragonFlyBSD, FreeBSD
-            use std::process::{Command, Stdio};
-
-            // Use GNU ls, if available (support for --color=auto, better LS_COLORS support)
-            let gnu_ls_exists = Command::new("gls")
-                .arg("--version")
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-                .is_ok();
-
-            if gnu_ls_exists {
-                gnu_ls("gls")
-            } else {
-                let mut cmd = vec![
-                    "ls", // BSD version of ls
-                    "-l", // long listing format
-                    "-h", // '--human-readable' is not available, '-h' is
-                    "-d", // '--directory' is not available, but '-d' is
-                ];
-
-                if !cfg!(any(target_os = "netbsd", target_os = "openbsd")) && colored_output {
-                    // -G is not available in NetBSD's and OpenBSD's ls
-                    cmd.push("-G");
-                }
-
-                cmd
-            }
-        }
-    } else if cfg!(windows) {
-        use std::process::{Command, Stdio};
-
-        // Use GNU ls, if available
-        let gnu_ls_exists = Command::new("ls")
-            .arg("--version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .is_ok();
-
-        if gnu_ls_exists {
-            gnu_ls("ls")
-        } else {
-            return Err(anyhow!(
-                "'fd --list-details' is not supported on Windows unless GNU 'ls' is installed."
-            ));
-        }
-    } else {
-        return Err(anyhow!(
-            "'fd --list-details' is not supported on this platform."
-        ));
-    };
-    Ok(cmd)
+fn extract_command(opts: &mut Opts) -> Result<Option<CommandSet>> {
+    opts.exec.command.take().map(Ok).transpose()
 }
 
 fn extract_time_constraints(opts: &Opts) -> Result<Vec<TimeFilter>> {

--- a/src/output.rs
+++ b/src/output.rs
@@ -219,7 +219,7 @@ fn print_details<W: Write>(stdout: &mut W, meta: &std::fs::Metadata) -> io::Resu
     stdout.write_all(&attr_buf)?;
     stdout.write_all(b" ")?;
 
-    print_time(stdout, meta.last_write_time())?;
+    print_time(stdout, filetime_to_unix_seconds(meta.last_write_time()))?;
 
     if meta.is_file() {
         print_size(stdout, meta.len())?;
@@ -262,29 +262,21 @@ fn print_details<W: Write>(stdout: &mut W, meta: &std::fs::Metadata) -> io::Resu
     stdout.write_all(b" ")
 }
 
-#[cfg(target_os = "windows")]
-fn print_time<W: Write>(stdout: &mut W, file_time: u64) -> io::Result<()> {
+fn print_time<W: Write>(stdout: &mut W, unix_seconds: i64) -> io::Result<()> {
     use jiff::{Timestamp, Zoned};
 
-    const INTERVALS_PER_SECOND: u64 = 10_000_000;
-    const EPOCH_DIFF_SECONDS: u64 = 11_644_473_600;
-
-    let unix_seconds = (file_time / INTERVALS_PER_SECOND).saturating_sub(EPOCH_DIFF_SECONDS);
-    let timestamp = Timestamp::from_second(unix_seconds as i64).unwrap_or(Timestamp::UNIX_EPOCH);
-
+    let timestamp = Timestamp::from_second(unix_seconds)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let zoned: Zoned = timestamp.to_zoned(jiff::tz::TimeZone::system());
+
     write!(stdout, "  {:>20}", zoned.strftime("%d-%m-%Y %H:%M:%S"))
 }
 
-#[cfg(not(target_os = "windows"))]
-fn print_time<W: Write>(stdout: &mut W, mtime: i64) -> io::Result<()> {
-    use jiff::{Timestamp, Zoned};
-
-    let timestamp =
-        Timestamp::from_second(mtime).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-    let zoned: Zoned = timestamp.to_zoned(jiff::tz::TimeZone::system());
-
-    write!(stdout, "  {:>20}", zoned.strftime("%d-%m-%Y %H:%M:%S"))
+#[cfg(target_os = "windows")]
+fn filetime_to_unix_seconds(file_time: u64) -> i64 {
+    const INTERVALS_PER_SECOND: u64 = 10_000_000;
+    const EPOCH_DIFF_SECONDS: u64 = 11_644_473_600;
+    (file_time / INTERVALS_PER_SECOND).saturating_sub(EPOCH_DIFF_SECONDS) as i64
 }
 
 fn print_size<W: Write>(stdout: &mut W, size: u64) -> io::Result<()> {
@@ -299,5 +291,62 @@ fn print_size<W: Write>(stdout: &mut W, size: u64) -> io::Result<()> {
         write!(stdout, "{:>6}{}", size, UNITS[unit_idx])
     } else {
         write!(stdout, "{:>6.1}{}", sz, UNITS[unit_idx])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_print_size() {
+        let re = regex::Regex::new(r"^\s+\d{0,4}(\.\d?)?[BKMGTP]").unwrap();
+
+        let mut buf = Vec::new();
+
+        let mut sz = 1;
+        for _ in 0..19 {
+            print_size(&mut buf, sz).unwrap();
+            let out = String::from_utf8_lossy(&buf);
+
+            assert!(
+                re.is_match(&out),
+                "{out}\nthe output doesn't math the template"
+            );
+            sz *= 10;
+            buf.clear();
+        }
+
+        let mut check = |size: u64, expect: &str| {
+            print_size(&mut buf, size).unwrap();
+            let out = String::from_utf8_lossy(&buf);
+            assert!(
+                out.contains(expect),
+                "{out}\nthe output doesn't math the template"
+            );
+            buf.clear();
+        };
+
+        check(0, "0B");
+        check(1025, "1.0K");
+        check(6505537, "6.2M");
+    }
+
+    #[test]
+    fn test_print_time() {
+        let re = regex::Regex::new(r"^\s+\d{2}-\d{2}-\d{4} \d{2}:\d{2}:\d{2}").unwrap();
+        let mut buf = Vec::new();
+
+        let mut check = |timestamp| {
+            print_time(&mut buf, timestamp).unwrap();
+            let out = String::from_utf8_lossy(&buf);
+            assert!(
+                re.is_match(&out),
+                "{out}\nthe output doesn't math the template"
+            );
+            buf.clear();
+        };
+
+        check(0x00000000_00000000);
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -24,9 +24,10 @@ pub fn print_entry<W: Write>(stdout: &mut W, entry: &DirEntry, config: &Config) 
     }
 
     if let Some(meta) = entry.metadata()
-        && config.list_details {
-            print_details(stdout, meta)?;
-        };
+        && config.list_details
+    {
+        print_details(stdout, meta)?;
+    };
 
     if let Some(ref format) = config.format {
         print_entry_format(stdout, entry, config, format)?;

--- a/src/output.rs
+++ b/src/output.rs
@@ -23,6 +23,11 @@ pub fn print_entry<W: Write>(stdout: &mut W, entry: &DirEntry, config: &Config) 
         has_hyperlink = true;
     }
 
+    if let Some(meta) = entry.metadata()
+        && config.list_details {
+            print_details(stdout, meta)?;
+        };
+
     if let Some(ref format) = config.format {
         print_entry_format(stdout, entry, config, format)?;
     } else if let Some(ref ls_colors) = config.ls_colors {
@@ -178,5 +183,120 @@ fn print_entry_uncolorized<W: Write>(
         // Piped output: raw bytes so invalid UTF-8 filenames reach downstream tools intact.
         stdout.write_all(entry.stripped_path(config).as_os_str().as_bytes())?;
         print_trailing_slash(stdout, entry, config, None)
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn print_details<W: Write>(stdout: &mut W, meta: &std::fs::Metadata) -> io::Result<()> {
+    use std::os::windows::fs::MetadataExt;
+
+    const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10;
+    const FILE_ATTRIBUTE_ARCHIVE: u32 = 0x20;
+    const FILE_ATTRIBUTE_READONLY: u32 = 0x01;
+    const FILE_ATTRIBUTE_HIDDEN: u32 = 0x02;
+    const FILE_ATTRIBUTE_SYSTEM: u32 = 0x04;
+
+    let attrs = meta.file_attributes();
+    let mut attr_buf = [b'-'; 6];
+
+    if attrs & FILE_ATTRIBUTE_DIRECTORY != 0 {
+        attr_buf[0] = b'd';
+    }
+    if attrs & FILE_ATTRIBUTE_ARCHIVE != 0 {
+        attr_buf[1] = b'a';
+    }
+    if attrs & FILE_ATTRIBUTE_READONLY != 0 {
+        attr_buf[2] = b'r';
+    }
+    if attrs & FILE_ATTRIBUTE_HIDDEN != 0 {
+        attr_buf[3] = b'h';
+    }
+    if attrs & FILE_ATTRIBUTE_SYSTEM != 0 {
+        attr_buf[4] = b's';
+    }
+
+    stdout.write_all(&attr_buf)?;
+    stdout.write_all(b" ")?;
+
+    print_time(stdout, meta.last_write_time())?;
+
+    if meta.is_file() {
+        print_size(stdout, meta.len())?;
+    } else {
+        write!(stdout, "{:>7}", "")?
+    }
+
+    stdout.write_all(b"  ")
+}
+
+#[cfg(not(target_os = "windows"))]
+fn print_details<W: Write>(stdout: &mut W, meta: &std::fs::Metadata) -> io::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let mode = meta.mode();
+    let mode_string = unix_mode::to_string(mode);
+
+    let nlink = meta.nlink();
+
+    let uid = meta.uid();
+    let gid = meta.gid();
+
+    let user_name = users::get_user_by_uid(uid)
+        .map(|u| u.name().to_string_lossy().into_owned())
+        .unwrap_or_else(|| uid.to_string());
+
+    let group_name = users::get_group_by_gid(gid)
+        .map(|g| g.name().to_string_lossy().into_owned())
+        .unwrap_or_else(|| gid.to_string());
+
+    write!(
+        stdout,
+        "{:<10} {:>3} {:<8} {:<8} ",
+        mode_string, nlink, user_name, group_name,
+    )?;
+
+    print_size(stdout, meta.len())?;
+    print_time(stdout, meta.mtime())?;
+
+    stdout.write_all(b" ")
+}
+
+#[cfg(target_os = "windows")]
+fn print_time<W: Write>(stdout: &mut W, file_time: u64) -> io::Result<()> {
+    use jiff::{Timestamp, Zoned};
+
+    const INTERVALS_PER_SECOND: u64 = 10_000_000;
+    const EPOCH_DIFF_SECONDS: u64 = 11_644_473_600;
+
+    let unix_seconds = (file_time / INTERVALS_PER_SECOND).saturating_sub(EPOCH_DIFF_SECONDS);
+    let timestamp = Timestamp::from_second(unix_seconds as i64).unwrap_or(Timestamp::UNIX_EPOCH);
+
+    let zoned: Zoned = timestamp.to_zoned(jiff::tz::TimeZone::system());
+    write!(stdout, "  {:>20}", zoned.strftime("%d-%m-%Y %H:%M:%S"))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn print_time<W: Write>(stdout: &mut W, mtime: i64) -> io::Result<()> {
+    use jiff::{Timestamp, Zoned};
+
+    let timestamp =
+        Timestamp::from_second(mtime).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let zoned: Zoned = timestamp.to_zoned(jiff::tz::TimeZone::system());
+
+    write!(stdout, "  {:>20}", zoned.strftime("%d-%m-%Y %H:%M:%S"))
+}
+
+fn print_size<W: Write>(stdout: &mut W, size: u64) -> io::Result<()> {
+    const UNITS: &[&str] = &["B", "K", "M", "G", "T", "P"];
+    let mut sz = size as f64;
+    let mut unit_idx = 0;
+    while sz >= 1024.0 && unit_idx < UNITS.len() - 1 {
+        sz /= 1024.0;
+        unit_idx += 1;
+    }
+    if unit_idx == 0 {
+        write!(stdout, "{:>6}{}", size, UNITS[unit_idx])
+    } else {
+        write!(stdout, "{:>6.1}{}", sz, UNITS[unit_idx])
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,7 +10,7 @@ use test_case::test_case;
 
 use jiff::Timestamp;
 use normpath::PathExt;
-use regex::escape;
+use regex::{Regex, escape};
 
 use crate::testenv::TestEnv;
 
@@ -2875,4 +2875,34 @@ fn test_ignore_contain_precedence_over_root_check() {
     let te = TestEnv::new(&["include"], &["CACHEDIR.TAG", "top", "include/foo"]);
     let expected = "";
     te.assert_output(&["--ignore-contain=CACHEDIR.TAG", "."], expected);
+}
+
+#[test]
+fn test_print_details() {
+    #[cfg(target_os = "windows")]
+    let re = Regex::new(
+        r"^[darh-]{6}\s+\d{2}-\d{2}-\d{4} \d{2}:\d{2}:\d{2}\s+(\d{0,4}(\.\d?)?[BKMGTP])?\s.*",
+    )
+    .unwrap();
+
+    #[cfg(not(target_os = "windows"))]
+    let re = Regex::new(
+        r"^([drwxlsStT-]{10})\s+(\d+)\s+(\S+)\s+(\S+)\s+([\d.]+[KMB]?)\s+(\d{2}-\d{2}-\d{4}\s+\d{2}:\d{2}:\d{2})\s+(.+)$",
+    )
+    .unwrap();
+
+    let te = TestEnv::new(&["include"], &["CACHEDIR.TAG", "top", "include/foo"]);
+
+    let output = te.assert_success_and_get_output(".", &["-l", "--hidden"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let mut out: Vec<&str> = stdout.split('\n').collect();
+    out.pop();
+
+    for row in out {
+        assert!(
+            re.is_match(row),
+            "{row}\nthe output doesn't match the pattern"
+        );
+    }
 }


### PR DESCRIPTION
This PR replaces the external `ls` call with a native implementation for the `--list-details` option

#1845

Some output samples:
<details>
<summary>Windows</summary>
<img width="513" height="527" alt="изображение" src="https://github.com/user-attachments/assets/13da5457-6f26-401c-b627-3cc6578ac7b5" />
</details>
<details>
<summary>Linux</summary>
<img width="686" height="492" alt="изображение" src="https://github.com/user-attachments/assets/930516d4-c514-47ea-8e01-564fe1239a42" />
</details>
