### PR TITLE
Escape Unicode line/paragraph separators (U+2028, U+2029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 -
 
 ## Bugfixes
--
+- Escape U+2028 (line separator) and U+2029 (paragraph separator) when sanitizing paths for terminal output, so a filename can't forge terminal lines, see #2105 (@nikolauspschuetz)
 
 # 10.5.0
 

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -15,6 +15,7 @@ fn needs_escape(c: char) -> bool {
             '\u{00AD}'                  // soft hyphen (invisible)
             | '\u{180E}'                // Mongolian vowel separator
             | '\u{200B}'..='\u{200F}'   // zero-width + LRM/RLM
+            | '\u{2028}'..='\u{2029}'   // line + paragraph separators
             | '\u{202A}'..='\u{202E}'   // bidi embedding/override
             | '\u{2060}'..='\u{206F}'   // word joiner, invisibles, deprecated formats
             | '\u{FEFF}'                // BOM / zero-width no-break space
@@ -137,6 +138,12 @@ mod tests {
         // Zero-width space and BOM are also format chars used to disguise filenames.
         assert_eq!(sanitize_for_terminal("a\u{200B}b"), "a\\u{200B}b");
         assert_eq!(sanitize_for_terminal("\u{FEFF}name"), "\\u{FEFF}name");
+    }
+
+    #[test]
+    fn strips_unicode_line_separators() {
+        assert_eq!(sanitize_for_terminal("A\u{2028}B"), "A\\u{2028}B");
+        assert_eq!(sanitize_for_terminal("A\u{2029}B"), "A\\u{2029}B");
     }
 
     #[test]


### PR DESCRIPTION
`needs_escape` omitted **U+2028** (line separator) and **U+2029** (paragraph separator). `char::is_control()` doesn't cover them, yet many terminals render them as a line break — so a crafted filename could still forge terminal output lines, which is exactly what this sanitizer exists to prevent.

Adds `'\u{2028}'..='\u{2029}'` to `needs_escape` and a `strips_unicode_line_separators` test.

Verified locally: the new test passes with the fix and fails without it; `cargo test --bin fd sanitize` is green (13 tests) and `cargo fmt --check` is clean.

<sub>Developed with AI assistance (Claude Code); I directed, reviewed, and verified it locally.</sub>
