### PR TITLE
refactor: exit code simplification

### DIFF
--- a/src/exec/job.rs
+++ b/src/exec/job.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::error::print_error;
-use crate::exit_codes::{ExitCode, merge_exitcodes};
+use crate::exit_codes::ExitCode;
 use crate::walk::WorkerResult;
 
 use super::CommandSet;
@@ -37,7 +37,7 @@ pub fn job(
             config.null_separator,
             buffer_output,
         );
-        ret = merge_exitcodes([ret, code]);
+        ret = ret.merge(code);
     }
     // Returns error in case of any error.
     ret

--- a/src/exit_codes.rs
+++ b/src/exit_codes.rs
@@ -6,7 +6,6 @@ use nix::sys::signal::{SigHandler, Signal, raise, signal};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExitCode {
     Success,
-    HasResults(bool),
     GeneralError,
     KilledBySigint,
 }
@@ -15,7 +14,6 @@ impl From<ExitCode> for i32 {
     fn from(code: ExitCode) -> Self {
         match code {
             ExitCode::Success => 0,
-            ExitCode::HasResults(has_results) => !has_results as i32,
             ExitCode::GeneralError => 1,
             ExitCode::KilledBySigint => 130,
         }
@@ -23,10 +21,6 @@ impl From<ExitCode> for i32 {
 }
 
 impl ExitCode {
-    fn is_error(self) -> bool {
-        i32::from(self) != 0
-    }
-
     /// Exit the process with the appropriate code.
     pub fn exit(self) -> ! {
         #[cfg(unix)]
@@ -41,13 +35,33 @@ impl ExitCode {
 
         process::exit(self.into())
     }
+
+    /// Merge another exit code with the current exit code.
+    ///
+    /// Currently returns GeneralError if either is an error.
+    /// In the future may merge more intelligently.
+    pub fn merge(self, other: ExitCode) -> ExitCode {
+        if self == ExitCode::Success && other == ExitCode::Success {
+            ExitCode::Success
+        } else {
+            ExitCode::GeneralError
+        }
+    }
+
+    /// Create an exit code based on the number of results.
+    ///
+    /// `n_results` is the number of results.
+    pub fn has_results(n_results: usize) -> ExitCode {
+        if n_results > 0 {
+            ExitCode::Success
+        } else {
+            ExitCode::GeneralError
+        }
+    }
 }
 
 pub fn merge_exitcodes(results: impl IntoIterator<Item = ExitCode>) -> ExitCode {
-    if results.into_iter().any(ExitCode::is_error) {
-        return ExitCode::GeneralError;
-    }
-    ExitCode::Success
+    results.into_iter().fold(ExitCode::Success, ExitCode::merge)
 }
 
 #[cfg(test)]

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -202,7 +202,7 @@ impl<'a, W: Write> ReceiverBuffer<'a, W> {
                     match result {
                         WorkerResult::Entry(dir_entry) => {
                             if self.config.quiet {
-                                return Err(ExitCode::HasResults(true));
+                                return Err(ExitCode::Success);
                             }
 
                             match self.mode {
@@ -286,7 +286,7 @@ impl<'a, W: Write> ReceiverBuffer<'a, W> {
         }
 
         if self.config.quiet {
-            Err(ExitCode::HasResults(self.num_results > 0))
+            Err(ExitCode::has_results(self.num_results))
         } else {
             Err(ExitCode::Success)
         }


### PR DESCRIPTION
 I think this is a little bit simpler, and it removes duplicate exit
 codes from the enum.

 It also makes it a little easier if we ever want to change the way we
 merge exit codes.