### PR TITLE
Include files modified exactly at the starting timestamp for --changed-after and its aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 -
 
 ## Bugfixes
+- Include files modified exactly at the starting timestamp for `--changed-after` and its aliases, see #2122 (@pederbe).
 - Don't incorrectly escape newlines in error messages, see #2104
 - Restore jemalloc as default allocator on supported systems
 

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -355,7 +355,7 @@ tebibytes
 .TP
 .BI "\-\-changed-within " date|duration
 Filter results based on the file modification time.
-Files with modification timestamps greater than the argument will be returned.
+Files with modification timestamps greater than or equal to the argument will be returned.
 The argument can be provided as a duration (\fI10h, 1d, 35min\fR) or as a specific point
 in time as full RFC3339 format with time zone, as a date or datetime in the
 local time zone (\fIYYYY-MM-DD\fR or \fIYYYY-MM-DD HH:MM:SS\fR), or as the prefix '@'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -417,7 +417,7 @@ pub struct Opts {
     pub size: Vec<SizeFilter>,
 
     /// Filter results based on the file modification time. Files with modification times
-    /// greater than the argument are returned. The argument can be provided
+    /// greater than or equal to the argument are returned. The argument can be provided
     /// as a specific point in time (YYYY-MM-DD HH:MM:SS or @timestamp) or as a duration (10h, 1d, 35min).
     /// If the time is not specified, it defaults to 00:00:00.
     /// '--change-newer-than', '--newer', or '--changed-after' can be used as aliases.

--- a/src/filter/time.rs
+++ b/src/filter/time.rs
@@ -57,7 +57,7 @@ impl TimeFilter {
     pub fn applies_to(&self, t: &SystemTime) -> bool {
         match self {
             TimeFilter::Before(limit) => t < limit,
-            TimeFilter::After(limit) => t > limit,
+            TimeFilter::After(limit) => t >= limit,
         }
     }
 }
@@ -198,6 +198,21 @@ mod tests {
                 .unwrap()
                 .applies_to(&t1s_later)
         );
+    }
+
+    #[test]
+    fn time_filter_boundaries() {
+        let limit = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let tick = Duration::from_nanos(100);
+        let after = TimeFilter::after("@1700000000").unwrap();
+        let before = TimeFilter::before("@1700000000").unwrap();
+
+        assert!(!after.applies_to(&(limit - tick)));
+        assert!(after.applies_to(&limit));
+        assert!(after.applies_to(&(limit + tick)));
+        assert!(before.applies_to(&(limit - tick)));
+        assert!(!before.applies_to(&limit));
+        assert!(!before.applies_to(&(limit + tick)));
     }
 
     #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2447,6 +2447,46 @@ fn test_modified_absolute() {
     );
 }
 
+#[test]
+fn test_modified_range_boundaries() {
+    let te = TestEnv::new(&[], &["before", "start", "inside", "end"]);
+    remove_symlink(te.test_root().join("symlink"));
+    for (name, timestamp) in [
+        ("before", "2018-01-01T23:59:59Z"),
+        ("start", "2018-01-02T00:00:00Z"),
+        ("inside", "2018-01-02T00:30:00Z"),
+        ("end", "2018-01-02T01:00:00Z"),
+    ] {
+        change_file_modified(te.test_root().join(name), timestamp);
+    }
+
+    for after in [
+        "--changed-after",
+        "--changed-within",
+        "--change-newer-than",
+        "--newer",
+    ] {
+        te.assert_output(
+            &[
+                after,
+                "2018-01-02T00:00:00Z",
+                "--changed-before",
+                "2018-01-02T01:00:00Z",
+            ],
+            "start\ninside",
+        );
+    }
+    te.assert_output(
+        &[
+            "--changed-after",
+            "2018-01-02T01:00:00Z",
+            "--changed-before",
+            "2018-01-02T02:00:00Z",
+        ],
+        "end",
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn test_owner_ignore_all() {


### PR DESCRIPTION
## Summary

Include files modified exactly at the starting timestamp for `--changed-after` and its aliases. Starting timestamp is now included; end remains excluded.

Added boundary tests and updated help, man page, and changelog.

Fixes #2122

## Testing

- All 148 unit tests and direct CLI checks passed.
- Formatting passed. Clippy passed with existing unused-code warnings suppressed.
- All 95 integration tests passed, including the new timestamp-boundary regression.

## AI assistance

I used Codex to help develop and test this change. I personally reviewed the work and wrote this PR.
