### PR TITLE
docs: update required Rust version in README to match Cargo.toml MSRV (1.77.2 -> 1.90.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ With Rust's package manager [cargo](https://github.com/rust-lang/cargo), you can
 ```
 cargo install fd-find
 ```
-Note that rust version *1.77.2* or later is required.
+Note that rust version *1.90.0* or later is required.
 
 `make` is also needed for the build.
 


### PR DESCRIPTION
Hi, and thank you for fd.

Small docs fix: the README's build note is out of date. `README.md` (line 726) says:

> Note that rust version *1.77.2* or later is required.

but `Cargo.toml` now declares `rust-version = "1.90.0"` (and `edition = "2024"`), so 1.77.2 no longer builds it. This updates the README to `1.90.0` to match the actual MSRV.

For transparency: I used AI assistance to spot and draft this; I verified the README and `Cargo.toml` against the current source myself.
