### PR TITLE
fix: preserve newlines in terminal-sanitized error messages

### DIFF
--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -3,11 +3,11 @@
 use std::borrow::Cow;
 use std::fmt::Write;
 
-/// True for any char that is neither printable nor permitted whitespace (only HT).
+/// True for any char that is neither printable nor permitted whitespace (HT, LF).
 /// Covers C0/C1/DEL, bidi overrides, zero-width and format chars, and tag chars.
 #[inline]
 fn needs_escape(c: char) -> bool {
-    if c == '\t' {
+    if c == '\t' || c == '\n' {
         return false;
     }
     c.is_control()
@@ -107,8 +107,8 @@ mod tests {
     }
 
     #[test]
-    fn strips_newline() {
-        assert_eq!(sanitize_for_terminal("a\nb"), "a\\x0Ab");
+    fn preserves_newline() {
+        assert_eq!(sanitize_for_terminal("a\nb"), "a\nb");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The TTY-output sanitizer in `src/sanitize.rs` escapes all control characters, including `\n` (U+000A). This causes multi-line error messages to render as single lines with literal `\x0A` on terminals.

**Before (broken):**
```
[fd error]: The search pattern 'foo/bar' contains a path-separation character and will not lead to any search results.\x0A\x0AIf you want to search for all files inside the 'foo/bar' directory, use a match-all pattern:\x0A\x0A  fd . 'foo/bar'\x0A\x0AInstead, if you want your pattern to match the full file path, use:\x0A\x0A  fd --full-path 'foo/bar'
```

**After (fixed):**
```
[fd error]: The search pattern 'foo/bar' contains a path-separation character and will not lead to any search results.

If you want to search for all files inside the 'foo/bar' directory, use a match-all pattern:

  fd . 'foo/bar'

Instead, if you want your pattern to match the full file path, use:

  fd --full-path 'foo/bar'
```

## Fix

In `needs_escape()`, treat `\n` like `\t` — both are legitimate whitespace in diagnostic output, not injection vectors. `\r` (U+000D) remains escaped because it enables carriage-return output forgery.

## Test

Updated `strips_newline` test → `preserves_newline` to assert that newlines pass through the sanitizer unchanged.

Fixes #2104
