### PR TITLE
Clarify benchmark parallelism note

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,9 @@ Benchmark 3: fd -u '[0-9]\.jpg$' ~
   Time (mean ± σ):     854.8 ms ±  10.0 ms
   Range (min … max):   839.2 ms … 868.9 ms
 ```
+This uses `fd`'s default thread count, which is the number of available CPU
+cores. Use `--threads=1` to compare single-threaded traversal.
+
 For this particular example, `fd` is approximately **23 times faster** than `find -iregex`
 and about **13 times faster** than `find -iname`. By the way, both tools found the exact
 same 546 files :smile:.


### PR DESCRIPTION
## Summary

- Clarify that the README benchmark uses `fd`'s default thread count.
- Point readers to `--threads=1` for single-threaded traversal comparisons.
- Addresses #1661.

## Validation

- `cargo fmt -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`

## AI assistance

- Codex assisted with preparing this documentation patch and opening this draft PR. Please review and replace this section/body with your own wording before marking the PR ready for maintainer discussion.