### PR TITLE
fix: reject over-large @timestamps that overflow SystemTime

### DIFF
--- a/src/filter/time.rs
+++ b/src/filter/time.rs
@@ -42,6 +42,9 @@ impl TimeFilter {
             )
         } else {
             let timestamp_secs: u64 = s.strip_prefix('@')?.parse().ok()?;
+            if timestamp_secs > i64::MAX as u64 {
+                return None;
+            }
             Some(UNIX_EPOCH + Duration::from_secs(timestamp_secs))
         }
     }


### PR DESCRIPTION
Fixes #2077. When a `@timestamp` value exceeds `i64::MAX` seconds, `UNIX_EPOCH + Duration::from_secs(timestamp_secs)` overflows the underlying `SystemTime` representation and panics. Adding an explicit range check returns a clean parse error instead.

AI disclosure: This PR was created with the assistance of an AI coding tool. The fix was reviewed and verified by a human.

## Verification

- `cargo test` passes (111/111)