### PR TITLE
fix: sanitize control characters in error messages again

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,28 @@
+use crate::sanitize::sanitize_for_terminal_except_newline;
+
 pub fn print_error(msg: impl std::fmt::Display) {
-    eprintln!("[fd error]: {msg}");
+    eprintln!("{}", format_error(&msg.to_string()));
+}
+
+/// Build the `[fd error]: ...` line, escaping terminal control characters in
+/// `msg` while preserving newlines so multi-line errors stay readable.
+fn format_error(msg: &str) -> String {
+    format!("[fd error]: {}", sanitize_for_terminal_except_newline(msg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_error_escapes_control_chars_but_keeps_newlines() {
+        let msg = format_error("path\x1b]0;pwned\x07.txt\nsecond line");
+        assert_eq!(msg, "[fd error]: path\\x1B]0;pwned\\x07.txt\nsecond line");
+    }
+
+    #[test]
+    fn format_error_passes_plain_text_through() {
+        let msg = format_error("Search path 'fake' is not a directory.");
+        assert_eq!(msg, "[fd error]: Search path 'fake' is not a directory.");
+    }
 }

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -6,8 +6,8 @@ use std::fmt::Write;
 /// True for any char that is neither printable nor permitted whitespace (only HT).
 /// Covers C0/C1/DEL, bidi overrides, zero-width and format chars, and tag chars.
 #[inline]
-fn needs_escape(c: char) -> bool {
-    if c == '\t' {
+fn needs_escape(c: char, keep_newline: bool) -> bool {
+    if c == '\t' || (keep_newline && c == '\n') {
         return false;
     }
     c.is_control()
@@ -23,15 +23,13 @@ fn needs_escape(c: char) -> bool {
         )
 }
 
-/// Returns a `Cow<str>` borrowing `s` when no escaping is needed, otherwise an owned
-/// escaped copy. Use this when an owned `&str`/`String` is required (e.g. ANSI paint).
-pub fn sanitize_for_terminal(s: &str) -> Cow<'_, str> {
-    if !s.chars().any(needs_escape) {
+fn sanitize_inner(s: &str, keep_newline: bool) -> Cow<'_, str> {
+    if !s.chars().any(|c| needs_escape(c, keep_newline)) {
         return Cow::Borrowed(s);
     }
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
-        if needs_escape(c) {
+        if needs_escape(c, keep_newline) {
             let v = c as u32;
             if v <= 0xFF {
                 let _ = write!(out, "\\x{v:02X}");
@@ -43,6 +41,20 @@ pub fn sanitize_for_terminal(s: &str) -> Cow<'_, str> {
         }
     }
     Cow::Owned(out)
+}
+
+/// Returns a `Cow<str>` borrowing `s` when no escaping is needed, otherwise an owned
+/// escaped copy. Use this when an owned `&str`/`String` is required (e.g. ANSI paint).
+pub fn sanitize_for_terminal(s: &str) -> Cow<'_, str> {
+    sanitize_inner(s, false)
+}
+
+/// Like [`sanitize_for_terminal`], but keeps newlines intact.
+///
+/// Error messages are often multi-line; newlines are safe for a terminal, while
+/// every other control and format character is still escaped.
+pub fn sanitize_for_terminal_except_newline(s: &str) -> Cow<'_, str> {
+    sanitize_inner(s, true)
 }
 
 /// Sanitize for terminal output only; raw bytes pass through on pipes/files.
@@ -109,6 +121,31 @@ mod tests {
     #[test]
     fn strips_newline() {
         assert_eq!(sanitize_for_terminal("a\nb"), "a\\x0Ab");
+    }
+
+    #[test]
+    fn except_newline_keeps_newlines() {
+        assert!(matches!(
+            sanitize_for_terminal_except_newline("a\nb"),
+            Cow::Borrowed(_)
+        ));
+        assert_eq!(sanitize_for_terminal_except_newline("a\nb"), "a\nb");
+    }
+
+    #[test]
+    fn except_newline_still_escapes_other_controls() {
+        assert_eq!(
+            sanitize_for_terminal_except_newline("a\x1bb\nc"),
+            "a\\x1Bb\nc"
+        );
+        assert_eq!(
+            sanitize_for_terminal_except_newline("a\0b\nc"),
+            "a\\x00b\nc"
+        );
+        assert_eq!(
+            sanitize_for_terminal_except_newline("A\rFAKE\nOUTPUT"),
+            "A\\x0DFAKE\nOUTPUT"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Error output lost its terminal-escape filtering in a3942db: while fixing newline rendering, the whole sanitization filter was dropped. File names and command placeholders in `[fd error]:` lines can carry control characters, so an injected filename reached the terminal unchanged again.

Changes:

- `src/sanitize.rs`: refactored the escaping loop into `sanitize_inner` and added `sanitize_for_terminal_except_newline`, which escapes every control/format character except `\n`. The strict `sanitize_for_terminal` (which also escapes newlines) is unchanged and remains the tool for file names.
- `src/error.rs`: `print_error` now routes the message through the new variant, so control characters are escaped while multi-line error chains keep their line breaks (the original purpose of a3942db).

## Tests

- `src/sanitize.rs`: new tests for the except-newline variant (newlines kept, other controls still escaped, borrow passthrough for safe input).
- `src/error.rs`: new `format_error` tests covering an OSC-injection payload mixed with a newline and plain-text passthrough.

## Verification

```bash
cargo test --bin fd           # 151 passed
cargo test                    # 151 unit + 92 integration passed;
                              # 2 pre-existing Windows-only failures:
                              # test_list_details needs GNU ls,
                              # test_exec_with_separator needs a POSIX echo
cargo fmt -- --check          # clean
cargo clippy --all-targets    # clean (2 pre-existing dead-code warnings)
```

Fixes #2119.