### PR TITLE
fix: Re-enable jemalloc by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bugfixes
 - Don't incorrectly escape newlines in error messages, see #2104
+- Restore jemalloc as default allocator on supported systems
 
 # 10.5.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ codegen-units = 1
 use-jemalloc = ["tikv-jemallocator"]
 completions = ["clap_complete"]
 base = ["use-jemalloc"]
-default = ["completions"]
+default = ["use-jemalloc", "completions"]
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }.{ archive-format }"


### PR DESCRIPTION
The "use-jemalloc" feature was accidentally removed from the default
features in 92c54d37c0a3425b4d8b25dd8c9e4ddbbecfbe0a.

This turns it back on.
