### PR TITLE
Fix inconsistent code fence language in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ See below for more details on the placeholder syntax.
 The terminal output of commands run from parallel threads using `-x` will not be interlaced or garbled,
 so `fd -x` can be used to rudimentarily parallelize a task run over many files.
 An example of this is calculating the checksum of each individual file within a directory.
-```
+``` bash
 fd -tf -x md5sum > file_checksums.txt
 ```
 


### PR DESCRIPTION
## Summary
- The checksum example under the "Command execution" section was missing the `bash` language tag on its opening code fence, unlike every other shell example in the README.
- This meant that one snippet didn't get syntax highlighting while all the surrounding ones did.

## Change
- Added ` bash` to the opening fence for the `fd -tf -x md5sum > file_checksums.txt` example.

This is my first contribution to open source, thanks for maintaining such a great tool!