### PR TITLE
fix: do not list hidden files negated in .gitignore without --hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Also fire the "search pattern contains a path separator" diagnostic for `--and` patterns, not only the primary positional pattern. `--and` patterns are matched against the file name just like the primary pattern, so a path separator in them silently returned zero results. See #1873.
 - Fix bug where passing "-" as a directory argument didn't actually search that directory, see #849 (@Sean-Kenneth-Doherty).
 - Fix panic when `--changed-before`/`--changed-within` is given an out-of-range `@` Unix timestamp; the value is now rejected gracefully, see #2081 (@nikolauspschuetz).
-- Fix hidden files being listed when a `.gitignore` pattern negates them, even without `--hidden`, see #1266 (@SomSamantray).
+- Fix dot-prefixed hidden files being listed when a `.gitignore` pattern negates them, even without `--hidden`, see #1266 (@SomSamantray).
 
 # 10.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Also fire the "search pattern contains a path separator" diagnostic for `--and` patterns, not only the primary positional pattern. `--and` patterns are matched against the file name just like the primary pattern, so a path separator in them silently returned zero results. See #1873.
 - Fix bug where passing "-" as a directory argument didn't actually search that directory, see #849 (@Sean-Kenneth-Doherty).
 - Fix panic when `--changed-before`/`--changed-within` is given an out-of-range `@` Unix timestamp; the value is now rejected gracefully, see #2081 (@nikolauspschuetz).
+- Fix hidden files being listed when a `.gitignore` pattern negates them, even without `--hidden`, see #1266 (@SomSamantray).
 
 # 10.4.2
 

--- a/docs/residual-review-findings/3bd8980b5250d0e969adf36b45b64d784ca868f8.md
+++ b/docs/residual-review-findings/3bd8980b5250d0e969adf36b45b64d784ca868f8.md
@@ -1,0 +1,12 @@
+# Residual Review Findings
+
+Run context: LFG pipeline for sharkdp/fd issue #1266 (hidden files wrongly listed when negated in `.gitignore`). Plan: `docs/plans/2026-08-15-001-fix-hidden-gitignore-negation-plan.md`. Review run: `ce-code-review mode:agent`, run id `20260815-212237-5e098adb`, artifact at `/tmp/compound-engineering-501/ce-code-review/20260815-212237-5e098adb/`.
+
+## Residual Review Findings
+
+- P3 — `src/walk.rs:515` — Hidden check only covers dot-prefix names, so attribute-hidden entries with non-dot names still leak on Windows when un-ignored by a gitignore negation — tracker ticket: https://github.com/sharkdp/fd/issues/2096
+
+## Not applied in step 5
+
+- #1 (above): fix is a behavior change (per-entry attribute metadata checks on Windows) conflicting with the plan's documented name-based, no-syscall decision (KTD1); documented as a limitation in the plan's Assumptions and in the PR description. Filed as issue #2096.
+- Broken-symlink dot-prefix coverage gap (advisory, anchor 50): routed to `testing_gaps`; not eligible for apply per the review-followup bar.

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -511,6 +511,19 @@ impl WorkerState {
                     return WalkState::Continue;
                 }
 
+                // Never show hidden entries unless --hidden is set. This is enforced here
+                // instead of relying on the ignore crate's hidden filter, because a negated
+                // ignore pattern overrides that filter (see #1266). Skipping prunes hidden
+                // directories as well, so their contents are not searched.
+                if config.ignore_hidden
+                    && entry
+                        .path()
+                        .file_name()
+                        .is_some_and(|name| name.as_encoded_bytes().first() == Some(&b'.'))
+                {
+                    return WalkState::Skip;
+                }
+
                 // Check the name first, since it doesn't require metadata
                 let entry_path = entry.path();
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -505,28 +505,26 @@ impl WorkerState {
                     }
                 };
 
+                // Never show dot-prefixed hidden entries unless --hidden is set. This is
+                // enforced here instead of relying on the ignore crate's hidden filter,
+                // because a negated ignore pattern overrides that filter (see #1266).
+                // Skipping prunes hidden directories as well, so their contents are not
+                // searched.
+                let entry_path = entry.path();
+                let file_name = entry_path.file_name();
+                if config.ignore_hidden
+                    && file_name.is_some_and(|name| name.as_encoded_bytes().first() == Some(&b'.'))
+                {
+                    return WalkState::Skip;
+                }
+
                 if let Some(min_depth) = config.min_depth
                     && entry.depth().is_none_or(|d| d < min_depth)
                 {
                     return WalkState::Continue;
                 }
 
