### PR TITLE
feat: add --no-ignore-vcs-exclude / --ignore-vcs-exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Features
+- Add `--no-ignore-vcs-exclude` option to show search results that would otherwise be ignored by `.git/info/exclude`, while still respecting other gitignore files, see #1612 and #1652 (@AckslD)
 - Add `--ignore-parent` option to override `--no-ignore-parent`, see #1958 (@tmchow)
 - Add `--exact` option to match the entire filename exactly (literal, non-substring).
 

--- a/contrib/completion/_fd
+++ b/contrib/completion/_fd
@@ -58,6 +58,7 @@ _fd() {
 
     + no-ignore-partial # some ignore files
     "(no-ignore-full --no-ignore-vcs)--no-ignore-vcs[don't respect .gitignore files]"
+    "(no-ignore-full --no-ignore-vcs --no-ignore-vcs-exclude)--no-ignore-vcs-exclude[don't respect .git/info/exclude files]"
     "!(no-ignore-full --no-global-ignore-file)--no-global-ignore-file[don't respect the global ignore file]"
     $no'(no-ignore-full --no-ignore-parent)--no-ignore-parent[]'
 

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -85,6 +85,12 @@ git setting, which defaults to
 .IR $HOME/.config/git/ignore ).
 The flag can be overridden with '--ignore-vcs'.
 .TP
+.B \-\-no\-ignore\-vcs\-exclude
+Show search results from files and directories that would otherwise be ignored by
+.IR .git/info/exclude .
+Other gitignore files are still respected unless '--no-ignore-vcs' is also used.
+The flag can be overridden with '--ignore-vcs-exclude'.
+.TP
 .B \-\-no\-require\-git
 Do not require a git repository to respect gitignores. By default, fd will only
 respect global gitignore rules, .gitignore rules and local exclude rules if fd

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,6 +78,22 @@ pub struct Opts {
     #[arg(long, overrides_with = "no_ignore_vcs", hide = true, action = ArgAction::SetTrue)]
     ignore_vcs: (),
 
+    ///Show search results from files and directories that
+    ///would otherwise be ignored by '.git/info/exclude'.
+    ///Git ignore files are still respected unless --no-ignore-vsc is given.
+    ///The flag can be overridden with --ignore-vcs.
+    #[arg(
+        long,
+        hide_short_help = true,
+        help = "Do not respect .git/info/exclude",
+        long_help
+    )]
+    pub no_ignore_vcs_exclude: bool,
+
+    /// Overrides --no-ignore-vcs-exclude
+    #[arg(long, overrides_with = "no_ignore_vcs_exclude", hide = true, action = ArgAction::SetTrue)]
+    ignore_vcs_exclude: (),
+
     /// Do not require a git repository to respect gitignores.
     /// By default, fd will only respect global gitignore rules, .gitignore rules,
     /// and local exclude rules if fd detects that you are searching inside a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,8 +80,8 @@ pub struct Opts {
 
     ///Show search results from files and directories that
     ///would otherwise be ignored by '.git/info/exclude'.
