### PR TITLE
fix: don't sanitize error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 -
 
 ## Bugfixes
--
+- Don't incorrectly escape newlines in error messages, see #2104
 
 # 10.5.0
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,3 @@
-use std::io::IsTerminal;
-
-use crate::sanitize::maybe_sanitize;
-
-pub fn print_error(msg: impl Into<String>) {
-    let msg = msg.into();
-    let safe = maybe_sanitize(&msg, std::io::stderr().is_terminal());
-    eprintln!("[fd error]: {safe}");
+pub fn print_error(msg: impl std::fmt::Display) {
+    eprintln!("[fd error]: {msg}");
 }


### PR DESCRIPTION
Calling `maybe_sanitize` on error messages results in newlines getting replaced with "\x0a". This is not desirable for error messages that have newlines.

I audited everwhere we construct an error, and call print_error and confirmed that none of those places have inputs that include found paths. I'm not too worried about inputs that come from command line arguments.

This bug was introduced in 92c54d37c0a3425b4d8b25dd8c9e4ddbbecfbe0a.

Fixes: #2104