### PR TITLE
Clamp --threads to a sane maximum to avoid panic/abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Also fire the "search pattern contains a path separator" diagnostic for `--and` patterns, not only the primary positional pattern. `--and` patterns are matched against the file name just like the primary pattern, so a path separator in them silently returned zero results. See #1873.
 - Fix bug where passing "-" as a directory argument didn't actually search that directory, see #849 (@Sean-Kenneth-Doherty).
 - Fix panic when `--changed-before`/`--changed-within` is given an out-of-range `@` Unix timestamp; the value is now rejected gracefully, see #2081 (@nikolauspschuetz).
-- Fix panic/abort when `--threads`/`-j` is given an unsatisfiably large value (e.g. `-j 9223372036854775807`, which overflowed the `2 * threads` channel capacity, or `-j 200000 --exec`, which exhausted thread creation). The thread count is now clamped to a sane maximum, see #2078 (@nagendramohan).
+- Fix panic/abort when `--threads`/`-j` is given an unsatisfiably large value (e.g. `-j 9223372036854775807`, which overflowed the `2 * threads` channel capacity, or `-j 200000 --exec`, which exhausted thread creation). The thread count is now clamped to a sane maximum, see #2078 and #2099 (@nagendramohan).
 
 # 10.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Also fire the "search pattern contains a path separator" diagnostic for `--and` patterns, not only the primary positional pattern. `--and` patterns are matched against the file name just like the primary pattern, so a path separator in them silently returned zero results. See #1873.
 - Fix bug where passing "-" as a directory argument didn't actually search that directory, see #849 (@Sean-Kenneth-Doherty).
 - Fix panic when `--changed-before`/`--changed-within` is given an out-of-range `@` Unix timestamp; the value is now rejected gracefully, see #2081 (@nikolauspschuetz).
+- Fix panic/abort when `--threads`/`-j` is given an unsatisfiably large value (e.g. `-j 9223372036854775807`, which overflowed the `2 * threads` channel capacity, or `-j 200000 --exec`, which exhausted thread creation). The thread count is now clamped to a sane maximum, see #2078 (@nagendramohan).
 
 # 10.4.2
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -753,7 +753,13 @@ impl Opts {
     }
 
     pub fn threads(&self) -> NonZeroUsize {
-        self.threads.unwrap_or_else(default_num_threads)
+        // Clamp the requested thread count to a sane maximum. Using far more worker threads than
+        // the machine can run provides no benefit for fd's workload, and pathological values
+        // otherwise overflow the work-channel capacity (`2 * threads`) or exhaust thread creation
+        // with `--exec`, surfacing as a panic/abort instead of a normal run. See #2078.
+        self.threads
+            .unwrap_or_else(default_num_threads)
+            .min(max_num_threads())
     }
 
     pub fn max_results(&self) -> Option<usize> {
@@ -797,6 +803,18 @@ fn default_num_threads() -> NonZeroUsize {
     std::thread::available_parallelism()
         .unwrap_or(fallback)
         .min(limit)
+}
+
+/// Upper bound on worker threads for an explicit `--threads`/`-j` value.
+///
+/// Using more worker threads than the hardware can run provides no benefit for fd's workload, and
+/// unbounded values otherwise overflow the work-channel capacity (`2 * threads`) or exhaust thread
+/// creation with `--exec`, aborting the process (#2078). We never clamp below the machine's
+/// available parallelism, nor below the 64-thread default cap, so realistic values are unaffected.
+fn max_num_threads() -> NonZeroUsize {
+    let floor = NonZeroUsize::new(64).unwrap();
+    let hardware = std::thread::available_parallelism().unwrap_or(NonZeroUsize::MIN);
+    hardware.max(floor)
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -79,6 +79,26 @@ fn test_simple() {
     );
 }
 
+/// Regression test for #2078: a pathologically large `--threads`/`-j` value must not overflow the
+/// work-channel capacity (`2 * threads`) and abort. The requested count is clamped, so the search
+/// still runs and returns the correct results.
+#[test]
+fn test_threads_large_value_does_not_panic() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_output(&["--threads", "9223372036854775807", "a.foo"], "a.foo");
+    te.assert_output(&["-j", "200000", "a.foo"], "a.foo");
+}
+
+/// Regression test for #2078: a large `--threads` value combined with `--exec` must not exhaust
+/// thread creation and abort.
+#[test]
+fn test_threads_large_value_with_exec_does_not_panic() {
+    let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    te.assert_success_and_get_output(".", &["-j", "200000", "a.foo", "--exec", "echo"]);
+}
+
 static AND_EXTRA_FILES: &[&str] = &[
     "a.foo",
     "one/b.foo",

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -86,7 +86,10 @@ fn test_simple() {
 fn test_threads_large_value_does_not_panic() {
     let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
 
-    te.assert_output(&["--threads", "9223372036854775807", "a.foo"], "a.foo");
+    // `usize::MAX` is portable across 32- and 64-bit targets; without the clamp, `2 * threads`
+    // overflows the work-channel capacity and aborts.
+    let huge = usize::MAX.to_string();
+    te.assert_output(&["--threads", &huge, "a.foo"], "a.foo");
     te.assert_output(&["-j", "200000", "a.foo"], "a.foo");
 }
 


### PR DESCRIPTION
fd -j N parses N into an unbounded thread count. Pathological values then either overflow the work-channel capacity (bounded(2 * threads), 'capacity overflow', exit 101 on every run) or exhaust thread creation with --exec ('failed to spawn thread', abort).

Clamp the resolved thread count to max(available_parallelism, 64) — more worker threads than the machine can run give fd no benefit, and this never clamps below the hardware parallelism nor below the existing 64-thread default cap, so realistic values are unaffected.

Adds regression tests (verified failing before the fix) and a CHANGELOG entry. Closes #2078.

Closes #2078.

fd -j N parses N into an unbounded thread count, so pathological values crash:
- fd -j 9223372036854775807 . → capacity overflow (exit 101) — the work channel is bounded(2 * threads). Happens on every run.
- fd -j 200000 -x echo . → failed to spawn thread → abort (exit 134) with --exec.

Fix: clamp the resolved thread count to max(available_parallelism(), 64). More worker threads than the machine can run provide no benefit for fd's workload, and this never clamps below the hardware parallelism nor below the existing 64-thread default cap (default_num_threads), so realistic values are unaffected. Happy to switch to a hard error or a different bound if you'd prefer — flagging the policy choice.

Adds regression tests (verified failing before the fix) and a CHANGELOG entry. cargo fmt --check, cargo clippy --all-targets, and the full test suite pass.