### PR TITLE
fix: don't let --type executable/empty filter out other requested types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Also fire the "search pattern contains a path separator" diagnostic for `--and` patterns, not only the primary positional pattern. `--and` patterns are matched against the file name just like the primary pattern, so a path separator in them silently returned zero results. See #1873.
 - Fix bug where passing "-" as a directory argument didn't actually search that directory, see #849 (@Sean-Kenneth-Doherty).
 - Fix panic when `--changed-before`/`--changed-within` is given an out-of-range `@` Unix timestamp; the value is now rejected gracefully, see #2081 (@nikolauspschuetz).
+- Fix `--type executable`/`--type empty` incorrectly filtering out other explicitly-requested types. When combined with e.g. `--type symlink`, the `executable`/`empty` modifier was applied to *all* results, so non-executable / non-empty symlinks (and other types) were dropped even though `--type` values are meant to be combined as a union.
 
 # 10.4.2
 

--- a/src/filetypes.rs
+++ b/src/filetypes.rs
@@ -27,8 +27,15 @@ impl FileTypes {
                 || (!self.char_devices && filesystem::is_char_device(*entry_type))
                 || (!self.sockets && filesystem::is_socket(*entry_type))
                 || (!self.pipes && filesystem::is_pipe(*entry_type))
-                || (self.executables_only && !entry.path().executable())
-                || (self.empty_only && !filesystem::is_empty(entry))
+                // The `executable` and `empty` modifiers only refine the file (and, for
+                // `empty`, directory) results they apply to. They must not filter out other
+                // explicitly-requested types such as symlinks, which are matched as a union.
+                || (self.executables_only
+                    && entry_type.is_file()
+                    && !entry.path().executable())
+                || (self.empty_only
+                    && (entry_type.is_file() || entry_type.is_dir())
+                    && !filesystem::is_empty(entry))
                 || !(entry_type.is_file()
                     || entry_type.is_dir()
                     || entry_type.is_symlink()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1438,6 +1438,81 @@ fn test_type_empty() {
     te.assert_output(&["--type", "empty", "--type", "directory"], "dir_empty/");
 }
 
+/// The `executable` type modifier must only constrain the file results it
+/// applies to. When another type such as `symlink` is requested in addition,
+/// those entries must still be included even if they are not executable.
+#[cfg(unix)]
+#[test]
+fn test_type_executable_combined_with_symlink() {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    // This test assumes the current user isn't root
+    // (otherwise if the executable bit is set for any level, it is executable for the current
+    // user)
+    if Uid::current().is_root() {
+        return;
+    }
+
+    let mut te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
+
+    fs::OpenOptions::new()
+        .create_new(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o777)
+        .open(te.test_root().join("executable-file.sh"))
+        .unwrap();
+
+    // A broken symlink is a symlink that is not executable.
+    te.create_broken_symlink("broken_symlink").unwrap();
+
+    // `--type executable` on its own only lists executable regular files.
+    te.assert_output(&["--type", "executable"], "executable-file.sh");
+
+    // Adding `--type symlink` must additionally list *all* symlinks, including
+    // the non-executable broken symlink. `symlink` is the pre-existing symlink
+    // in the test fixture (pointing at a directory).
+    te.assert_output(
+        &["--type", "executable", "--type", "symlink"],
+        "executable-file.sh
+        symlink
+        broken_symlink",
+    );
+}
+
+/// The `empty` type modifier must only constrain the file/directory results it
+/// applies to. When another type such as `symlink` is requested in addition,
+/// those entries must still be included even if they are not empty.
+#[cfg(unix)]
+#[test]
+fn test_type_empty_combined_with_symlink() {
+    let mut te = TestEnv::new(&["dir_empty"], &[]);
+
+    create_file_with_size(te.test_root().join("0_bytes.foo"), 0);
+    create_file_with_size(te.test_root().join("5_bytes.foo"), 5);
+
+    // A broken symlink is a symlink that is not considered empty.
+    te.create_broken_symlink("broken_symlink").unwrap();
+
+    // `--type empty` on its own only lists empty files and directories.
+    te.assert_output(
+        &["--type", "empty"],
+        "0_bytes.foo
+        dir_empty/",
+    );
+
+    // Adding `--type symlink` must additionally list *all* symlinks, including
+    // the non-empty broken symlink. `symlink` is the symlink from the test
+    // fixture (dangling here, as its target does not exist in this environment).
+    te.assert_output(
+        &["--type", "empty", "--type", "symlink"],
+        "0_bytes.foo
+        dir_empty/
+        broken_symlink
+        symlink",
+    );
+}
+
 /// File extension (--extension)
 #[test]
 fn test_extension() {


### PR DESCRIPTION
`--type` is documented to combine multiple values as a union — the `--help` text says specifying `--type` more than once "include[s] multiple file types", giving `--type file --type symlink` as an example that shows both regular files and symlinks.

However, the `executable` and `empty` type values were applied as global filters in `FileTypes::should_ignore`, so combining either with another type dropped that other type's entries whenever they weren't executable/empty. For example, `fd --type executable --type symlink` omits every non-executable symlink, and `fd --type empty --type symlink` omits every non-empty symlink, even though the symlinks were explicitly requested.

This scopes each modifier to the results it actually refines: `executable` to regular files, and `empty` to files and directories. Single-type behavior (`--type executable`, `--type empty`) is unchanged. This is consistent with the existing `test_type_executable` test, which already expects `--type executable --type directory` to list all directories as a union.

Added regression tests (`test_type_executable_combined_with_symlink`, `test_type_empty_combined_with_symlink`) that fail before the change and pass after. `cargo fmt`, `cargo clippy -- -D warnings`, and the full test suite pass.

*AI-usage disclosure (per CONTRIBUTING): this change was prepared with the assistance of an AI coding tool.*
