### PR TITLE
docs: update Guix package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ winget install sharkdp.fd
 
 ### On GuixOS
 
-You can install [the fd package](https://packages.guix.gnu.org/packages/fd/) from the official repo:
+You can install [the fd package](https://packages.guix.gnu.org/packages/fd/10.4.2/) from the official repo:
 ```
 guix install fd
 ```

--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ winget install sharkdp.fd
 
 ### On GuixOS
 
-You can install [the fd package](https://guix.gnu.org/en/packages/fd-8.1.1/) from the official repo:
+You can install [the fd package](https://packages.guix.gnu.org/packages/fd/) from the official repo:
 ```
 guix install fd
 ```


### PR DESCRIPTION
## Problem

The Guix install section linked to a version-pinned page
`https://guix.gnu.org/en/packages/fd-8.1.1/`. That URL no longer serves the
package page; GET follows to the packages index (`https://packages.guix.gnu.org/`)
instead of the fd package.

The current package page is `https://packages.guix.gnu.org/packages/fd/`.

Verified:

    GET https://guix.gnu.org/en/packages/fd-8.1.1/ -> 200, final URL is https://packages.guix.gnu.org/
    GET https://packages.guix.gnu.org/packages/fd/ -> 200, stays on the fd package page

## Solution

Link the unversioned Guix package page so the README does not go stale
when fd's Guix version changes.

## Verification

GET `https://packages.guix.gnu.org/packages/fd/` returns 200.

Documentation-only README change. I did not add a CHANGELOG entry because
this does not change fd's runtime behavior.