-                // Never show hidden entries unless --hidden is set. This is enforced here
-                // instead of relying on the ignore crate's hidden filter, because a negated
-                // ignore pattern overrides that filter (see #1266). Skipping prunes hidden
-                // directories as well, so their contents are not searched.
-                if config.ignore_hidden
-                    && entry
-                        .path()
-                        .file_name()
-                        .is_some_and(|name| name.as_encoded_bytes().first() == Some(&b'.'))
-                {
-                    return WalkState::Skip;
-                }
-
                 // Check the name first, since it doesn't require metadata
-                let entry_path = entry.path();
-
                 let search_str = search_str_for_entry(entry_path, config.full_path_base.as_deref());
 
                 if !patterns
@@ -538,7 +536,7 @@ impl WorkerState {
 
                 // Filter out unwanted extensions.
                 if let Some(ref exts_regex) = config.extensions {
-                    if let Some(path_str) = entry_path.file_name() {
+                    if let Some(path_str) = file_name {
                         if !exts_regex.is_match(&filesystem::osstr_to_bytes(path_str)) {
                             return WalkState::Continue;
                         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -714,6 +714,10 @@ fn test_hidden_negated_gitignore() {
     // A negated hidden directory is not searched without --hidden.
     te.assert_output(&["x.txt"], "");
     te.assert_output(&["--hidden", "x.txt"], ".hdir/x.txt");
+
+    // The hidden check applies regardless of --min-depth.
+    te.assert_output(&["--min-depth", "2", "x.txt"], "");
+    te.assert_output(&["--hidden", "--min-depth", "2", "x.txt"], ".hdir/x.txt");
 }
 
 /// Hidden file attribute on Windows

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -694,6 +694,28 @@ fn test_hidden() {
     );
 }
 
+/// Hidden entries un-ignored by a negated .gitignore pattern must stay hidden without --hidden
+#[test]
+fn test_hidden_negated_gitignore() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    fs::File::create(te.test_root().join(".gitignore"))
+        .unwrap()
+        .write_all(b"!.gitignore\n!.hdir/")
+        .unwrap();
+    fs::create_dir(te.test_root().join(".hdir")).unwrap();
+    fs::File::create(te.test_root().join(".hdir").join("x.txt")).unwrap();
+
+    // The negation un-ignores .gitignore, but it is a hidden file and must not be
+    // listed without --hidden.
+    te.assert_output(&[".gitignore"], "");
+    te.assert_output(&["--hidden", ".gitignore"], ".gitignore");
+
+    // A negated hidden directory is not searched without --hidden.
+    te.assert_output(&["x.txt"], "");
+    te.assert_output(&["--hidden", "x.txt"], ".hdir/x.txt");
+}
+
 /// Hidden file attribute on Windows
 #[cfg(windows)]
 #[test]


### PR DESCRIPTION
Without `--hidden`, `fd` now never lists dot-prefixed hidden entries, even when a `.gitignore` pattern negates them. Previously, a negation such as `!.gitignore` bypassed the ignore crate's hidden filter and the file was listed; negated hidden directories were traversed as well. Hidden directories are now pruned, so their contents are not searched. With `--hidden`, behavior is unchanged.

The check is name-based and runs before the `--min-depth` guard, so the hidden contract holds regardless of depth configuration.

Fixes #1266

One known limitation: on Windows, files hidden via `FILE_ATTRIBUTE_HIDDEN` whose names lack a leading dot are not covered by the name-based check. The follow-up is tracked separately (see Related).

Related: #2096

Validation: new regression test `test_hidden_negated_gitignore` fails on master and passes here. It covers self-negated hidden files, negated hidden directories, and `--min-depth` interplay. Full suite: 157 unit + 109 integration tests pass; `cargo fmt` and `cargo clippy --all-targets --all-features -- -Dwarnings` are clean. Manual repro of the issue verified against a local build.

Session-settled decisions carried from planning: no third-party branding on this PR (user-directed); fd contribution guidelines followed (user-directed).

AI disclosure: This PR was produced with the assistance of an AI coding assistant (fix implementation, regression test, changelog entry, and PR scaffolding) and was reviewed by the human author before submission.