-    ///Git ignore files are still respected unless --no-ignore-vsc is given.
-    ///The flag can be overridden with --ignore-vcs.
+    ///Git ignore files are still respected unless --no-ignore-vcs is given.
+    ///The flag can be overridden with --ignore-vcs-exclude.
     #[arg(
         long,
         hide_short_help = true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,9 @@ pub struct Config {
     /// Whether to respect VCS ignore files (`.gitignore`, ..) or not.
     pub read_vcsignore: bool,
 
+    /// Whether to respect VCS exclude files (`.git/info/exclude`, ..) or not.
+    pub read_vcsexclude: bool,
+
     /// Whether to require a `.git` directory to respect gitignore files.
     pub require_git_to_read_vcsignore: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,6 +313,10 @@ fn construct_config(mut opts: Opts, pattern_regexps: &[String]) -> Result<Config
         ignore_hidden: !(opts.hidden || opts.rg_alias_ignore()),
         read_fdignore: !(opts.no_ignore || opts.rg_alias_ignore()),
         read_vcsignore: !(opts.no_ignore || opts.rg_alias_ignore() || opts.no_ignore_vcs),
+        read_vcsexclude: !(opts.no_ignore
+            || opts.rg_alias_ignore()
+            || opts.no_ignore_vcs
+            || opts.no_ignore_vcs_exclude),
         require_git_to_read_vcsignore: !opts.no_require_git,
         read_parent_ignore: !opts.no_ignore_parent,
         read_global_ignore: !(opts.no_ignore

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -356,7 +356,7 @@ impl WorkerState {
             .parents(config.read_parent_ignore && (config.read_fdignore || config.read_vcsignore))
             .git_ignore(config.read_vcsignore)
             .git_global(config.read_vcsignore)
-            .git_exclude(config.read_vcsignore)
+            .git_exclude(config.read_vcsexclude)
             .require_git(config.require_git_to_read_vcsignore)
             .overrides(overrides)
             .follow_links(config.follow_links)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -972,6 +972,53 @@ fn test_no_ignore_vcs_child_dir() {
     );
 }
 
+/// VCS exclude files (--no-ignore-vcs-exclude)
+#[test]
+fn test_no_ignore_vcs_exclude() {
+    let files = &[
+        "ignored-by-nothing",
+        "ignored-by-gitignore",
+        "ignored-by-exclude",
+    ];
+    let te = TestEnv::new(&[], files);
+
+    fs::File::create(te.test_root().join(".gitignore"))
+        .unwrap()
+        .write_all(b"ignored-by-gitignore")
+        .unwrap();
+
+    fs::create_dir_all(te.test_root().join(".git/info")).unwrap();
+    fs::File::create(te.test_root().join(".git/info/exclude"))
+        .unwrap()
+        .write_all(b"ignored-by-exclude")
+        .unwrap();
+
+    te.assert_output(&["ignored"], "ignored-by-nothing");
+
+    // Files ignored via .git/info/exclude are shown, but .gitignore is still respected
+    te.assert_output(
+        &["--no-ignore-vcs-exclude", "ignored"],
+        "ignored-by-nothing
+        ignored-by-exclude",
+    );
+
+    // --ignore-vcs-exclude overrides --no-ignore-vcs-exclude
+    te.assert_output(
+        &["--no-ignore-vcs-exclude", "--ignore-vcs-exclude", "ignored"],
+        "ignored-by-nothing",
+    );
+
+    // --no-ignore-vcs, --no-ignore and -u also disable .git/info/exclude
+    for flag in ["--no-ignore-vcs", "--no-ignore", "-u"] {
+        te.assert_output(
+            &[flag, "ignored"],
+            "ignored-by-nothing
+            ignored-by-gitignore
+            ignored-by-exclude",
+        );
+    }
+}
+
 /// Custom ignore files (--ignore-file)
 #[test]
 fn test_custom_ignore_files() {
@@ -2674,6 +2721,7 @@ fn test_number_parsing_errors() {
 #[test_case("--hidden", &["--no-hidden"] ; "hidden")]
 #[test_case("--no-ignore", &["--ignore"] ; "no-ignore")]
 #[test_case("--no-ignore-vcs", &["--ignore-vcs"] ; "no-ignore-vcs")]
+#[test_case("--no-ignore-vcs-exclude", &["--ignore-vcs-exclude"] ; "no-ignore-vcs-exclude")]
 #[test_case("--no-require-git", &["--require-git"] ; "no-require-git")]
 #[test_case("--follow", &["--no-follow"] ; "follow")]
 #[test_case("--absolute-path", &["--relative-path"] ; "absolute-path")]


### PR DESCRIPTION
Closes #1612. Supersedes #1652 — this takes @AckslD's original commit (rebased onto current master) and completes the review feedback from that PR.

Adds `--no-ignore-vcs-exclude`, which shows results that would otherwise be ignored by `.git/info/exclude` while still respecting `.gitignore` and other ignore files. The motivation (from #1612) is that these two kinds of ignore files tend to serve different purposes: `.gitignore` is committed and typically lists generated or automatic files that nobody wants to see, while `.git/info/exclude` is often used for personal files that you actively use and *do* want to find — you just don't want to commit them or impose them on the repo. This flag lets you keep those personal files visible in searches without giving up gitignore filtering entirely. `--ignore-vcs-exclude` overrides it, following the existing flag-pair convention.

On top of the original commit: integration tests (including interaction with `--no-ignore-vcs`, `--no-ignore`, and `-u`, plus an override-pair case), CHANGELOG entry, man page entry, zsh completion entry, and two typo fixes in the flag's long help.

**AI disclosure** (per the contributing guide): the follow-up commit (tests, docs, changelog, typo fixes) was written with an AI coding assistant (Claude Code) under my direction, and I have reviewed the changes. The original feature commit is human-written by @AckslD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
