### PR TITLE
Fix panic on out-of-range '@' Unix timestamp in time filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fire the "search pattern contains a path separator" diagnostic for any pattern containing `/`, not just patterns that happen to name an existing directory. Preserves the legacy Windows behaviour that also flags native `\` separators when the pattern resolves to a real directory. See #1873.
 - Also fire the "search pattern contains a path separator" diagnostic for `--and` patterns, not only the primary positional pattern. `--and` patterns are matched against the file name just like the primary pattern, so a path separator in them silently returned zero results. See #1873.
 - Fix bug where passing "-" as a directory argument didn't actually search that directory, see #849 (@Sean-Kenneth-Doherty).
+- Fix panic when `--changed-before`/`--changed-within` is given an out-of-range `@` Unix timestamp; the value is now rejected gracefully, see #2081 (@nikolauspschuetz).
 
 # 10.4.2
 

--- a/src/filter/time.rs
+++ b/src/filter/time.rs
@@ -199,4 +199,12 @@ mod tests {
                 .applies_to(&t1s_later)
         );
     }
+
+    #[test]
+    fn out_of_range_unix_timestamp_is_rejected() {
+        // A '@' timestamp large enough to overflow SystemTime must return
+        // None rather than panicking.
+        assert!(TimeFilter::before(&format!("@{}", u64::MAX)).is_none());
+        assert!(TimeFilter::after(&format!("@{}", u64::MAX)).is_none());
+    }
 }

--- a/src/filter/time.rs
+++ b/src/filter/time.rs
@@ -42,7 +42,7 @@ impl TimeFilter {
             )
         } else {
             let timestamp_secs: u64 = s.strip_prefix('@')?.parse().ok()?;
-            Some(UNIX_EPOCH + Duration::from_secs(timestamp_secs))
+            UNIX_EPOCH.checked_add(Duration::from_secs(timestamp_secs))
         }
     }
 


### PR DESCRIPTION
Fixes #2081.

### Bug

`fd` panics instead of failing gracefully when a `@`-prefixed Unix timestamp passed to `--changed-before` / `--changed-within` is large enough to overflow `SystemTime`:

```
$ fd --changed-before "@18446744073709551615" . /tmp
thread 'main' panicked at library/std/src/time.rs:614:31:
overflow when adding duration to instant
```

### Fix

In `src/filter/time.rs`, the `@`-timestamp branch of `TimeFilter::from_str` used `UNIX_EPOCH + Duration::from_secs(...)`; `SystemTime`'s `Add<Duration>` panics on overflow. Every other branch in that function already fails softly via `.ok()?` — this one didn't.

Switched to `UNIX_EPOCH.checked_add(...)`, which returns `Option`, so an out-of-range value propagates `None` through the existing `?` and is rejected like any other unparseable time input (no behavior change for valid timestamps).

### Test

Added `out_of_range_unix_timestamp_is_rejected`, asserting `TimeFilter::before`/`after` with `@{u64::MAX}` return `None`. Verified it panics on `master` without the fix and passes with it; `cargo test --bin fd filter::time` is green and `cargo fmt --check` is clean.

CHANGELOG updated.

---
🤖 Disclosure (per CONTRIBUTING §4): the bug was found and the fix drafted with the help of an AI coding assistant; I reviewed it, reproduced the panic and the fails-before/passes-after behavior myself, and understand the change. This PR text is my own.
