### PR TITLE
Allow stripping cwd prefix with explicit search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Upcoming Release
 
 ## Features
--
+- Allow `--strip-cwd-prefix` with explicit search paths, see #2113 (@pederbe)
 
 ## Bugfixes
 - Don't incorrectly escape newlines in error messages, see #2104

--- a/doc/fd.1
+++ b/doc/fd.1
@@ -174,14 +174,16 @@ By default, relative paths are prefixed with './' when -x/--exec,
 -X/--exec-batch, or -0/--print0 are given, to reduce the risk of a
 path starting with '-' being treated as a command line option. Use
 this flag to change this behavior. If this flag is used without a value,
-it is equivalent to passing "always". Possible values are:
+it is equivalent to passing "always". This also works with explicit search
+paths. Possible values are:
 .RS
 .IP never
 Never strip the ./ at the beginning of paths
 .IP always
 Always strip the ./ at the beginning of paths
 .IP auto
-Only strip if used with --exec, --exec-batch, or --print0. That is, it resets to the default behavior.
+Only strip without explicit search paths and without --exec, --exec-batch,
+or --print0. That is, it resets to the default behavior.
 .RE
 .TP
 .B \-\-one\-file\-system, \-\-mount, \-\-xdev

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -675,8 +675,15 @@ pub struct Opts {
     /// -X/--exec-batch, or -0/--print0 are given, to reduce the risk of a
     /// path starting with '-' being treated as a command line option. Use
     /// this flag to change this behavior. If this flag is used without a value,
-    /// it is equivalent to passing "always".
-    #[arg(long, conflicts_with_all(&["path", "search_path"]), value_name = "when", hide_short_help = true, require_equals = true, long_help)]
+    /// it is equivalent to passing "always". This also works with explicit search
+    /// paths. In "auto" mode, prefixes are only stripped without explicit search paths.
+    #[arg(
+        long,
+        value_name = "when",
+        hide_short_help = true,
+        require_equals = true,
+        long_help
+    )]
     strip_cwd_prefix: Option<Option<StripCwdWhen>>,
 
     /// By default, fd will traverse the file system tree as far as other options
@@ -764,12 +771,11 @@ impl Opts {
 
     pub fn strip_cwd_prefix<P: FnOnce() -> bool>(&self, auto_pred: P) -> bool {
         use self::StripCwdWhen::*;
-        self.no_search_paths()
-            && match self.strip_cwd_prefix.map_or(Auto, |o| o.unwrap_or(Always)) {
-                Auto => auto_pred(),
-                Always => true,
-                Never => false,
-            }
+        match self.strip_cwd_prefix.map_or(Auto, |o| o.unwrap_or(Always)) {
+            Auto => self.no_search_paths() && auto_pred(),
+            Always => true,
+            Never => false,
+        }
     }
 
     #[cfg(feature = "completions")]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2712,6 +2712,37 @@ fn test_error_if_hidden_not_set_and_pattern_starts_with_dot() {
 }
 
 #[test]
+fn test_strip_cwd_prefix_search_paths() {
+    let te = TestEnv::new(
+        &["a/b/c"],
+        &["a/fileA", "a/b/fileB", "a/b/c/fileC", "a/-file"],
+    );
+
+    for paths in [
+        vec!["--search-path=.", "--search-path=b/c"],
+        vec!["", ".", "b/c"],
+    ] {
+        let mut args = vec!["-C", "a", "--type", "f", "--exclude", "b"];
+        args.extend_from_slice(&paths);
+        te.assert_output(&args, "./-file\n./fileA\nb/c/fileC");
+
+        for mode in ["--strip-cwd-prefix=auto", "--strip-cwd-prefix=never"] {
+            let mut args = args.clone();
+            args.push(mode);
+            te.assert_output(&args, "./-file\n./fileA\nb/c/fileC");
+        }
+
+        for mode in ["--strip-cwd-prefix", "--strip-cwd-prefix=always"] {
+            let mut args = args.clone();
+            args.push(mode);
+            te.assert_output(&args, "./-file\nfileA\nb/c/fileC");
+            args.push("--print0");
+            te.assert_output(&args, "./-fileNULL\nfileANULL\nb/c/fileCNULL");
+        }
+    }
+}
+
+#[test]
 fn test_strip_cwd_prefix() {
     let te = TestEnv::new(DEFAULT_DIRS, DEFAULT_FILES);
 


### PR DESCRIPTION
## Summary

- Allow --strip-cwd-prefix with positional paths and --search-path by removing the argument conflicts and limiting the no-search-path check to auto mode.
- Default, auto, never, and dash-filename protection retain their behavior. Add --strip-cwd-prefix to the issue's command to get fileA and b/c/fileC.
- Updated long help, manual, and changelog. Corrected the manual's inverted description of auto mode.

Fixes #2113

## Testing

- Regression exercises both path syntaxes, all modes, print0, mixed roots, and a dash filename. Failed before the fix on the argument conflict, passed after it.
- cargo test --locked: 147 unit tests and 95 integration tests passed on Windows GNU.
- cargo fmt --all --check passed after formatting.
- cargo clippy --locked --all-targets --all-features -- -D warnings failed on two existing dead-code warnings in tests/testenv/mod.rs. With -A dead-code appended, passed.

## AI assistance

I used Codex to assist coding and testing. I personally reviewed all work and verified testing.
