### PR TITLE
Validate maximum thread count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add `--exact` option to match the entire filename exactly (literal, non-substring).
 
 ## Bugfixes
+- Reject `--threads` values above 64 instead of panicking during resource
+  allocation, see #2078 (@Sushanth012).
 - Sanitize control characters and bidirectional override characters in filenames
   when output goes to a terminal, to prevent terminal escape-sequence injection.
   Also reject a placeholder as the executable for `--exec-batch`, while still

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,8 @@ use crate::filesystem;
 use crate::filter::OwnerFilter;
 use crate::filter::SizeFilter;
 
+const MAX_NUM_THREADS: usize = 64;
+
 #[derive(Parser)]
 #[command(
     name = "fd",
@@ -553,7 +555,7 @@ pub struct Opts {
 
     /// Set number of threads to use for searching & executing (default: number
     /// of available CPU cores)
-    #[arg(long, short = 'j', value_name = "num", hide_short_help = true, value_parser = str::parse::<NonZeroUsize>)]
+    #[arg(long, short = 'j', value_name = "num", hide_short_help = true, value_parser = parse_num_threads)]
     pub threads: Option<NonZeroUsize>,
 
     /// Milliseconds to buffer before streaming search results to console
@@ -792,11 +794,23 @@ fn default_num_threads() -> NonZeroUsize {
     let fallback = NonZeroUsize::MIN;
     // To limit startup overhead on massively parallel machines, don't use more
     // than 64 threads.
-    let limit = NonZeroUsize::new(64).unwrap();
+    let limit = NonZeroUsize::new(MAX_NUM_THREADS).unwrap();
 
     std::thread::available_parallelism()
         .unwrap_or(fallback)
         .min(limit)
+}
+
+fn parse_num_threads(arg: &str) -> Result<NonZeroUsize, String> {
+    let threads = arg
+        .parse::<NonZeroUsize>()
+        .map_err(|error| error.to_string())?;
+    if threads.get() > MAX_NUM_THREADS {
+        return Err(format!(
+            "the number of threads cannot exceed {MAX_NUM_THREADS}"
+        ));
+    }
+    Ok(threads)
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]
@@ -967,5 +981,17 @@ fn ensure_current_directory_exists(current_directory: &Path) -> anyhow::Result<(
         Err(anyhow!(
             "Could not retrieve current directory (has it been deleted?)."
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_num_threads;
+
+    #[test]
+    fn number_of_threads_is_bounded() {
+        assert_eq!(parse_num_threads("64").unwrap().get(), 64);
+        assert!(parse_num_threads("65").is_err());
+        assert!(parse_num_threads("9223372036854775807").is_err());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use clap::{
-    Arg, ArgAction, ArgGroup, ArgMatches, Command, Parser, ValueEnum, error::ErrorKind,
-    value_parser,
+    Arg, ArgAction, ArgGroup, ArgMatches, Command, Parser, ValueEnum,
+    builder::RangedU64ValueParser, error::ErrorKind, value_parser,
 };
 #[cfg(feature = "completions")]
 use clap_complete::Shell;
@@ -565,8 +565,15 @@ pub struct Opts {
 
     /// Set number of threads to use for searching & executing (default: number
     /// of available CPU cores)
-    #[arg(long, short = 'j', value_name = "num", hide_short_help = true, value_parser = parse_num_threads)]
-    pub threads: Option<NonZeroUsize>,
+    #[arg(
+        long,
+        short = 'j',
+        value_name = "num",
+        hide_short_help = true,
+        value_parser = RangedU64ValueParser::<usize>::new()
+            .range(1..=MAX_NUM_THREADS as u64)
+    )]
+    pub threads: Option<usize>,
 
     /// Milliseconds to buffer before streaming search results to console
     ///
@@ -765,7 +772,9 @@ impl Opts {
     }
 
     pub fn threads(&self) -> NonZeroUsize {
-        self.threads.unwrap_or_else(default_num_threads)
+        self.threads.map_or_else(default_num_threads, |threads| {
+            NonZeroUsize::new(threads).expect("--threads is validated as nonzero")
+        })
     }
 
     pub fn max_results(&self) -> Option<usize> {
@@ -809,18 +818,6 @@ fn default_num_threads() -> NonZeroUsize {
     std::thread::available_parallelism()
         .unwrap_or(fallback)
         .min(limit)
-}
-
-fn parse_num_threads(arg: &str) -> Result<NonZeroUsize, String> {
-    let threads = arg
-        .parse::<NonZeroUsize>()
-        .map_err(|error| error.to_string())?;
-    if threads.get() > MAX_NUM_THREADS {
-        return Err(format!(
-            "the number of threads cannot exceed {MAX_NUM_THREADS}"
-        ));
-    }
-    Ok(threads)
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]
@@ -996,18 +993,18 @@ fn ensure_current_directory_exists(current_directory: &Path) -> anyhow::Result<(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_num_threads;
+    use super::{MAX_NUM_THREADS, Opts};
+    use clap::Parser;
 
     #[test]
     fn number_of_threads_is_bounded() {
-        assert_eq!(parse_num_threads("1").unwrap().get(), 1);
-        assert_eq!(parse_num_threads("64").unwrap().get(), 64);
-        assert_eq!(parse_num_threads("128").unwrap().get(), 128);
         assert_eq!(
-            parse_num_threads("65536").unwrap().get(),
-            super::MAX_NUM_THREADS
+            Opts::try_parse_from(["fd", "--threads", "65536"])
+                .unwrap()
+                .threads,
+            Some(MAX_NUM_THREADS)
         );
-        assert!(parse_num_threads("65537").is_err());
-        assert!(parse_num_threads("9223372036854775807").is_err());
+        assert!(Opts::try_parse_from(["fd", "--threads", "0"]).is_err());
+        assert!(Opts::try_parse_from(["fd", "--threads", "65537"]).is_err());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,17 @@ use crate::filesystem;
 use crate::filter::OwnerFilter;
 use crate::filter::SizeFilter;
 
-const MAX_NUM_THREADS: usize = 64;
+/// Upper bound for the `--threads` option. This is not meant to reflect the
+/// maximum number of useful threads (which depends on the OS, available
+/// memory, ulimit settings, etc.), but only to catch absurd values that
+/// would otherwise fail much later with a panic during channel or thread
+/// allocation.
+const MAX_NUM_THREADS: usize = 1 << 16;
+
+/// Cap for the implicit default thread count to limit startup overhead on
+/// massively parallel machines. Explicitly requested thread counts are only
+/// bounded by MAX_NUM_THREADS.
+const DEFAULT_NUM_THREADS_LIMIT: usize = 64;
 
 #[derive(Parser)]
 #[command(
@@ -793,8 +803,8 @@ fn default_num_threads() -> NonZeroUsize {
     // default to a single thread, because that is safe.
     let fallback = NonZeroUsize::MIN;
     // To limit startup overhead on massively parallel machines, don't use more
-    // than 64 threads.
-    let limit = NonZeroUsize::new(MAX_NUM_THREADS).unwrap();
+    // than DEFAULT_NUM_THREADS_LIMIT threads.
+    let limit = NonZeroUsize::new(DEFAULT_NUM_THREADS_LIMIT).unwrap();
 
     std::thread::available_parallelism()
         .unwrap_or(fallback)
@@ -990,8 +1000,14 @@ mod tests {
 
     #[test]
     fn number_of_threads_is_bounded() {
+        assert_eq!(parse_num_threads("1").unwrap().get(), 1);
         assert_eq!(parse_num_threads("64").unwrap().get(), 64);
-        assert!(parse_num_threads("65").is_err());
+        assert_eq!(parse_num_threads("128").unwrap().get(), 128);
+        assert_eq!(
+            parse_num_threads("65536").unwrap().get(),
+            super::MAX_NUM_THREADS
+        );
+        assert!(parse_num_threads("65537").is_err());
         assert!(parse_num_threads("9223372036854775807").is_err());
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2659,8 +2659,8 @@ fn test_number_parsing_errors() {
     te.assert_failure(&["--threads=a"]);
     te.assert_failure(&["-j", ""]);
     te.assert_failure(&["--threads=0"]);
-    te.assert_failure(&["--threads=65"]);
-    te.assert_failure(&["--threads=9223372036854775807"]);
+    let _ = te.assert_success_and_get_output(".", &["--threads=65"]);
+    te.assert_failure(&["--threads=65537"]);
 
     te.assert_failure(&["--min-depth=a"]);
     te.assert_failure(&["--mindepth=a"]);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2659,6 +2659,8 @@ fn test_number_parsing_errors() {
     te.assert_failure(&["--threads=a"]);
     te.assert_failure(&["-j", ""]);
     te.assert_failure(&["--threads=0"]);
+    te.assert_failure(&["--threads=65"]);
+    te.assert_failure(&["--threads=9223372036854775807"]);
 
     te.assert_failure(&["--min-depth=a"]);
     te.assert_failure(&["--mindepth=a"]);


### PR DESCRIPTION
## Summary

Validate explicit `--threads` values during CLI argument parsing and reject values outside `1..=65536`.

Previously, excessively large values could be accepted and later trigger panics or aborts during channel allocation or thread creation. The implicit default remains capped at 64 threads to limit startup overhead, while users on high-core-count systems can explicitly request larger values.

## Changes

- use Clap built-in ranged integer validation for `--threads`
- accept explicit values from 1 through 65536
- retain the separate 64-thread implicit default cap
- test both accepted and rejected range boundaries
- document the fix in the changelog

## Testing

- `cargo fmt --check`
- `cargo test --bin fd` (147 passed)
- `cargo clippy --bin fd -- -D warnings`
- the focused Windows integration test is blocked during test-environment setup by OS error 1314 because symlink privileges are unavailable; it fails before reaching the parser assertions

## Fixes

Closes #2078

## AI usage

OpenCode was used to inspect the review feedback and assist with the implementation and validation of the follow-up change.