### PR TITLE
fix: allow hyphen-leading --format templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 -
 
 ## Bugfixes
+- Accept `--format` templates that start with `-` when passed as a separate argument, see #2126 (@vulragrag-star)
 - Don't incorrectly escape newlines in error messages, see #2104
 - Restore jemalloc as default allocator on supported systems
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -482,7 +482,8 @@ pub struct Opts {
         long,
         value_name = "fmt",
         help = "Print results according to template",
-        conflicts_with = "list_details"
+        conflicts_with = "list_details",
+        allow_hyphen_values = true
     )]
     pub format: Option<String>,
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1755,6 +1755,17 @@ fn format() {
         parent=one/two/three
         parent=one/two/three",
     );
+
+    // Templates may start with '-' (e.g. markdown list items); see #2126.
+    te.assert_output(
+        &["foo", "--format", "- {/.}", "--path-separator=/"],
+        "- a
+        - b
+        - C
+        - c
+        - d
+        - directory_foo",
+    );
 }
 
 /// Shell script execution (--exec)


### PR DESCRIPTION
## Summary
`--format` values that start with `-` were rejected when passed as a separate argument (`fd --format "- {/.}"`), while the `=` form worked. Clap treated the value as a new flag. Enable `allow_hyphen_values` for `--format` (same treatment as `--and`) so markdown-list-style templates work as documented.

Fixes #2126

## Test plan
- [x] Added regression in `tests/tests.rs` for `--format "- {/.}"`
- [x] Fork CI green (fmt, clippy, MSRV, multi-target builds)

## Notes
AI coding assistance was used to help locate the clap option and draft the patch; I reviewed the change, wrote/adjusted the regression, and verified CI.

Signed-off-by: Jason Wang <vulragrag@gmail.com>