### PR TITLE
docs(exec): clarify command ordering and output grouping for -x/--exec

### DIFF
--- a/doc/fd.1
+++ b/doc/fd.1
@@ -448,13 +448,13 @@ Note that all subsequent positional arguments are considered to be arguments to 
 It is therefore recommended to place the \-x/\-\-exec option last. Alternatively, you can supply
 a ';' argument to end the argument list and continue with more fd options.
 Most shells require ';' to be escaped: '\\;'.
-This option can be specified multiple times, in which case all commands are run for each
-file found, in the order they are provided. In that case, you must supply a ';' argument for
-all but the last commands.
+This option can be specified multiple times. Commands for the same search result run sequentially
+in the order they are given. In that case, you must supply a ';' argument for all but the last command.
+When running in parallel, fd buffers command output and prints it together for each search result,
+without interleaving it with command output for other results.
 
-If parallelism is enabled, the order commands will be executed in is non-deterministic. And even with
---threads=1, the order is determined by the operating system and may not be what you expect. Thus, it is
-recommended that you don't rely on any ordering of the results.
+The order in which different search results are processed and their output is printed is not
+guaranteed, even with --threads=1.
 
 Before executing the command, any placeholder patterns in the command are replaced with the
 corresponding values for the current file. The same placeholders are used as in the "\-\-format"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -894,10 +894,14 @@ impl clap::Args for Exec {
                 .help("Execute a command for each search result")
                 .long_help(
                     "Execute a command for each search result in parallel (use --threads=1 for sequential command execution). \
-                     There is no guarantee of the order commands are executed in, and the order should not be depended upon. \
+                     The order in which different search results are processed and their output is printed is not guaranteed, even with --threads=1. \
                      All positional arguments following --exec are considered to be arguments to the command - not to fd. \
                      It is therefore recommended to place the '-x'/'--exec' option last. \
-                     Use '\\;' to terminate the command template if you need to continue passing fd arguments afterwards.\n\
+                     Use '\\;' to terminate the command template if you need to continue passing fd arguments afterwards.\n\n\
+                     This option can be specified multiple times. Commands for the same search result run sequentially in the order they are given. \
+                     Terminate each command except the last with '\\;'. \
+                     When running in parallel, fd buffers command output and prints it together for each search result, \
+                     without interleaving it with command output for other results.\n\n\
                      The following placeholders are substituted before the command is executed:\n  \
                        '{}':   path (of the current search result)\n  \
                        '{/}':  basename\n  \


### PR DESCRIPTION
## Summary

The previous manpage explained the order of repeated -x commands for a single search result, but then added a broader note that command execution order isn't guaranteed. That could read as contradicting the per-result sequencing it had just described. The --help text had a similar broad caveat without explaining repeated -x behavior at all.

The updated wording clarifies three points:

- For a single search result, commands supplied via repeated -x run sequentially in the order given.
- When running in parallel, fd buffers command output for each result and prints it together, without interleaving it with command output from other results.
- The existing non-determinism warning is about the order in which different search results are processed, not about commands within one result, and it still holds even with --threads=1.

The long help text also now explains repeated -x usage, including the need to terminate each command except the last with a `;` argument (escaped as `\;` in most shells).

This is a documentation-only change. No execution logic, flags, or behavior changed. It does not add the separator flag requested in the issue.

## Related issue

https://github.com/sharkdp/fd/issues/1761

## Testing

- `cargo test --locked --all-features`: 147 unit and 94 integration tests   passed on Windows, with no failures. Unix-only tests are excluded from this Windows run.
- `cargo fmt --all --check` and `cargo clippy --locked --all-targets --all-features`: both passed; clippy showed two pre-existing dead-code warnings in unrelated Windows test helpers.
- `git diff --check`: passed.
- A local probe exercised 8 files, 2 commands, at 1 and 4 threads, 3 runs each, checking per-result command order (via a marker dependency) and output grouping independently for stdout and stderr.
- `fd.exe --help` inspected manually for correct wrapping/spacing of the new paragraph.
- Updated manpage section rendered via `groff -Kutf8 -man -Tutf8` (WSL), passed with no stderr warnings.

## AI disclosure

I used Codex to assist coding and testing. I personally reviewed all work and verified testing.
