### PR TITLE
Improve changed date parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Fire the "search pattern contains a path separator" diagnostic for any pattern containing `/`, not just patterns that happen to name an existing directory. Preserves the legacy Windows behaviour that also flags native `\` separators when the pattern resolves to a real directory. See #1873.
 - Also fire the "search pattern contains a path separator" diagnostic for `--and` patterns, not only the primary positional pattern. `--and` patterns are matched against the file name just like the primary pattern, so a path separator in them silently returned zero results. See #1873.
 - Fix bug where passing "-" as a directory argument didn't actually search that directory, see #849 (@Sean-Kenneth-Doherty).
+- Include the underlying date parse error when `--changed-before` or
+  `--changed-within` receives a malformed date, see #2053.
 
 # 10.4.2
 

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,5 +1,5 @@
 pub use self::size::SizeFilter;
-pub use self::time::TimeFilter;
+pub use self::time::{TimeFilter, TimeFilterParseError};
 
 #[cfg(unix)]
 pub use self::owner::OwnerFilter;

--- a/src/filter/time.rs
+++ b/src/filter/time.rs
@@ -9,6 +9,12 @@ pub enum TimeFilter {
     After(SystemTime),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum TimeFilterParseError {
+    Invalid,
+    InvalidDateOrTimestamp(String),
+}
+
 #[cfg(not(test))]
 fn now() -> Zoned {
     Zoned::now()
@@ -26,31 +32,57 @@ fn now() -> Zoned {
 }
 
 impl TimeFilter {
-    fn from_str(s: &str) -> Option<SystemTime> {
+    fn from_str(s: &str) -> Result<SystemTime, TimeFilterParseError> {
         if let Ok(span) = s.parse::<Span>() {
-            let datetime = now().checked_sub(span).ok()?;
-            Some(datetime.into())
-        } else if let Ok(timestamp) = s.parse::<Timestamp>() {
-            Some(timestamp.into())
-        } else if let Ok(datetime) = s.parse::<DateTime>() {
-            Some(
-                TimeZone::system()
+            let datetime = now()
+                .checked_sub(span)
+                .map_err(|_| TimeFilterParseError::Invalid)?;
+            return Ok(datetime.into());
+        }
+
+        let timestamp_error = match s.parse::<Timestamp>() {
+            Ok(timestamp) => return Ok(timestamp.into()),
+            Err(error) => error,
+        };
+
+        let datetime_error = match s.parse::<DateTime>() {
+            Ok(datetime) => {
+                return TimeZone::system()
                     .to_ambiguous_zoned(datetime)
                     .later()
-                    .ok()?
-                    .into(),
-            )
+                    .map(SystemTime::from)
+                    .map_err(|error| {
+                        TimeFilterParseError::InvalidDateOrTimestamp(error.to_string())
+                    });
+            }
+            Err(error) => error,
+        };
+
+        if let Some(timestamp_secs) = s.strip_prefix('@') {
+            return timestamp_secs
+                .parse()
+                .map(|secs| UNIX_EPOCH + Duration::from_secs(secs))
+                .map_err(|error| TimeFilterParseError::InvalidDateOrTimestamp(error.to_string()));
+        }
+
+        if looks_like_date_or_time(s) {
+            Err(TimeFilterParseError::InvalidDateOrTimestamp(
+                datetime_error.to_string(),
+            ))
+        } else if s.contains('T') {
+            Err(TimeFilterParseError::InvalidDateOrTimestamp(
+                timestamp_error.to_string(),
+            ))
         } else {
-            let timestamp_secs: u64 = s.strip_prefix('@')?.parse().ok()?;
-            Some(UNIX_EPOCH + Duration::from_secs(timestamp_secs))
+            Err(TimeFilterParseError::Invalid)
         }
     }
 
-    pub fn before(s: &str) -> Option<TimeFilter> {
+    pub fn before(s: &str) -> Result<TimeFilter, TimeFilterParseError> {
         TimeFilter::from_str(s).map(TimeFilter::Before)
     }
 
-    pub fn after(s: &str) -> Option<TimeFilter> {
+    pub fn after(s: &str) -> Result<TimeFilter, TimeFilterParseError> {
         TimeFilter::from_str(s).map(TimeFilter::After)
     }
 
@@ -60,6 +92,11 @@ impl TimeFilter {
             TimeFilter::After(limit) => t > limit,
         }
     }
+}
+
+fn looks_like_date_or_time(s: &str) -> bool {
+    s.starts_with(|c: char| c.is_ascii_digit())
+        && (s.contains('-') || s.contains(':') || s.contains('T'))
 }
 
 #[cfg(test)]
@@ -177,7 +214,7 @@ mod tests {
         let t1m_ago = ref_time - Duration::from_secs(60);
         let t1s_later = ref_time + Duration::from_secs(1);
         // Timestamp only supported via '@' prefix
-        assert!(TimeFilter::before(&ref_timestamp.to_string()).is_none());
+        assert!(TimeFilter::before(&ref_timestamp.to_string()).is_err());
         assert!(
             TimeFilter::before(&format!("@{ref_timestamp}"))
                 .unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use crate::exit_codes::ExitCode;
 use crate::filetypes::FileTypes;
 #[cfg(unix)]
 use crate::filter::OwnerFilter;
-use crate::filter::TimeFilter;
+use crate::filter::{TimeFilter, TimeFilterParseError};
 use crate::regex_helper::{pattern_has_uppercase_char, pattern_matches_strings_with_leading_dot};
 
 // We use jemalloc for performance reasons, see https://github.com/sharkdp/fd/pull/481
@@ -496,26 +496,26 @@ fn determine_ls_command(colored_output: bool) -> Result<Vec<&'static str>> {
 fn extract_time_constraints(opts: &Opts) -> Result<Vec<TimeFilter>> {
     let mut time_constraints: Vec<TimeFilter> = Vec::new();
     if let Some(ref t) = opts.changed_within {
-        if let Some(f) = TimeFilter::after(t) {
-            time_constraints.push(f);
-        } else {
-            return Err(anyhow!(
-                "'{}' is not a valid date or duration. See 'fd --help'.",
-                t
-            ));
-        }
+        time_constraints.push(TimeFilter::after(t).map_err(|err| format_time_error(t, err))?);
     }
     if let Some(ref t) = opts.changed_before {
-        if let Some(f) = TimeFilter::before(t) {
-            time_constraints.push(f);
-        } else {
-            return Err(anyhow!(
-                "'{}' is not a valid date or duration. See 'fd --help'.",
-                t
-            ));
-        }
+        time_constraints.push(TimeFilter::before(t).map_err(|err| format_time_error(t, err))?);
     }
     Ok(time_constraints)
+}
+
+fn format_time_error(input: &str, err: TimeFilterParseError) -> anyhow::Error {
+    match err {
+        TimeFilterParseError::Invalid => anyhow!(
+            "'{}' is not a valid date or duration. See 'fd --help'.",
+            input
+        ),
+        TimeFilterParseError::InvalidDateOrTimestamp(detail) => anyhow!(
+            "'{}' is not a valid date or duration: {}. See 'fd --help'.",
+            input,
+            detail
+        ),
+    }
 }
 
 fn ensure_use_hidden_option_for_leading_dot_pattern(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2447,6 +2447,16 @@ fn test_modified_absolute() {
     );
 }
 
+#[test]
+fn test_modified_invalid_date_error() {
+    let te = TestEnv::new(&[], &[]);
+
+    te.assert_failure_with_error(
+        &["", "--changed-before", "2025-11-31"],
+        "[fd error]: '2025-11-31' is not a valid date or duration: parsed date is not valid: parameter 'day' for `2025-11` is invalid, must be in range `1..=30`. See 'fd --help'.",
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn test_owner_ignore_all() {


### PR DESCRIPTION
## Summary

- Improve error reporting for invalid `--changed-*` date arguments.
- Keep the parsed time filter context available so parse failures can mention the specific option.
- Add a regression test for invalid modified-date input.

## Validation

- `cargo test`